### PR TITLE
Added packageId for SDK

### DIFF
--- a/prisma/migrations/20250815061733_add_packageid/migration.sql
+++ b/prisma/migrations/20250815061733_add_packageid/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `packageId` to the `Project` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN     "packageId" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,6 +62,7 @@ model Project {
   projectId       String        @id(map: "project_pkey") @default(uuid()) @db.Uuid
   ownerId         String        @db.Uuid
   customId        String        @db.VarChar(12)
+  packageId       String        @db.Text
   name            String        @db.Text
   lead            String        @db.Text
   university      String        @db.Text

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -116,9 +116,16 @@ export class ProjectService {
   }
 
   async createProject(dto: ProjectDto) {
+    const customId = nanoid(12);
+    const packageName = dto.name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '');
+
     const request = {
       ownerId: dto.ownerId,
-      customId: nanoid(12),
+      customId: customId,
+      packageId: `${packageName}_${customId.slice(0, 6)}`,
       name: dto.name,
       lead: dto.lead,
       university: dto.university,


### PR DESCRIPTION
Added packageId column to store safe package names from project names with short nanoid suffixes.

- Added migration for `packageId` column
- Generate a safe package name for the project

Closes #23 