### PR TITLE
fix(keycloak)!: fixed refresh token issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ You need to be logged in to get the data-broker image used for crawling.
 docker login ghcr.io -u YOUR_USERNAME -p YOUR_GITHUB_TOKEN
 ```
 
+### Add Keycloak hostname
+
+For local development setup, this is needed in order for `token-handler-api` to be able to connect to Keycloak inside docker network and to trust the issuer, you need to add extra host in your machine:
+
+```bash
+# edit  /etc/hosts to add
+127.0.0.1 keycloak
+```
+
 ### Install global dependencies
 
 Install `pnpm` and `typescript` globally

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -16,7 +16,7 @@ export default () => ({
   auth: {
     trustedWebOrigins: trustedWebOrigins(),
     issuerBaseURL:
-      env.EPSILON_AUTH_URI || 'http://localhost:8080/realms/epsilon',
+      env.EPSILON_AUTH_URI || 'http://keycloak:8080/realms/epsilon',
     // TODO: check changing for client-id
     audience: env.EPSILON_AUTH_AUDIENCE || 'epsilon.api',
     scopePrefix: env.EPSILON_AUTH_SCOPE_PREFIX || 'api.test',
@@ -27,7 +27,7 @@ export default () => ({
     clientId: env.EPSILON_AUTH_CLIENT_ID || 'epsilon-token-handler',
   },
   admin: {
-    issuerBaseURL: env.EPSILON_AUTH_ISSUER_BASE_URL || 'http://localhost:8080',
+    issuerBaseURL: env.EPSILON_AUTH_ISSUER_BASE_URL || 'http://keycloak:8080',
     realm: env.EPSILON_AUTH_REALM || 'epsilon',
     audience: env.EPSILON_AUTH_AUDIENCE || 'epsilon.api',
     scopePrefix: env.EPSILON_ADMIN_AUTH_SCOPE_PREFIX || 'api.permissions',
@@ -39,7 +39,7 @@ export default () => ({
       env.EPSILON_AUTH_COOKIE_ENCRYPTION_KEY ||
       'e2c8470d07a8dcdcd07267e353e32805d87dd560ce93e2fae5c1869b7118e5a9',
     trustedWebOrigins: [
-      env.EPSILON_AUTH_TRUSTED_WEB_ORIGIN || 'http://localhost:3000',
+      env.EPSILON_AUTH_TRUSTED_WEB_ORIGIN || 'http://keycloak:3000',
     ],
   },
   sdk: {
@@ -69,5 +69,5 @@ export default () => ({
     'postgresql://epsilon_admin:supersecret@localhost:6543/epsilon',
   tokenEndpoint:
     env.EPSILON_TOKEN_ENDPOINT ||
-    'http://localhost:8080/realms/epsilon/protocol/openid-connect/token',
+    'http://keycloak:8080/realms/epsilon/protocol/openid-connect/token',
 });


### PR DESCRIPTION
BREAKING CHANGES!

@chuleeshen and @khajievN added you both for visibility.

I've gotten to the bottom of why the refresh token never worked (https://github.com/Epsilon-Data/platform/pull/39) .

The problem is that when you connect to Keycloak inside the docker network it has a different hostname `keycloak`:8080 but outside it's either `localhost`:8080 or `host.docker.internal`:8080, this means that the `issuer` or `iss` variable doesn't match up when doing the refresh request from the frontend via the `token-handler-api`.

A simple fix for this would be to set a `keycloak` as hostname in the local machine:

```bash
# edit  /etc/hosts to add
127.0.0.1 keycloak
```

Also make sure you have the latest platform codebase as the `token-hadler-api` endpoints have also changed in the docker-compose. This PR needs to be in - https://github.com/Epsilon-Data/platform/pull/44