### PR TITLE
Sdk integrations

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -21,6 +21,6 @@ export class AdminController {
   @UseGuards(new ScopesGuard('api.permissions.users.read'))
   async getUserById(@Param('id') id: string) {
     // TODO: need some proper error handling here
-    return this.keycloakService.getUserById(id);
+    return this.keycloakService.getUserInfoById(id);
   }
 }

--- a/src/admin/keycloak/keycloak.admin.service.ts
+++ b/src/admin/keycloak/keycloak.admin.service.ts
@@ -247,7 +247,7 @@ export class KeycloakAdminService {
       this.logger.error('Error in getClients', error);
     }
   }
-  async getUserById(id: string) {
+  async getUserInfoById(id: string) {
     try {
       const userQuery = await this.kcAdminClient.users.findOne(
         {
@@ -269,6 +269,20 @@ export class KeycloakAdminService {
         ...user,
         lastLogin: new Date(lastLoginEvent?.time),
       };
+    } catch (error) {
+      this.logger.error('Error in getUserInfoById', error);
+    }
+  }
+
+  async getUserById(id: string) {
+    try {
+      return await this.kcAdminClient.users.findOne(
+        {
+          id,
+          realm: this.config.realm,
+        },
+        { catchNotFound: false },
+      );
     } catch (error) {
       this.logger.error('Error in getUserById', error);
     }
@@ -416,30 +430,25 @@ export class KeycloakAdminService {
       .sort((a, b) => (b.time || 0) - (a.time || 0))[0];
   }
 
-  async createScope(scope: ClientScopeRepresentation) {
-    try {
-      // get new scope id
-      return await this.kcAdminClient.clientScopes.create(scope);
-    } catch (error) {
-      this.logger.error('Error in createScope', error);
-    }
-  }
-
   async newResource(
     id: string,
-    owner: string,
+    ownerId: string,
     collaborators: string[],
     custodian?: string,
   ) {
+    // get owner username
+    const owner = (await this.getUserById(ownerId)).username;
+
     // create resource
     await this.createResource({
       name: `${resourcePrefix}${id}`,
       type: 'project',
       displayName: `${resourcePrefix}${id}`,
+      // TODO: make this URL same as frontend
       uris: [`project/${id}`],
-      // TODO: make into const object
       scopes: projectScopes,
     });
+
     // create owner policy
     await this.createPolicy('user', {
       name: `${ownerPolicyPrefix}${id}`,
@@ -551,6 +560,14 @@ export class KeycloakAdminService {
       );
     } catch (error) {
       this.logger.error('Error in createResource', error);
+    }
+  }
+  async createScope(scope: ClientScopeRepresentation) {
+    try {
+      // get new scope id
+      return await this.kcAdminClient.clientScopes.create(scope);
+    } catch (error) {
+      this.logger.error('Error in createScope', error);
     }
   }
   async createPolicy(policyType: string, policy: PolicyRepresentation) {

--- a/src/admin/keycloak/keycloak.admin.service.ts
+++ b/src/admin/keycloak/keycloak.admin.service.ts
@@ -14,6 +14,7 @@ import {
 } from '../config.interface';
 
 import { ConfigService } from '@nestjs/config';
+import { LoginDto } from 'src/analysis/dto';
 
 export type UserQueryParams = {
   readonly email?: string;
@@ -583,26 +584,16 @@ export class KeycloakAdminService {
     }
   }
 
-  async getAccessToken(
-    username: string,
-    password: string,
-  ): Promise<{
+  async getAccessToken(login: LoginDto): Promise<{
     access_token: string;
     expires_in?: number;
   }> {
     try {
-      const { issuerBaseURL, realm } = this.config;
-      await this.kcAdminClient.setConfig({
-        baseUrl: issuerBaseURL,
-        realmName: realm,
-      });
-
       await this.kcAdminClient.auth({
         grantType: 'password',
         clientId: this.configService.get<string>('sdk.clientId'),
-        clientSecret: this.configService.get<string>('sdk.clientSecret'),
-        username,
-        password,
+        username: login.username,
+        password: login.password,
       });
 
       const token = await this.kcAdminClient.getAccessToken();

--- a/src/admin/keycloak/keycloak.admin.service.ts
+++ b/src/admin/keycloak/keycloak.admin.service.ts
@@ -16,16 +16,7 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { LoginDto } from 'src/analysis/dto';
 
-export type UserQueryParams = {
-  readonly email?: string;
-  readonly emailVerified?: string;
-  readonly enabled?: boolean;
-  readonly exact?: boolean;
-  readonly firstName?: string;
-  readonly lastName?: string;
-  readonly username?: string;
-};
-
+// FIXME: add to consts and DTOs
 const resourcePrefix = 'project:';
 const projectScopes = [
   {
@@ -69,6 +60,16 @@ const custodianPermissionPrefix = `Custodian `;
 const custodianPermissions = ['view', 'edit', 'connect'];
 
 // FIXME: add to keycloak-admin-client
+
+export type UserQueryParams = {
+  readonly email?: string;
+  readonly emailVerified?: string;
+  readonly enabled?: boolean;
+  readonly exact?: boolean;
+  readonly firstName?: string;
+  readonly lastName?: string;
+  readonly username?: string;
+};
 export enum DecisionStrategy {
   AFFIRMATIVE = 'AFFIRMATIVE',
   UNANIMOUS = 'UNANIMOUS',
@@ -125,7 +126,6 @@ export interface GroupRepresentation {
 @Injectable()
 export class KeycloakAdminService {
   private readonly logger = new Logger('KeycloakAdminService');
-  // private kcAdminClient: KeycloakAdminClient;
 
   constructor(
     @Inject(ADMIN_CONFIG) private config: AdminModuleConfig,

--- a/src/analysis/analysis.controller.ts
+++ b/src/analysis/analysis.controller.ts
@@ -7,7 +7,6 @@ import {
   Post,
   Req,
 } from '@nestjs/common';
-import { AnalysisService } from './analysis.service';
 import { ApiOperation } from '@nestjs/swagger';
 import { KeycloakAdminService } from 'src/admin/keycloak/keycloak.admin.service';
 import { KeycloakService } from 'src/auth/keycloak/keycloak.service';
@@ -34,7 +33,7 @@ export class AnalysisController {
   // TODO: check if they have analysis scope for this and SDK scope
   @ApiOperation({ summary: 'Get list of all projects for logged in user' })
   async getUserDatasets(@Req() request: Request) {
-    // check for user resorce permissions
+    // check for user resource permissions
     // TODO: perhaps call this once and cache
     const authzRequest = {
       response_mode: 'permissions',
@@ -43,7 +42,7 @@ export class AnalysisController {
       authzRequest,
       request,
     );
-    //TODO: need a different query for the project to get info for SDK
+    //TODO: may need a different query for the project to get info for SDK
     return await this.projectService.getUserProjects(permissions);
   }
 
@@ -54,6 +53,6 @@ export class AnalysisController {
     @Param('projectId', ParseUUIDPipe) projectId: string,
   ) {
     //TODO: convert to JSON Schema
-    return this.archetypeService.archetypes(projectId);
+    return this.archetypeService.getAnalysisArchetype(projectId);
   }
 }

--- a/src/analysis/analysis.controller.ts
+++ b/src/analysis/analysis.controller.ts
@@ -1,15 +1,24 @@
-import { Body, Controller, Get, Post, Req } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Req,
+} from '@nestjs/common';
 import { AnalysisService } from './analysis.service';
 import { ApiOperation } from '@nestjs/swagger';
 import { KeycloakAdminService } from 'src/admin/keycloak/keycloak.admin.service';
 import { KeycloakService } from 'src/auth/keycloak/keycloak.service';
 import { ProjectService } from 'src/project/project.service';
 import { LoginDto } from './dto/login.dto';
+import { ArchetypeService } from 'src/archetype/archetype.service';
 
 @Controller('analysis')
 export class AnalysisController {
   constructor(
-    private readonly analysisService: AnalysisService,
+    private readonly archetypeService: ArchetypeService,
     private readonly keycloakService: KeycloakAdminService,
     private readonly projectService: ProjectService,
     private readonly keycloakConnect: KeycloakService,
@@ -22,8 +31,9 @@ export class AnalysisController {
   }
 
   @Get('datasets')
+  // TODO: check if they have analysis scope for this and SDK scope
   @ApiOperation({ summary: 'Get list of all projects for logged in user' })
-  async getUserProjects(@Req() request: Request) {
+  async getUserDatasets(@Req() request: Request) {
     // check for user resorce permissions
     // TODO: perhaps call this once and cache
     const authzRequest = {
@@ -33,6 +43,17 @@ export class AnalysisController {
       authzRequest,
       request,
     );
+    //TODO: need a different query for the project to get info for SDK
     return await this.projectService.getUserProjects(permissions);
+  }
+
+  @Get('datasets/:projectId')
+  // TODO: check if they have analysis scope for this and SDK scope
+  @ApiOperation({ summary: 'Get archetype for a dataset' })
+  async getDatasetArchetype(
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+  ) {
+    //TODO: convert to JSON Schema
+    return this.archetypeService.archetypes(projectId);
   }
 }

--- a/src/analysis/analysis.controller.ts
+++ b/src/analysis/analysis.controller.ts
@@ -1,20 +1,38 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Body, Controller, Get, Post, Req } from '@nestjs/common';
 import { AnalysisService } from './analysis.service';
 import { ApiOperation } from '@nestjs/swagger';
 import { KeycloakAdminService } from 'src/admin/keycloak/keycloak.admin.service';
+import { KeycloakService } from 'src/auth/keycloak/keycloak.service';
+import { ProjectService } from 'src/project/project.service';
+import { LoginDto } from './dto/login.dto';
 
 @Controller('analysis')
 export class AnalysisController {
   constructor(
     private readonly analysisService: AnalysisService,
     private readonly keycloakService: KeycloakAdminService,
+    private readonly projectService: ProjectService,
+    private readonly keycloakConnect: KeycloakService,
   ) {}
-  @Get('access-token')
+
+  @Post('auth')
   @ApiOperation({ summary: 'Get access token' })
-  async getAccessToken(
-    @Query('username') username: string,
-    @Query('password') password: string,
-  ) {
-    return await this.keycloakService.getAccessToken(username, password);
+  async getAccessToken(@Body() login: LoginDto) {
+    return await this.keycloakService.getAccessToken(login);
+  }
+
+  @Get('datasets')
+  @ApiOperation({ summary: 'Get list of all projects for logged in user' })
+  async getUserProjects(@Req() request: Request) {
+    // check for user resorce permissions
+    // TODO: perhaps call this once and cache
+    const authzRequest = {
+      response_mode: 'permissions',
+    };
+    const permissions = await this.keycloakConnect.getPermissions(
+      authzRequest,
+      request,
+    );
+    return await this.projectService.getUserProjects(permissions);
   }
 }

--- a/src/analysis/analysis.module.ts
+++ b/src/analysis/analysis.module.ts
@@ -1,12 +1,14 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { AnalysisService } from './analysis.service';
 import { AnalysisController } from './analysis.controller';
 import { AdminModule } from 'src/admin/admin.module';
 import { ProjectService } from 'src/project/project.service';
+import { ArchetypeService } from 'src/archetype/archetype.service';
+import { DatabaseModule } from 'src/database/database.module';
 
 @Module({
-  imports: [AdminModule],
+  imports: [AdminModule, forwardRef(() => DatabaseModule)],
   controllers: [AnalysisController],
-  providers: [AnalysisService, ProjectService],
+  providers: [AnalysisService, ProjectService, ArchetypeService],
 })
 export class AnalysisModule {}

--- a/src/analysis/analysis.module.ts
+++ b/src/analysis/analysis.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { AnalysisService } from './analysis.service';
 import { AnalysisController } from './analysis.controller';
 import { AdminModule } from 'src/admin/admin.module';
+import { ProjectService } from 'src/project/project.service';
 
 @Module({
   imports: [AdminModule],
   controllers: [AnalysisController],
-  providers: [AnalysisService],
+  providers: [AnalysisService, ProjectService],
 })
 export class AnalysisModule {}

--- a/src/analysis/dto/index.ts
+++ b/src/analysis/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './login.dto';

--- a/src/analysis/dto/login.dto.ts
+++ b/src/analysis/dto/login.dto.ts
@@ -1,0 +1,10 @@
+// auth.dto.ts
+import { IsString } from 'class-validator';
+
+export class LoginDto {
+  @IsString()
+  username: string;
+
+  @IsString()
+  password: string;
+}

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -5,6 +5,16 @@ import { PrismaService } from 'src/prisma/prisma.service';
 import { QueueService } from 'src/queue/queue.service';
 import { ArchetypeDto } from './dto';
 
+type AtlasAttributeDef = {
+  name: string;
+  typeName: string; // like 'string', 'int', 'boolean', etc.
+};
+
+type AtlasEntityDef = {
+  name: string;
+  attributeDefs: AtlasAttributeDef[];
+};
+
 @Injectable()
 export class ArchetypeService {
   constructor(
@@ -125,5 +135,46 @@ export class ArchetypeService {
   async createArchetype(projectId: string, template: ArchetypeDto) {
     const dbId = await this.databaseSource.findDbId(projectId);
     await this.queue.addArchetypeJob(template, dbId);
+  }
+
+  private atlasTypeToJSONType(typeName: string): string {
+    switch (typeName) {
+      case 'string':
+      case 'date':
+        return 'string';
+      case 'int':
+        return 'integer';
+      case 'long':
+      case 'float':
+      case 'double':
+      case 'short':
+        return 'number';
+      case 'boolean':
+        return 'boolean';
+      case 'array<string>':
+      case 'list<string>':
+        return 'array';
+      // You can expand this for nested object types too
+      default:
+        return 'object'; // fallback for unknown types
+    }
+  }
+
+  convertAtlasEntityToJSONSchema(entityDef: AtlasEntityDef): object {
+    const properties: Record<string, object> = {};
+
+    entityDef.attributeDefs.forEach((attr) => {
+      //filter for lable
+      const jsonType = this.atlasTypeToJSONType(attr.typeName);
+      properties[attr.name] = { type: jsonType };
+    });
+
+    return {
+      $schema: 'https://json-schema.org/draft/2020-12/schema#',
+      title: entityDef.name,
+      type: 'object',
+      properties,
+      required: entityDef.attributeDefs.map((attr) => attr.name), // adjust if optional attrs exist
+    };
   }
 }

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -30,6 +30,7 @@ export class ArchetypeService {
 
     let activeTemplates = [];
 
+    // TODO: I think it is better to write the projectId into atlas instance as that should have 1=1 relationship
     const params = {
       query: `from archetype where instance.__guid = "${dbId}" select __state, __guid, qualifiedName, progress`,
     };
@@ -143,6 +144,7 @@ export class ArchetypeService {
       case 'date':
         return 'string';
       case 'int':
+      case 'integer':
         return 'integer';
       case 'long':
       case 'float':

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -137,7 +137,7 @@ export class ArchetypeService {
     await this.queue.addArchetypeJob(template, dbId);
   }
 
-  private atlasTypeToJSONType(typeName: string): string {
+  private atlasTypeToJSONType(dataType: string): string {
     switch (typeName) {
       case 'string':
       case 'date':

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -138,7 +138,7 @@ export class ArchetypeService {
   }
 
   private atlasTypeToJSONType(dataType: string): string {
-    switch (typeName) {
+    switch (dataType) {
       case 'string':
       case 'date':
         return 'string';

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -32,7 +32,7 @@ export class ArchetypeService {
 
     // TODO: I think it is better to write the projectId into atlas instance as that should have 1=1 relationship
     const params = {
-      query: `from archetype where instance.__guid = "${dbId}" select __state, __guid, qualifiedName, progress`,
+      query: `from archetype where instance.__guid = "${dbId}" select __state, __guid, qualifiedName`,
     };
     await this.atlas
       .get('/search/dsl', params, token)
@@ -43,7 +43,8 @@ export class ArchetypeService {
             return {
               guid: item[1],
               name: item[2].split('@', 2)[1],
-              progress: item[3],
+              //FIXME: this doesn't exist in the archetype model
+              // progress: item[3],
             };
           });
       })
@@ -129,6 +130,75 @@ export class ArchetypeService {
     return output;
   }
 
+  async getAnalysisArchetype(projectId: string, token?: string) {
+    const activeTemplates = await this.archetypeNames(projectId);
+
+    const output = [];
+    for (const template of activeTemplates) {
+      const templateGuid = template.guid;
+
+      const properties: Record<string, object> = {};
+      const schema = {
+        $schema: 'https://json-schema.org/draft/2020-12/schema#',
+        title: template.name,
+        type: 'object',
+        properties,
+      };
+
+      const templateEntity = await this.atlas.get(
+        `/entity/guid/${templateGuid}`,
+        undefined,
+        token,
+      );
+
+      for (const key in templateEntity.referredEntities) {
+        const entity = templateEntity.referredEntities[key];
+
+        if (entity.typeName.includes('archetype_')) {
+          if (entity.typeName != 'archetype_object') {
+            const objectName = entity.attributes.qualifiedName;
+            if (entity.relationshipAttributes.subcategories?.length) {
+              const type = 'object';
+              const properties: Record<string, object> = {};
+              schema.properties[objectName] = { type, properties };
+            }
+            if (entity.relationshipAttributes.columns?.length) {
+              const properties: Record<string, object> = {};
+              for (const column of entity.relationshipAttributes.columns) {
+                const { entity } = await this.atlas.get(
+                  `/entity/guid/${column.guid}`,
+                  undefined,
+                  token,
+                );
+                const jsonType = this.atlasTypeToJSONType(
+                  entity.attributes.data_type,
+                );
+                properties[objectName] = {
+                  type: jsonType,
+                };
+              }
+              if (entity.relationshipAttributes.category) {
+                schema.properties[
+                  entity.relationshipAttributes.category.qualifiedName
+                ]['properties'] = {
+                  ...schema.properties[
+                    entity.relationshipAttributes.category.qualifiedName
+                  ]['properties'],
+                  ...properties,
+                };
+              } else {
+                schema.properties = { ...schema.properties, ...properties };
+              }
+            }
+          }
+        }
+      }
+
+      output.push(schema);
+    }
+    return output;
+  }
+
   async deleteArchetype(template: ArchetypeDto) {
     return await this.queue.deleteTemplateJob(template);
   }
@@ -160,23 +230,5 @@ export class ArchetypeService {
       default:
         return 'object'; // fallback for unknown types
     }
-  }
-
-  convertAtlasEntityToJSONSchema(entityDef: AtlasEntityDef): object {
-    const properties: Record<string, object> = {};
-
-    entityDef.attributeDefs.forEach((attr) => {
-      //filter for lable
-      const jsonType = this.atlasTypeToJSONType(attr.typeName);
-      properties[attr.name] = { type: jsonType };
-    });
-
-    return {
-      $schema: 'https://json-schema.org/draft/2020-12/schema#',
-      title: entityDef.name,
-      type: 'object',
-      properties,
-      required: entityDef.attributeDefs.map((attr) => attr.name), // adjust if optional attrs exist
-    };
   }
 }

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -5,16 +5,6 @@ import { PrismaService } from 'src/prisma/prisma.service';
 import { QueueService } from 'src/queue/queue.service';
 import { ArchetypeDto } from './dto';
 
-type AtlasAttributeDef = {
-  name: string;
-  typeName: string; // like 'string', 'int', 'boolean', etc.
-};
-
-type AtlasEntityDef = {
-  name: string;
-  attributeDefs: AtlasAttributeDef[];
-};
-
 @Injectable()
 export class ArchetypeService {
   constructor(

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -43,7 +43,7 @@ export class AuthModule implements NestModule {
       )
       .exclude({ path: 'health', method: RequestMethod.GET })
       .exclude({ path: 'docs', method: RequestMethod.GET })
-      .exclude({ path: 'analysis/access-token', method: RequestMethod.GET })
+      .exclude({ path: 'analysis/(.*)', method: RequestMethod.ALL })
       .forRoutes('*');
   }
 

--- a/src/auth/dto/index.ts
+++ b/src/auth/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './permissions.dto';

--- a/src/auth/dto/permissions.dto.ts
+++ b/src/auth/dto/permissions.dto.ts
@@ -1,0 +1,15 @@
+import { IsDefined, IsString } from 'class-validator';
+
+export class PermissionsDto {
+  @IsDefined()
+  @IsString()
+  rsid: string;
+
+  @IsDefined()
+  @IsString()
+  rsname: string;
+
+  @IsDefined()
+  @IsString({ each: true })
+  scopes: string[];
+}

--- a/src/auth/keycloak/keycloak.service.ts
+++ b/src/auth/keycloak/keycloak.service.ts
@@ -15,7 +15,8 @@ export class KeycloakService {
   constructor(@Inject(AUTH_CONFIG) private config: AuthModuleConfig) {}
 
   async checkPermission(authzRequest, request) {
-    if (!request.auth.token) {
+    const token = request.auth?.token || this.extractTokenFromHeader(request);
+    if (!token) {
       return Promise.reject(new Error('No bearer token'));
     }
     const params = {
@@ -50,7 +51,7 @@ export class KeycloakService {
         {
           method: 'POST',
           headers: {
-            Authorization: 'Bearer ' + request.auth.token,
+            Authorization: 'Bearer ' + token,
             'Content-Type': 'application/x-www-form-urlencoded',
           },
           body: data,
@@ -87,13 +88,14 @@ export class KeycloakService {
   }
 
   async getPermissions(authzRequest, request) {
-    if (!request.auth.token) {
+    const token = request.auth?.token || this.extractTokenFromHeader(request);
+    if (!token) {
       return Promise.reject(new Error('No bearer token'));
     }
     const params = {
       grant_type: 'urn:ietf:params:oauth:grant-type:uma-ticket',
       audience: authzRequest.audience || this.config.clientId,
-      response_mode: authzRequest.response_mode || 'decision',
+      response_mode: authzRequest.response_mode || 'permissions',
     };
 
     const data = querystring.stringify(params);
@@ -103,13 +105,12 @@ export class KeycloakService {
         {
           method: 'POST',
           headers: {
-            Authorization: 'Bearer ' + request.auth.token,
+            Authorization: 'Bearer ' + token,
             'Content-Type': 'application/x-www-form-urlencoded',
           },
           body: data,
         },
       );
-
       // Read text if it exists
       const text = await res.text();
       if (res.status >= 500) {
@@ -137,5 +138,13 @@ export class KeycloakService {
         throw err;
       }
     }
+  }
+
+  private extractTokenFromHeader(request: Request): string | null {
+    const authHeader = request.headers['authorization'];
+    if (!authHeader || typeof authHeader !== 'string') return null;
+
+    const [type, token] = authHeader.split(' ');
+    return type === 'Bearer' ? token : null;
   }
 }

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -12,7 +12,7 @@ export class ProjectService {
     private prisma: PrismaService,
     private atlas: AtlasService,
     private fileStorage: FileStorageService,
-    private keycloak: KeycloakAdminService,
+    private readonly keycloak: KeycloakAdminService,
   ) {}
 
   async getUserOwnedProjects(userId: string) {
@@ -31,7 +31,6 @@ export class ProjectService {
         faculty: true,
       },
     });
-
     return projects;
   }
 

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -6,6 +6,7 @@ import { FileStorageService } from 'src/file_storage/file_storage.service';
 import { KeycloakAdminService } from 'src/admin/keycloak/keycloak.admin.service';
 import { nanoid } from 'nanoid';
 
+import { PermissionsDto } from 'src/auth/dto';
 @Injectable()
 export class ProjectService {
   constructor(
@@ -34,7 +35,7 @@ export class ProjectService {
     return projects;
   }
 
-  async getUserProjects(permissions: any) {
+  async getUserProjects(permissions: PermissionsDto[]) {
     const uuids = permissions.map((item) => item.rsname.split(':')[1]);
     const projects = await this.prisma.project.findMany({
       where: {

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -152,8 +152,12 @@ export class ProjectService {
         },
       },
     });
-    // NOTE: example of add resource and permissions
-    this.keycloak.newResource(project.projectId, 'test_user', project.members);
+    // add keycloak resource
+    this.keycloak.newResource(
+      project.projectId,
+      project.ownerId,
+      project.members,
+    );
 
     if (dto.connection.additionalInfo) {
       await this.prisma.comment.create({

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -30,7 +30,8 @@ export class AtlasProcessor {
           owner: 'user',
           qualifiedName: `${dbId}@${template.name}`,
           is_active: true,
-          progress: 0,
+          // FIXME: this doesn't exist in archetype model
+          // progress: 0,
         },
         relationshipAttributes: {
           instance: {

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -26,6 +26,7 @@ export class AtlasProcessor {
         typeName: 'archetype',
         status: 'ACTIVE',
         attributes: {
+          // TODO: use actual username here
           owner: 'user',
           qualifiedName: `${dbId}@${template.name}`,
           is_active: true,


### PR DESCRIPTION
Added endpoints for analysis SDK:

- `/analysis/auth` - used to authenticate using username/password via SDK
- `/analysis/datasets` - used to get list of projects that user has analysis access
- `/analysis/datasets/:projectId` - used to get JSONSchema representation to generate of archetype template

Future:
- Archetype models need a cleanup see https://github.com/Epsilon-Data/platform/issues/13
- Archetype service functions need refactoring after cleanup
- We need to decide how much extra details is needed for the JSONSchema in the SDK