### PR TITLE
fix: allow empty strings and add check for database url

### DIFF
--- a/src/project/dto/project.dto.ts
+++ b/src/project/dto/project.dto.ts
@@ -26,17 +26,14 @@ class DatabaseDto {
 
   @IsOptional()
   @IsString()
-  @IsNotEmpty()
   url: string;
 
   @IsOptional()
   @IsString()
-  @IsNotEmpty()
   username: string;
 
   @IsOptional()
   @IsString()
-  @IsNotEmpty()
   password: string;
 }
 

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -209,7 +209,7 @@ export class ProjectService {
       });
     }
 
-    if (dto.connection.tempDbDetails) {
+    if (dto.connection.tempDbDetails.url) {
       await this.prisma.request.update({
         where: {
           requestId: project.connection.requestId,
@@ -224,6 +224,15 @@ export class ProjectService {
         project.connection.requestId,
         dto.connection.tempDbDetails,
       );
+    } else {
+      await this.prisma.request.update({
+        where: {
+          requestId: project.connection.requestId,
+        },
+        data: {
+          status: 'PENDING',
+        },
+      });
     }
 
     return project;


### PR DESCRIPTION
- Allow empty strings for username, password and database url 
- Check for database url when determining whether data crawling is required
- `PENDING` status for projects created using organisation admin email rather than `CRAWLING`