### PR TITLE
46 refactor archetypes api endpoints and methods

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -4,5 +4,8 @@
   "sourceRoot": "src",
   "compilerOptions": {
     "deleteOutDir": true
+  },
+  "generateOptions": {
+    "spec": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
-    "start:dev": "NODE_ENV=development nest start --watch --env development",
+    "start:dev": "NODE_ENV=development nest start --watch --env development --trace-deprecation",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
-    "start:dev": "NODE_ENV=development nest start --watch --env development --trace-deprecation",
+    "start:dev": "NODE_OPTIONS='--trace-deprecation' NODE_ENV=development nest start --watch --env development -- --trace-deprecation",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",

--- a/src/analysis/analysis.controller.ts
+++ b/src/analysis/analysis.controller.ts
@@ -52,7 +52,6 @@ export class AnalysisController {
   async getDatasetArchetype(
     @Param('projectId', ParseUUIDPipe) projectId: string,
   ) {
-    //TODO: convert to JSON Schema
     return this.archetypeService.getAnalysisArchetype(projectId);
   }
 }

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,9 +1,12 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 
-@Controller()
+@ApiTags('App')
+@Controller('app')
 export class AppController {
   constructor() {}
 
+  @ApiOperation({ summary: 'Get application health information' })
   @Get('health')
   getHealth() {
     return { status: 'OK', title: 'Epsilon API Hub' };

--- a/src/archetype/archetype.controller.spec.ts
+++ b/src/archetype/archetype.controller.spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ArchetypeController } from './archetype.controller';
+
+describe('ArchetypeController', () => {
+  let archetypeController: ArchetypeController;
+
+  beforeEach(async () => {
+    const app: TestingModule = await Test.createTestingModule({
+      controllers: [ArchetypeController],
+    }).compile();
+
+    archetypeController = app.get<ArchetypeController>(ArchetypeController);
+  });
+
+  it('should be defined', () => {
+    expect(archetypeController).toBeDefined();
+  });
+
+  // describe('health', () => {
+  //   it('should return {"status":"OK","title":"Epsilon API Hub"}', () => {
+  //     expect(archetypeController.getArchetype()).toStrictEqual(
+  //       JSON.parse('{"status":"OK","title":"Epsilon API Hub"}'),
+  //     );
+  //   });
+  // });
+});

--- a/src/archetype/archetype.controller.ts
+++ b/src/archetype/archetype.controller.ts
@@ -14,9 +14,9 @@ import {
 import { ArchetypeService } from './archetype.service';
 import {
   ArchetypeDto,
-  // ArchetypeNodeType,
-  // ArchetypePermission,
-  // ArchetypeStatus,
+  ArchetypeNodeType,
+  ArchetypePermission,
+  ArchetypeStatus,
 } from './dto';
 import { Request } from 'express';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
@@ -24,106 +24,109 @@ import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Resource } from 'src/common/decorators/resource.decorator';
 import { Scopes } from 'src/common/decorators/scopes.decorator';
 import { ResourceGuard } from 'src/common/guards/resource.guard';
+import { customAlphabet } from 'nanoid';
 
-// const testArchetype: ArchetypeDto = {
-//   projectId: '8b422bfc-d830-439a-8982-4a8af193dee4',
-//   name: 'Test 222',
-//   nodes: [
-//     {
-//       id: 'node-0',
-//       data: {
-//         label: 'Person',
-//         level: 0,
-//       },
-//       position: {
-//         x: 0,
-//         y: 1,
-//       },
-//       type: 'root' as ArchetypeNodeType,
-//     },
-//     {
-//       id: 'node-1',
-//       data: {
-//         label: 'Age',
-//         level: 1,
-//       },
-//       position: {
-//         x: 100.5,
-//         y: 200,
-//       },
-//       type: 'category' as ArchetypeNodeType,
-//     },
-//     {
-//       id: 'node-2',
-//       data: {
-//         label: 'Stable',
-//         level: 1,
-//       },
-//       position: {
-//         x: 100.5,
-//         y: 200,
-//       },
-//       type: 'category' as ArchetypeNodeType,
-//     },
-//     {
-//       id: 'f8a951d7-9c21-4cb1-8383-959c11e91861',
-//       data: {
-//         label: 'public.stable',
-//         level: 2,
-//       },
-//       position: {
-//         x: 100.5,
-//         y: 200,
-//       },
-//       type: 'column' as ArchetypeNodeType,
-//     },
-//     {
-//       id: '154016d8-a140-40e4-9159-2c3bb4317629',
-//       data: {
-//         label: 'public.stable',
-//         level: 2,
-//       },
-//       position: {
-//         x: 100.5,
-//         y: 200,
-//       },
-//       type: 'column' as ArchetypeNodeType,
-//     },
-//   ],
-//   edges: [
-//     {
-//       id: 'edge-1',
-//       source: 'node-0',
-//       target: 'node-1',
-//     },
-//     {
-//       id: 'edge-1',
-//       source: 'node-0',
-//       target: 'node-2',
-//     },
-//     {
-//       id: 'edge-3',
-//       source: 'node-1',
-//       target: 'f8a951d7-9c21-4cb1-8383-959c11e91861',
-//     },
-//     {
-//       id: 'edge-4',
-//       source: 'node-2',
-//       target: '154016d8-a140-40e4-9159-2c3bb4317629',
-//     },
-//   ],
-//   permissions: [
-//     {
-//       id: 'node-1',
-//       permission: 'HIGH' as ArchetypePermission,
-//     },
-//     {
-//       id: 'node-2',
-//       permission: 'DETAILED' as ArchetypePermission,
-//     },
-//   ],
-//   status: 'DRAFT' as ArchetypeStatus,
-// };
+const customNanoidAlphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+const testArchetype: ArchetypeDto = {
+  projectId: '638c6f81-00c8-47f4-82ec-6b94240e757d',
+  name: `Test ${customAlphabet(customNanoidAlphabet, 6)()}`,
+  nodes: [
+    {
+      id: 'node-0',
+      data: {
+        label: 'Person',
+        level: 0,
+      },
+      position: {
+        x: 0,
+        y: 1,
+      },
+      type: 'root' as ArchetypeNodeType,
+    },
+    {
+      id: 'node-1',
+      data: {
+        label: 'Age',
+        level: 1,
+      },
+      position: {
+        x: 100.5,
+        y: 200,
+      },
+      type: 'category' as ArchetypeNodeType,
+    },
+    {
+      id: 'node-2',
+      data: {
+        label: 'Stable',
+        level: 1,
+      },
+      position: {
+        x: 100.5,
+        y: 200,
+      },
+      type: 'category' as ArchetypeNodeType,
+    },
+    {
+      id: '107bd314-6c77-4a6e-ad08-178ce898833b',
+      data: {
+        label: 'age',
+        level: 2,
+      },
+      position: {
+        x: 100.5,
+        y: 200,
+      },
+      type: 'column' as ArchetypeNodeType,
+    },
+    {
+      id: 'f6c44e6c-3cf5-47cb-bb0b-3d300bbbf348',
+      data: {
+        label: 'stable',
+        level: 2,
+      },
+      position: {
+        x: 100.5,
+        y: 200,
+      },
+      type: 'column' as ArchetypeNodeType,
+    },
+  ],
+  edges: [
+    {
+      id: 'edge-1',
+      source: 'node-0',
+      target: 'node-1',
+    },
+    {
+      id: 'edge-1',
+      source: 'node-0',
+      target: 'node-2',
+    },
+    {
+      id: 'edge-3',
+      source: 'node-1',
+      target: '107bd314-6c77-4a6e-ad08-178ce898833b',
+    },
+    {
+      id: 'edge-4',
+      source: 'node-2',
+      target: 'f6c44e6c-3cf5-47cb-bb0b-3d300bbbf348',
+    },
+  ],
+  permissions: [
+    {
+      id: 'node-1',
+      permission: 'HIGH' as ArchetypePermission,
+    },
+    {
+      id: 'node-2',
+      permission: 'DETAILED' as ArchetypePermission,
+    },
+  ],
+  status: 'DRAFT' as ArchetypeStatus,
+};
 
 @ApiTags('Archetype')
 @Controller('archetype')
@@ -137,8 +140,18 @@ export class ArchetypeController {
   @Get(':projectId')
   @ApiOperation({ summary: 'Get list of archetypes for a project' })
   async getArchetypes(@Param('projectId', ParseUUIDPipe) projectId: string) {
-    // this.logger.debug(JSON.stringify(testArchetype));
-    // await this.archetypeService.createArchetype('owner', testArchetype);
+    // this.logger.debug(
+    //   `Test archetype template:\n ${JSON.stringify(testArchetype, null, 2)}`,
+    // );
+    // const test = await this.archetypeService.createArchetype(
+    //   'owner',
+    //   testArchetype,
+    // );
+    // const getArchetype = await this.archetypeService.getArchetypeDetails(
+    //   projectId,
+    //   '32a9ffdb-47af-412c-8e7e-4500f919191d',
+    // );
+    // this.logger.debug(JSON.stringify(getArchetype));
     return await this.archetypeService.fetchArchetypes(projectId);
   }
 

--- a/src/archetype/archetype.controller.ts
+++ b/src/archetype/archetype.controller.ts
@@ -12,121 +12,13 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ArchetypeService } from './archetype.service';
-import {
-  ArchetypeDto,
-  ArchetypeNodeType,
-  ArchetypePermission,
-  ArchetypeStatus,
-} from './dto';
+import { ArchetypeDto } from './dto';
 import { Request } from 'express';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 
 import { Resource } from 'src/common/decorators/resource.decorator';
 import { Scopes } from 'src/common/decorators/scopes.decorator';
 import { ResourceGuard } from 'src/common/guards/resource.guard';
-import { customAlphabet } from 'nanoid';
-
-const customNanoidAlphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-
-const testArchetype: ArchetypeDto = {
-  projectId: '638c6f81-00c8-47f4-82ec-6b94240e757d',
-  name: `Test ${customAlphabet(customNanoidAlphabet, 6)()}`,
-  nodes: [
-    {
-      id: 'node-0',
-      data: {
-        label: 'Person',
-        level: 0,
-      },
-      position: {
-        x: 0,
-        y: 1,
-      },
-      type: 'root' as ArchetypeNodeType,
-    },
-    {
-      id: 'node-1',
-      data: {
-        label: 'Age',
-        level: 1,
-      },
-      position: {
-        x: 100.5,
-        y: 200,
-      },
-      type: 'category' as ArchetypeNodeType,
-    },
-    {
-      id: 'node-2',
-      data: {
-        label: 'Stable',
-        level: 1,
-      },
-      position: {
-        x: 100.5,
-        y: 200,
-      },
-      type: 'category' as ArchetypeNodeType,
-    },
-    {
-      id: '107bd314-6c77-4a6e-ad08-178ce898833b',
-      data: {
-        label: 'age',
-        level: 2,
-      },
-      position: {
-        x: 100.5,
-        y: 200,
-      },
-      type: 'column' as ArchetypeNodeType,
-    },
-    {
-      id: 'f6c44e6c-3cf5-47cb-bb0b-3d300bbbf348',
-      data: {
-        label: 'stable',
-        level: 2,
-      },
-      position: {
-        x: 100.5,
-        y: 200,
-      },
-      type: 'column' as ArchetypeNodeType,
-    },
-  ],
-  edges: [
-    {
-      id: 'edge-1',
-      source: 'node-0',
-      target: 'node-1',
-    },
-    {
-      id: 'edge-1',
-      source: 'node-0',
-      target: 'node-2',
-    },
-    {
-      id: 'edge-3',
-      source: 'node-1',
-      target: '107bd314-6c77-4a6e-ad08-178ce898833b',
-    },
-    {
-      id: 'edge-4',
-      source: 'node-2',
-      target: 'f6c44e6c-3cf5-47cb-bb0b-3d300bbbf348',
-    },
-  ],
-  permissions: [
-    {
-      id: 'node-1',
-      permission: 'HIGH' as ArchetypePermission,
-    },
-    {
-      id: 'node-2',
-      permission: 'DETAILED' as ArchetypePermission,
-    },
-  ],
-  status: 'DRAFT' as ArchetypeStatus,
-};
 
 @ApiTags('Archetype')
 @Controller('archetype')
@@ -140,18 +32,6 @@ export class ArchetypeController {
   @Get(':projectId')
   @ApiOperation({ summary: 'Get list of archetypes for a project' })
   async getArchetypes(@Param('projectId', ParseUUIDPipe) projectId: string) {
-    // this.logger.debug(
-    //   `Test archetype template:\n ${JSON.stringify(testArchetype, null, 2)}`,
-    // );
-    // const test = await this.archetypeService.createArchetype(
-    //   'owner',
-    //   testArchetype,
-    // );
-    // const getArchetype = await this.archetypeService.getArchetypeDetails(
-    //   projectId,
-    //   '32a9ffdb-47af-412c-8e7e-4500f919191d',
-    // );
-    // this.logger.debug(JSON.stringify(getArchetype));
     return await this.archetypeService.fetchArchetypes(projectId);
   }
 
@@ -182,6 +62,7 @@ export class ArchetypeController {
     return this.archetypeService.createArchetype(username, archetype);
   }
 
+  // TODO: needs further investigation of how best to update an archetype in atlas
   @UseGuards(ResourceGuard)
   @Scopes('view, edit')
   @Put(':projectId/:archetypeId')
@@ -193,8 +74,7 @@ export class ArchetypeController {
     @Req() request: Request,
   ) {
     const username = request.auth.payload.preferred_username.toString();
-    // TODO: create this update function
-    return this.archetypeService.createArchetype(username, archetype);
+    return this.archetypeService.updateArchetype(username, archetype);
   }
 
   @UseGuards(ResourceGuard)

--- a/src/archetype/archetype.controller.ts
+++ b/src/archetype/archetype.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Delete,
   Get,
+  Logger,
   Param,
   ParseUUIDPipe,
   Post,
@@ -11,7 +12,12 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ArchetypeService } from './archetype.service';
-import { ArchetypeDto } from './dto';
+import {
+  ArchetypeDto,
+  // ArchetypeNodeType,
+  // ArchetypePermission,
+  // ArchetypeStatus,
+} from './dto';
 import { Request } from 'express';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 
@@ -19,10 +25,111 @@ import { Resource } from 'src/common/decorators/resource.decorator';
 import { Scopes } from 'src/common/decorators/scopes.decorator';
 import { ResourceGuard } from 'src/common/guards/resource.guard';
 
+// const testArchetype: ArchetypeDto = {
+//   projectId: '8b422bfc-d830-439a-8982-4a8af193dee4',
+//   name: 'Test 222',
+//   nodes: [
+//     {
+//       id: 'node-0',
+//       data: {
+//         label: 'Person',
+//         level: 0,
+//       },
+//       position: {
+//         x: 0,
+//         y: 1,
+//       },
+//       type: 'root' as ArchetypeNodeType,
+//     },
+//     {
+//       id: 'node-1',
+//       data: {
+//         label: 'Age',
+//         level: 1,
+//       },
+//       position: {
+//         x: 100.5,
+//         y: 200,
+//       },
+//       type: 'category' as ArchetypeNodeType,
+//     },
+//     {
+//       id: 'node-2',
+//       data: {
+//         label: 'Stable',
+//         level: 1,
+//       },
+//       position: {
+//         x: 100.5,
+//         y: 200,
+//       },
+//       type: 'category' as ArchetypeNodeType,
+//     },
+//     {
+//       id: 'f8a951d7-9c21-4cb1-8383-959c11e91861',
+//       data: {
+//         label: 'public.stable',
+//         level: 2,
+//       },
+//       position: {
+//         x: 100.5,
+//         y: 200,
+//       },
+//       type: 'column' as ArchetypeNodeType,
+//     },
+//     {
+//       id: '154016d8-a140-40e4-9159-2c3bb4317629',
+//       data: {
+//         label: 'public.stable',
+//         level: 2,
+//       },
+//       position: {
+//         x: 100.5,
+//         y: 200,
+//       },
+//       type: 'column' as ArchetypeNodeType,
+//     },
+//   ],
+//   edges: [
+//     {
+//       id: 'edge-1',
+//       source: 'node-0',
+//       target: 'node-1',
+//     },
+//     {
+//       id: 'edge-1',
+//       source: 'node-0',
+//       target: 'node-2',
+//     },
+//     {
+//       id: 'edge-3',
+//       source: 'node-1',
+//       target: 'f8a951d7-9c21-4cb1-8383-959c11e91861',
+//     },
+//     {
+//       id: 'edge-4',
+//       source: 'node-2',
+//       target: '154016d8-a140-40e4-9159-2c3bb4317629',
+//     },
+//   ],
+//   permissions: [
+//     {
+//       id: 'node-1',
+//       permission: 'HIGH' as ArchetypePermission,
+//     },
+//     {
+//       id: 'node-2',
+//       permission: 'DETAILED' as ArchetypePermission,
+//     },
+//   ],
+//   status: 'DRAFT' as ArchetypeStatus,
+// };
+
 @ApiTags('Archetype')
 @Controller('archetype')
 @Resource('project')
 export class ArchetypeController {
+  private readonly logger = new Logger(ArchetypeController.name);
   constructor(private readonly archetypeService: ArchetypeService) {}
 
   @UseGuards(ResourceGuard)
@@ -30,6 +137,8 @@ export class ArchetypeController {
   @Get(':projectId')
   @ApiOperation({ summary: 'Get list of archetypes for a project' })
   async getArchetypes(@Param('projectId', ParseUUIDPipe) projectId: string) {
+    // this.logger.debug(JSON.stringify(testArchetype));
+    // await this.archetypeService.createArchetype('owner', testArchetype);
     return await this.archetypeService.fetchArchetypes(projectId);
   }
 

--- a/src/archetype/archetype.controller.ts
+++ b/src/archetype/archetype.controller.ts
@@ -7,49 +7,60 @@ import {
   ParseUUIDPipe,
   Post,
   Req,
+  UseGuards,
 } from '@nestjs/common';
 import { ArchetypeService } from './archetype.service';
-import { DockerService } from 'src/docker/docker.service';
 import { ArchetypeDto } from './dto';
 import { Request } from 'express';
-// import { DatabaseInfoDto } from 'src/connection_request/dto';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 
+import { Resource } from 'src/common/decorators/resource.decorator';
+import { Scopes } from 'src/common/decorators/scopes.decorator';
+import { ResourceGuard } from 'src/common/guards/resource.guard';
+
+@ApiTags('Archetype')
 @Controller('archetype')
 export class ArchetypeController {
-  constructor(
-    private readonly templateService: ArchetypeService,
-    private readonly dockerService: DockerService,
-  ) {}
+  constructor(private readonly archetypeService: ArchetypeService) {}
 
-  @Get(':projectId/names')
-  async getArchetypeNames(
-    @Param('projectId', ParseUUIDPipe) projectId: string,
-  ) {
-    return await this.templateService.archetypeNames(projectId);
+  @Resource('project')
+  @UseGuards(ResourceGuard)
+  @Scopes('view, edit')
+  @Get(':projectId')
+  @ApiOperation({ summary: 'Get list of archetypes for a project' })
+  async getArchetypes(@Param('projectId', ParseUUIDPipe) projectId: string) {
+    return await this.archetypeService.fetchArchetypes(projectId);
   }
 
-  @Get(':projectId')
-  async getArchetypes(@Param('projectId', ParseUUIDPipe) projectId: string) {
-    // await this.dockerService.runDataBroker('admin', projectId);
-    return await this.templateService.getArchetypes(projectId);
+  @Get(':projectId/:archetypeId')
+  @ApiOperation({ summary: 'Get project archetype details' })
+  async getArchetype(
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+    @Param('archetypeId', ParseUUIDPipe) archetypeId: string,
+  ) {
+    return await this.archetypeService.getArchetypeDetails(
+      projectId,
+      archetypeId,
+    );
+  }
+
+  @Post(':projectId')
+  @ApiOperation({ summary: 'Create archetype for a project' })
+  createArchetype(
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+    @Body() archetype: ArchetypeDto,
+    @Req() request: Request,
+  ) {
+    const username = request.auth.payload.preferred_username.toString();
+    return this.archetypeService.createArchetype(username, archetype);
   }
 
   @Delete(':projectId/:archetypeId')
+  @ApiOperation({ summary: 'Delete archetype for a project' })
   async deleteArchetype(
     @Param('projectId', ParseUUIDPipe) projectId: string,
     @Param('archetypeId', ParseUUIDPipe) archetypeId: string,
   ) {
-    const template = { projectId, archetypeId } as ArchetypeDto;
-    return await this.templateService.deleteArchetype(template);
-  }
-
-  @Post(':projectId')
-  createArchetype(
-    @Param('projectId', ParseUUIDPipe) projectId: string,
-    @Body() template: ArchetypeDto,
-    @Req() request: Request,
-  ) {
-    const username = request.auth.payload.preferred_username.toString();
-    return this.templateService.createArchetype(username, template);
+    return await this.archetypeService.deleteArchetype(projectId, archetypeId);
   }
 }

--- a/src/archetype/archetype.controller.ts
+++ b/src/archetype/archetype.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   ParseUUIDPipe,
   Post,
+  Put,
   Req,
   UseGuards,
 } from '@nestjs/common';
@@ -20,18 +21,20 @@ import { ResourceGuard } from 'src/common/guards/resource.guard';
 
 @ApiTags('Archetype')
 @Controller('archetype')
+@Resource('project')
 export class ArchetypeController {
   constructor(private readonly archetypeService: ArchetypeService) {}
 
-  @Resource('project')
   @UseGuards(ResourceGuard)
-  @Scopes('view, edit')
+  @Scopes('view')
   @Get(':projectId')
   @ApiOperation({ summary: 'Get list of archetypes for a project' })
   async getArchetypes(@Param('projectId', ParseUUIDPipe) projectId: string) {
     return await this.archetypeService.fetchArchetypes(projectId);
   }
 
+  @UseGuards(ResourceGuard)
+  @Scopes('view')
   @Get(':projectId/:archetypeId')
   @ApiOperation({ summary: 'Get project archetype details' })
   async getArchetype(
@@ -44,6 +47,8 @@ export class ArchetypeController {
     );
   }
 
+  @UseGuards(ResourceGuard)
+  @Scopes('view, edit')
   @Post(':projectId')
   @ApiOperation({ summary: 'Create archetype for a project' })
   createArchetype(
@@ -55,6 +60,24 @@ export class ArchetypeController {
     return this.archetypeService.createArchetype(username, archetype);
   }
 
+  @UseGuards(ResourceGuard)
+  @Scopes('view, edit')
+  @Put(':projectId/:archetypeId')
+  @ApiOperation({ summary: 'Update archetype for a project' })
+  updateArchetype(
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+    @Param('archetypeId', ParseUUIDPipe) archetypeId: string,
+    @Body() archetype: ArchetypeDto,
+    @Req() request: Request,
+  ) {
+    const username = request.auth.payload.preferred_username.toString();
+    // TODO: create this update function
+    return this.archetypeService.createArchetype(username, archetype);
+  }
+
+  @UseGuards(ResourceGuard)
+  @Scopes('view, edit')
+  @Get(':projectId')
   @Delete(':projectId/:archetypeId')
   @ApiOperation({ summary: 'Delete archetype for a project' })
   async deleteArchetype(

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -13,33 +13,9 @@ export class ArchetypeService {
     private databaseSource: DatabaseService,
   ) {}
 
-  async archetypeNames(projectId: string, token?: string) {
-    let activeTemplates = [];
-
-    const params = {
-      query: `from archetype where instance.projectId = "${projectId}" select __state, __guid, qualifiedName`,
-    };
-    await this.atlas
-      .get('/search/dsl', params, token)
-      .then((res) => {
-        activeTemplates = res.attributes.values
-          .filter((item) => item[0] === 'ACTIVE')
-          .map((item) => {
-            return {
-              guid: item[1],
-              name: item[2].split('@', 2)[1],
-            };
-          });
-      })
-      .catch(() => {
-        activeTemplates = [];
-      });
-
-    return activeTemplates;
-  }
-
+  // TODO: use code and remove this method
   async getArchetypes(projectId: string, token?: string) {
-    const activeTemplates = await this.archetypeNames(projectId, token);
+    const activeTemplates = await this.fetchArchetypes(projectId, token);
 
     const output = [];
     for (const template of activeTemplates) {
@@ -113,8 +89,71 @@ export class ArchetypeService {
     return output;
   }
 
+  async fetchArchetypes(projectId: string, token?: string) {
+    let activeTemplates = [];
+
+    const params = {
+      query: `from archetype where instance.projectId = "${projectId}" select __state, __guid, name, status, qualifiedName`,
+    };
+    await this.atlas
+      .get('/search/dsl', params, token)
+      .then((res) => {
+        activeTemplates = res.attributes.values
+          .filter((item) => item[0] === 'ACTIVE')
+          .map((item) => {
+            return {
+              guid: item[1],
+              name: item[2].split('@', 2)[1],
+            };
+          });
+      })
+      .catch(() => {
+        activeTemplates = [];
+      });
+
+    return activeTemplates;
+  }
+
+  async createArchetype(username: string, archetype: ArchetypeDto) {
+    await this.queue.addArchetypeJob(username, archetype);
+  }
+
+  // MAKE: entity call to Atlas
+  async getArchetypeDetails(
+    projectId: string,
+    archetypeId: string,
+    token?: string,
+  ) {
+    let activeTemplates = [];
+
+    const params = {
+      query: `from archetype where instance.projectId = "${projectId}" select __state, __guid, qualifiedName`,
+    };
+    await this.atlas
+      .get('/search/dsl', params, token)
+      .then((res) => {
+        activeTemplates = res.attributes.values
+          .filter((item) => item[0] === 'ACTIVE')
+          .map((item) => {
+            return {
+              guid: item[1],
+              name: item[2].split('@', 2)[1],
+            };
+          });
+      })
+      .catch(() => {
+        activeTemplates = [];
+      });
+
+    return activeTemplates;
+  }
+
+  async deleteArchetype(projectId: string, archetypeId: string) {
+    return await this.queue.deleteTemplateJob(projectId, archetypeId);
+  }
+
   async getAnalysisArchetype(projectId: string, token?: string) {
-    const activeTemplates = await this.archetypeNames(projectId, token);
+    const activeTemplates = await this.fetchArchetypes(projectId, token);
 
     const output = [];
     for (const template of activeTemplates) {
@@ -180,15 +219,6 @@ export class ArchetypeService {
       output.push(schema);
     }
     return output;
-  }
-
-  async deleteArchetype(template: ArchetypeDto) {
-    return await this.queue.deleteTemplateJob(template);
-  }
-
-  async createArchetype(username: string, template: ArchetypeDto) {
-    const dbId = await this.databaseSource.findDbId(template.projectId);
-    await this.queue.addArchetypeJob(username, dbId, template);
   }
 
   private atlasTypeToJSONType(dataType: string): string {

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -2,10 +2,10 @@ import { Injectable, Logger } from '@nestjs/common';
 import { AtlasService } from 'src/atlas/atlas.service';
 // import { DatabaseService } from 'src/database/database.service';
 import { QueueService } from 'src/queue/queue.service';
-import { ArchetypeDto } from './dto';
+import { ArchetypeDto, ArchetypeStatus } from './dto';
 import {
-  AtlasSearchAttributeResponseDto,
-  AtlasSearchDslAttributesResponseDto,
+  AtlasEntityResponseDto,
+  AtlasSearchBasicResponseDto,
 } from 'src/atlas/dto';
 
 @Injectable()
@@ -95,32 +95,39 @@ export class ArchetypeService {
   }
 
   async fetchArchetypes(projectId: string, token?: string) {
-    const params = {
+    // NOTE: can also remove headers to reduce payload
+    const body = {
       typeName: 'archetype_template',
-      attrName: `projectId`,
-      attrValuePrefix: projectId,
+      excludeDeletedEntities: true,
+      includeClassificationAttributes: false,
+      includeSubTypes: false,
+      includeSubClassifications: false,
+      excludeHeaderAttributes: false,
+      entityFilters: {
+        attributeName: 'projectId',
+        operator: 'eq',
+        attributeValue: projectId,
+      },
+      attributes: [
+        'name',
+        'qualifiedName',
+        'status',
+        '__modificationTimestamp',
+      ],
     };
-    try {
-      const res = await this.atlas.get<AtlasSearchAttributeResponseDto>(
-        '/search/attribute',
-        params,
-        token,
-      );
 
-      const entities = res?.entities ?? [];
-      return entities.map((entity) => {
-        this.logger.debug(entity);
-        return {
-          id: entity.guid,
-          name: entity.displayText,
-          status: entity.attributes?.status,
-        };
-      });
-    } catch (err) {
-      // translate to your API error if needed
-      // throw new InternalServerErrorException('Atlas search failed');
-      throw err;
-    }
+    const res = await this.atlas.post<AtlasSearchBasicResponseDto>(
+      '/search/basic',
+      body,
+      token,
+    );
+    const entities = res?.entities ?? [];
+    return entities.map((entity) => ({
+      id: entity.guid,
+      name: entity.displayText,
+      status: entity.attributes?.status,
+      lastModified: entity.attributes?.__modificationTimestamp,
+    }));
   }
 
   async createArchetype(username: string, archetype: ArchetypeDto) {
@@ -133,28 +140,72 @@ export class ArchetypeService {
     archetypeId: string,
     token?: string,
   ) {
-    let activeTemplates = [];
+    const entityRes = await this.atlas.get<AtlasEntityResponseDto>(
+      `/entity/guid/${archetypeId}`,
+      undefined,
+      token,
+    );
 
-    const params = {
-      query: `from archetype_template where instance.projectId = "${projectId}" select __state, __guid, qualifiedName`,
+    // TODO: handle errors
+
+    const templateInfo: ArchetypeDto = {
+      projectId: projectId,
+      archetypeId: archetypeId,
+      name: entityRes.entity?.displayText,
+      status: entityRes.entity?.attributes?.status as ArchetypeStatus,
+      nodes: [],
+      edges: [],
     };
-    await this.atlas
-      .get<AtlasSearchDslAttributesResponseDto>('/search/dsl', params, token)
-      .then((res) => {
-        activeTemplates = res.attributes.values
-          .filter((item) => item[0] === 'ACTIVE')
-          .map((item) => {
-            return {
-              guid: item[1],
-              name: item[2].split('@', 2)[1],
-            };
-          });
-      })
-      .catch(() => {
-        activeTemplates = [];
-      });
 
-    return activeTemplates;
+    // for (const key in entityRes.referredEntities) {
+    //   const entity = entityRes.referredEntities[key];
+
+    //   if (entity.typeName.includes('archetype_')) {
+    //     const splitted = entity.attributes.qualifiedName.split('@');
+    //     const node = {
+    //       id: splitted[2],
+    //       position: {
+    //         x: Number(entity.attributes.position.x),
+    //         y: Number(entity.attributes.position.y),
+    //       },
+    //       data: {
+    //         label: entity.attributes.displayName,
+    //       },
+    //       type: entity.typeName.replace('archetype_', ''),
+    //       width: entity.attributes.width,
+    //       height: entity.attributes.height,
+    //       selected: false,
+    //       positionAbsolute: {
+    //         x: Number(entity.attributes.position.x),
+    //         y: Number(entity.attributes.position.y),
+    //       },
+    //       dragging: false,
+    //     };
+    //     templateInfo.nodes.push(node);
+
+    //     if (entity.typeName != 'archetype_object') {
+    //       const edge = {
+    //         source: splitted[2],
+    //         target: '',
+    //         sourceHandle: null,
+    //         targetHandle: null,
+    //         id: '',
+    //       };
+
+    //       const name =
+    //         entity.typeName == 'archetype_category'
+    //           ? entity.relationshipAttributes.object.qualifiedName
+    //           : entity.relationshipAttributes.category.qualifiedName;
+
+    //       edge.target = name.split('@')[2];
+    //       edge.id = `edge_${edge.source}_${edge.target}`;
+
+    //       templateInfo.edges.push(edge);
+    //     }
+    //   }
+    // }
+
+    return templateInfo;
   }
 
   async deleteArchetype(projectId: string, archetypeId: string) {

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { AtlasService } from 'src/atlas/atlas.service';
-// import { DatabaseService } from 'src/database/database.service';
 import { QueueService } from 'src/queue/queue.service';
 import {
   ArchetypeDto,
@@ -12,6 +11,8 @@ import {
 } from './dto';
 import {
   AtlasArchetypeEntityResponseDto,
+  AtlasEntityResponseDto,
+  AtlasSearchBasicHeadlessResponseDto,
   AtlasSearchBasicResponseDto,
 } from 'src/atlas/dto';
 
@@ -21,8 +22,6 @@ export class ArchetypeService {
   constructor(
     private atlas: AtlasService,
     private readonly queue: QueueService,
-    // @Inject(forwardRef(() => DatabaseService))
-    // private databaseSource: DatabaseService,
   ) {}
 
   async fetchArchetypes(projectId: string, token?: string) {
@@ -63,6 +62,10 @@ export class ArchetypeService {
 
   async createArchetype(username: string, archetype: ArchetypeDto) {
     return await this.queue.addArchetypeJob(username, archetype);
+  }
+
+  async updateArchetype(username: string, archetype: ArchetypeDto) {
+    return await this.queue.updateArchetypeJob(username, archetype);
   }
 
   async getArchetypeDetails(
@@ -158,79 +161,108 @@ export class ArchetypeService {
     return templateInfo;
   }
 
-  // TODO: still need to refactor
   async deleteArchetype(projectId: string, archetypeId: string) {
-    return await this.queue.deleteTemplateJob(projectId, archetypeId);
+    return await this.queue.deleteArchetypeJob(projectId, archetypeId);
   }
 
-  // TODO: still need to refactor
   async getAnalysisArchetype(projectId: string, token?: string) {
-    const activeTemplates = await this.fetchArchetypes(projectId, token);
+    // get ID of PUBLISHED archetype
+    const body = {
+      typeName: 'archetype_template',
+      excludeDeletedEntities: true,
+      includeSubClassifications: false,
+      excludeHeaderAttributes: true,
+      includeSubTypes: false,
+      entityFilters: {
+        condition: 'AND',
+        criterion: [
+          {
+            attributeName: 'projectId',
+            operator: 'eq',
+            attributeValue: `${projectId}`,
+          },
+          {
+            attributeName: 'status',
+            operator: 'eq',
+            attributeValue: 'PUBLISHED',
+          },
+        ],
+      },
+      attributes: ['name', '__guid'],
+    };
 
-    const output = [];
-    for (const template of activeTemplates) {
-      // const templateGuid = template.guid;
-
+    const res = await this.atlas.post<AtlasSearchBasicHeadlessResponseDto>(
+      '/search/basic',
+      body,
+      token,
+    );
+    if (res.approximateCount) {
       const properties: Record<string, object> = {};
       const schema = {
         $schema: 'https://json-schema.org/draft/2020-12/schema#',
-        title: template.name,
+        title: res.attributes?.values[0][0],
         type: 'object',
         properties,
       };
 
-      // const templateEntity = await this.atlas.get(
-      //   `/entity/guid/${templateGuid}`,
-      //   undefined,
-      //   token,
-      // );
+      const templateGuid = res.attributes?.values[0][1];
+      const templateEntity =
+        await this.atlas.get<AtlasArchetypeEntityResponseDto>(
+          `/entity/guid/${templateGuid}`,
+          undefined,
+          token,
+        );
 
-      // for (const key in templateEntity.referredEntities) {
-      //   const entity = templateEntity.referredEntities[key];
+      // TODO: handle errors
+      for (const key in templateEntity.referredEntities) {
+        const node = templateEntity.referredEntities[key];
+        // TODO: check if this is the best thing to use
+        const objectName = node.attributes?.label
+          .replace(/\s+/g, '_')
+          .toLowerCase();
+        const description = node.attributes?.label;
+        // check for node has children
+        if (node.relationshipAttributes?.child_nodes?.length) {
+          const type = 'object';
+          const properties: Record<string, object> = {};
+          schema.properties[objectName] = { type, properties };
+        }
+        // check if node has a column
+        if (node.relationshipAttributes?.column) {
+          const column = node.relationshipAttributes?.column;
+          const properties: Record<string, object> = {};
+          // TODO: handle errors
+          const { entity } = await this.atlas.get<AtlasEntityResponseDto>(
+            `/entity/guid/${column.guid}`,
+            undefined,
+            token,
+          );
+          const jsonType = this.atlasTypeToJSONType(
+            entity.attributes?.data_type as string,
+          );
+          properties[objectName] = {
+            type: jsonType,
+            description,
+          };
 
-      //   if (entity.typeName.includes('archetype_')) {
-      //     if (entity.typeName != 'archetype_object') {
-      //       const objectName = entity.attributes.qualifiedName;
-      //       if (entity.relationshipAttributes.subcategories?.length) {
-      //         const type = 'object';
-      //         const properties: Record<string, object> = {};
-      //         schema.properties[objectName] = { type, properties };
-      //       }
-      //       if (entity.relationshipAttributes.columns?.length) {
-      //         const properties: Record<string, object> = {};
-      //         for (const column of entity.relationshipAttributes.columns) {
-      //           const { entity } = await this.atlas.get(
-      //             `/entity/guid/${column.guid}`,
-      //             undefined,
-      //             token,
-      //           );
-      //           const jsonType = this.atlasTypeToJSONType(
-      //             entity.attributes.data_type,
-      //           );
-      //           properties[objectName] = {
-      //             type: jsonType,
-      //           };
-      //         }
-      //         if (entity.relationshipAttributes.category) {
-      //           schema.properties[
-      //             entity.relationshipAttributes.category.qualifiedName
-      //           ]['properties'] = {
-      //             ...schema.properties[
-      //               entity.relationshipAttributes.category.qualifiedName
-      //             ]['properties'],
-      //             ...properties,
-      //           };
-      //         } else {
-      //           schema.properties = { ...schema.properties, ...properties };
-      //         }
-      //       }
-      //     }
-      //   }
-      // }
-
-      output.push(schema);
+          // add nodes to parent
+          if (node.relationshipAttributes?.parent_node) {
+            const parentRef =
+              node.relationshipAttributes?.parent_node.displayText
+                .replace(/\s+/g, '_')
+                .toLowerCase();
+            schema.properties[parentRef]['properties'] = {
+              ...schema.properties[parentRef]['properties'],
+              ...properties,
+            };
+          } else {
+            schema.properties = { ...schema.properties, ...properties };
+          }
+        }
+      }
+      return schema;
     }
-    return output;
+    return {};
   }
 
   private atlasTypeToJSONType(dataType: string): string {

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -131,7 +131,7 @@ export class ArchetypeService {
   }
 
   async createArchetype(username: string, archetype: ArchetypeDto) {
-    await this.queue.addArchetypeJob(username, archetype);
+    return await this.queue.addArchetypeJob(username, archetype);
   }
 
   // MAKE: entity call to Atlas

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -1,16 +1,21 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { AtlasService } from 'src/atlas/atlas.service';
-import { DatabaseService } from 'src/database/database.service';
+// import { DatabaseService } from 'src/database/database.service';
 import { QueueService } from 'src/queue/queue.service';
 import { ArchetypeDto } from './dto';
+import {
+  AtlasSearchAttributeResponseDto,
+  AtlasSearchDslAttributesResponseDto,
+} from 'src/atlas/dto';
 
 @Injectable()
 export class ArchetypeService {
+  private readonly logger = new Logger(ArchetypeService.name);
   constructor(
     private atlas: AtlasService,
     private readonly queue: QueueService,
-    @Inject(forwardRef(() => DatabaseService))
-    private databaseSource: DatabaseService,
+    // @Inject(forwardRef(() => DatabaseService))
+    // private databaseSource: DatabaseService,
   ) {}
 
   // TODO: use code and remove this method
@@ -19,7 +24,7 @@ export class ArchetypeService {
 
     const output = [];
     for (const template of activeTemplates) {
-      const templateGuid = template.guid;
+      const templateGuid = template.id;
       const templateName = template.name;
 
       const templateInfo = {
@@ -29,59 +34,59 @@ export class ArchetypeService {
         edges: [],
       };
 
-      const templateEntity = await this.atlas.get(
-        `/entity/guid/${templateGuid}`,
-        undefined,
-        token,
-      );
+      // const templateEntity = await this.atlas.get(
+      //   `/entity/guid/${templateGuid}`,
+      //   undefined,
+      //   token,
+      // );
 
-      for (const key in templateEntity.referredEntities) {
-        const entity = templateEntity.referredEntities[key];
+      // for (const key in templateEntity.referredEntities) {
+      //   const entity = templateEntity.referredEntities[key];
 
-        if (entity.typeName.includes('archetype_')) {
-          const splitted = entity.attributes.qualifiedName.split('@');
-          const node = {
-            id: splitted[2],
-            position: {
-              x: Number(entity.attributes.position.x),
-              y: Number(entity.attributes.position.y),
-            },
-            data: {
-              label: entity.attributes.displayName,
-            },
-            type: entity.typeName.replace('archetype_', ''),
-            width: entity.attributes.width,
-            height: entity.attributes.height,
-            selected: false,
-            positionAbsolute: {
-              x: Number(entity.attributes.position.x),
-              y: Number(entity.attributes.position.y),
-            },
-            dragging: false,
-          };
-          templateInfo.nodes.push(node);
+      //   if (entity.typeName.includes('archetype_')) {
+      //     const splitted = entity.attributes.qualifiedName.split('@');
+      //     const node = {
+      //       id: splitted[2],
+      //       position: {
+      //         x: Number(entity.attributes.position.x),
+      //         y: Number(entity.attributes.position.y),
+      //       },
+      //       data: {
+      //         label: entity.attributes.displayName,
+      //       },
+      //       type: entity.typeName.replace('archetype_', ''),
+      //       width: entity.attributes.width,
+      //       height: entity.attributes.height,
+      //       selected: false,
+      //       positionAbsolute: {
+      //         x: Number(entity.attributes.position.x),
+      //         y: Number(entity.attributes.position.y),
+      //       },
+      //       dragging: false,
+      //     };
+      //     templateInfo.nodes.push(node);
 
-          if (entity.typeName != 'archetype_object') {
-            const edge = {
-              source: splitted[2],
-              target: '',
-              sourceHandle: null,
-              targetHandle: null,
-              id: '',
-            };
+      //     if (entity.typeName != 'archetype_object') {
+      //       const edge = {
+      //         source: splitted[2],
+      //         target: '',
+      //         sourceHandle: null,
+      //         targetHandle: null,
+      //         id: '',
+      //       };
 
-            const name =
-              entity.typeName == 'archetype_category'
-                ? entity.relationshipAttributes.object.qualifiedName
-                : entity.relationshipAttributes.category.qualifiedName;
+      //       const name =
+      //         entity.typeName == 'archetype_category'
+      //           ? entity.relationshipAttributes.object.qualifiedName
+      //           : entity.relationshipAttributes.category.qualifiedName;
 
-            edge.target = name.split('@')[2];
-            edge.id = `edge_${edge.source}_${edge.target}`;
+      //       edge.target = name.split('@')[2];
+      //       edge.id = `edge_${edge.source}_${edge.target}`;
 
-            templateInfo.edges.push(edge);
-          }
-        }
-      }
+      //       templateInfo.edges.push(edge);
+      //     }
+      //   }
+      // }
 
       output.push(templateInfo);
     }
@@ -90,28 +95,32 @@ export class ArchetypeService {
   }
 
   async fetchArchetypes(projectId: string, token?: string) {
-    let activeTemplates = [];
-
     const params = {
-      query: `from archetype where instance.projectId = "${projectId}" select __state, __guid, name, status, qualifiedName`,
+      typeName: 'archetype_template',
+      attrName: `projectId`,
+      attrValuePrefix: projectId,
     };
-    await this.atlas
-      .get('/search/dsl', params, token)
-      .then((res) => {
-        activeTemplates = res.attributes.values
-          .filter((item) => item[0] === 'ACTIVE')
-          .map((item) => {
-            return {
-              guid: item[1],
-              name: item[2].split('@', 2)[1],
-            };
-          });
-      })
-      .catch(() => {
-        activeTemplates = [];
-      });
+    try {
+      const res = await this.atlas.get<AtlasSearchAttributeResponseDto>(
+        '/search/attribute',
+        params,
+        token,
+      );
 
-    return activeTemplates;
+      const entities = res?.entities ?? [];
+      return entities.map((entity) => {
+        this.logger.debug(entity);
+        return {
+          id: entity.guid,
+          name: entity.displayText,
+          status: entity.attributes?.status,
+        };
+      });
+    } catch (err) {
+      // translate to your API error if needed
+      // throw new InternalServerErrorException('Atlas search failed');
+      throw err;
+    }
   }
 
   async createArchetype(username: string, archetype: ArchetypeDto) {
@@ -127,10 +136,10 @@ export class ArchetypeService {
     let activeTemplates = [];
 
     const params = {
-      query: `from archetype where instance.projectId = "${projectId}" select __state, __guid, qualifiedName`,
+      query: `from archetype_template where instance.projectId = "${projectId}" select __state, __guid, qualifiedName`,
     };
     await this.atlas
-      .get('/search/dsl', params, token)
+      .get<AtlasSearchDslAttributesResponseDto>('/search/dsl', params, token)
       .then((res) => {
         activeTemplates = res.attributes.values
           .filter((item) => item[0] === 'ACTIVE')
@@ -157,7 +166,7 @@ export class ArchetypeService {
 
     const output = [];
     for (const template of activeTemplates) {
-      const templateGuid = template.guid;
+      // const templateGuid = template.guid;
 
       const properties: Record<string, object> = {};
       const schema = {
@@ -167,54 +176,54 @@ export class ArchetypeService {
         properties,
       };
 
-      const templateEntity = await this.atlas.get(
-        `/entity/guid/${templateGuid}`,
-        undefined,
-        token,
-      );
+      // const templateEntity = await this.atlas.get(
+      //   `/entity/guid/${templateGuid}`,
+      //   undefined,
+      //   token,
+      // );
 
-      for (const key in templateEntity.referredEntities) {
-        const entity = templateEntity.referredEntities[key];
+      // for (const key in templateEntity.referredEntities) {
+      //   const entity = templateEntity.referredEntities[key];
 
-        if (entity.typeName.includes('archetype_')) {
-          if (entity.typeName != 'archetype_object') {
-            const objectName = entity.attributes.qualifiedName;
-            if (entity.relationshipAttributes.subcategories?.length) {
-              const type = 'object';
-              const properties: Record<string, object> = {};
-              schema.properties[objectName] = { type, properties };
-            }
-            if (entity.relationshipAttributes.columns?.length) {
-              const properties: Record<string, object> = {};
-              for (const column of entity.relationshipAttributes.columns) {
-                const { entity } = await this.atlas.get(
-                  `/entity/guid/${column.guid}`,
-                  undefined,
-                  token,
-                );
-                const jsonType = this.atlasTypeToJSONType(
-                  entity.attributes.data_type,
-                );
-                properties[objectName] = {
-                  type: jsonType,
-                };
-              }
-              if (entity.relationshipAttributes.category) {
-                schema.properties[
-                  entity.relationshipAttributes.category.qualifiedName
-                ]['properties'] = {
-                  ...schema.properties[
-                    entity.relationshipAttributes.category.qualifiedName
-                  ]['properties'],
-                  ...properties,
-                };
-              } else {
-                schema.properties = { ...schema.properties, ...properties };
-              }
-            }
-          }
-        }
-      }
+      //   if (entity.typeName.includes('archetype_')) {
+      //     if (entity.typeName != 'archetype_object') {
+      //       const objectName = entity.attributes.qualifiedName;
+      //       if (entity.relationshipAttributes.subcategories?.length) {
+      //         const type = 'object';
+      //         const properties: Record<string, object> = {};
+      //         schema.properties[objectName] = { type, properties };
+      //       }
+      //       if (entity.relationshipAttributes.columns?.length) {
+      //         const properties: Record<string, object> = {};
+      //         for (const column of entity.relationshipAttributes.columns) {
+      //           const { entity } = await this.atlas.get(
+      //             `/entity/guid/${column.guid}`,
+      //             undefined,
+      //             token,
+      //           );
+      //           const jsonType = this.atlasTypeToJSONType(
+      //             entity.attributes.data_type,
+      //           );
+      //           properties[objectName] = {
+      //             type: jsonType,
+      //           };
+      //         }
+      //         if (entity.relationshipAttributes.category) {
+      //           schema.properties[
+      //             entity.relationshipAttributes.category.qualifiedName
+      //           ]['properties'] = {
+      //             ...schema.properties[
+      //               entity.relationshipAttributes.category.qualifiedName
+      //             ]['properties'],
+      //             ...properties,
+      //           };
+      //         } else {
+      //           schema.properties = { ...schema.properties, ...properties };
+      //         }
+      //       }
+      //     }
+      //   }
+      // }
 
       output.push(schema);
     }

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -2,9 +2,16 @@ import { Injectable, Logger } from '@nestjs/common';
 import { AtlasService } from 'src/atlas/atlas.service';
 // import { DatabaseService } from 'src/database/database.service';
 import { QueueService } from 'src/queue/queue.service';
-import { ArchetypeDto, ArchetypeStatus } from './dto';
 import {
-  AtlasEntityResponseDto,
+  ArchetypeDto,
+  ArchetypeEdgeDto,
+  ArchetypeNodeDto,
+  ArchetypeNodeType,
+  ArchetypePermission,
+  ArchetypeStatus,
+} from './dto';
+import {
+  AtlasArchetypeEntityResponseDto,
   AtlasSearchBasicResponseDto,
 } from 'src/atlas/dto';
 
@@ -17,82 +24,6 @@ export class ArchetypeService {
     // @Inject(forwardRef(() => DatabaseService))
     // private databaseSource: DatabaseService,
   ) {}
-
-  // TODO: use code and remove this method
-  async getArchetypes(projectId: string, token?: string) {
-    const activeTemplates = await this.fetchArchetypes(projectId, token);
-
-    const output = [];
-    for (const template of activeTemplates) {
-      const templateGuid = template.id;
-      const templateName = template.name;
-
-      const templateInfo = {
-        id: templateGuid,
-        name: templateName,
-        nodes: [],
-        edges: [],
-      };
-
-      // const templateEntity = await this.atlas.get(
-      //   `/entity/guid/${templateGuid}`,
-      //   undefined,
-      //   token,
-      // );
-
-      // for (const key in templateEntity.referredEntities) {
-      //   const entity = templateEntity.referredEntities[key];
-
-      //   if (entity.typeName.includes('archetype_')) {
-      //     const splitted = entity.attributes.qualifiedName.split('@');
-      //     const node = {
-      //       id: splitted[2],
-      //       position: {
-      //         x: Number(entity.attributes.position.x),
-      //         y: Number(entity.attributes.position.y),
-      //       },
-      //       data: {
-      //         label: entity.attributes.displayName,
-      //       },
-      //       type: entity.typeName.replace('archetype_', ''),
-      //       width: entity.attributes.width,
-      //       height: entity.attributes.height,
-      //       selected: false,
-      //       positionAbsolute: {
-      //         x: Number(entity.attributes.position.x),
-      //         y: Number(entity.attributes.position.y),
-      //       },
-      //       dragging: false,
-      //     };
-      //     templateInfo.nodes.push(node);
-
-      //     if (entity.typeName != 'archetype_object') {
-      //       const edge = {
-      //         source: splitted[2],
-      //         target: '',
-      //         sourceHandle: null,
-      //         targetHandle: null,
-      //         id: '',
-      //       };
-
-      //       const name =
-      //         entity.typeName == 'archetype_category'
-      //           ? entity.relationshipAttributes.object.qualifiedName
-      //           : entity.relationshipAttributes.category.qualifiedName;
-
-      //       edge.target = name.split('@')[2];
-      //       edge.id = `edge_${edge.source}_${edge.target}`;
-
-      //       templateInfo.edges.push(edge);
-      //     }
-      //   }
-      // }
-
-      output.push(templateInfo);
-    }
-
-    return output;
-  }
 
   async fetchArchetypes(projectId: string, token?: string) {
     // NOTE: can also remove headers to reduce payload
@@ -134,84 +65,105 @@ export class ArchetypeService {
     return await this.queue.addArchetypeJob(username, archetype);
   }
 
-  // MAKE: entity call to Atlas
   async getArchetypeDetails(
     projectId: string,
     archetypeId: string,
     token?: string,
   ) {
-    const entityRes = await this.atlas.get<AtlasEntityResponseDto>(
+    // TODO: handle errors
+    const entityRes = await this.atlas.get<AtlasArchetypeEntityResponseDto>(
       `/entity/guid/${archetypeId}`,
       undefined,
       token,
     );
 
-    // TODO: handle errors
-
     const templateInfo: ArchetypeDto = {
       projectId: projectId,
       archetypeId: archetypeId,
-      name: entityRes.entity?.displayText,
+      name: entityRes.entity?.attributes?.name,
       status: entityRes.entity?.attributes?.status as ArchetypeStatus,
       nodes: [],
       edges: [],
+      permissions: [],
+      lastModified: new Date(entityRes.entity?.updateTime),
     };
 
-    // for (const key in entityRes.referredEntities) {
-    //   const entity = entityRes.referredEntities[key];
+    // add all archetype_nodes
+    for (const key in entityRes.referredEntities) {
+      const entity = entityRes.referredEntities[key];
+      const nodeId = entity.attributes?.qualifiedName.split('@')[2];
+      // add node itself
+      const node: ArchetypeNodeDto = {
+        id: nodeId, // NOTE: Maybe use GUID
+        data: {
+          label: entity.attributes?.label,
+          level: entity.attributes?.level,
+        },
+        position: entity.attributes?.position,
+        type: (entity.attributes?.level === 0
+          ? 'root'
+          : 'category') as ArchetypeNodeType,
+      };
+      templateInfo.nodes.push(node);
 
-    //   if (entity.typeName.includes('archetype_')) {
-    //     const splitted = entity.attributes.qualifiedName.split('@');
-    //     const node = {
-    //       id: splitted[2],
-    //       position: {
-    //         x: Number(entity.attributes.position.x),
-    //         y: Number(entity.attributes.position.y),
-    //       },
-    //       data: {
-    //         label: entity.attributes.displayName,
-    //       },
-    //       type: entity.typeName.replace('archetype_', ''),
-    //       width: entity.attributes.width,
-    //       height: entity.attributes.height,
-    //       selected: false,
-    //       positionAbsolute: {
-    //         x: Number(entity.attributes.position.x),
-    //         y: Number(entity.attributes.position.y),
-    //       },
-    //       dragging: false,
-    //     };
-    //     templateInfo.nodes.push(node);
+      // add edge if has parent exists
+      if (entity.relationshipAttributes?.parent_node) {
+        const parentNodeId =
+          entity.relationshipAttributes?.parent_node?.qualifiedName.split(
+            '@',
+          )[2]; // NOTE: Maybe use GUID
+        const edge: ArchetypeEdgeDto = {
+          id: `edge_${parentNodeId}_${nodeId}`, // NOTE: maybe use relationship GUID here
+          source: parentNodeId,
+          target: nodeId,
+        };
+        templateInfo.edges.push(edge);
+      }
+      // add column node and edges
+      if (entity.relationshipAttributes?.column) {
+        const columnNodeId = entity.relationshipAttributes?.column?.guid;
+        const columName =
+          entity.relationshipAttributes?.column?.qualifiedName.split('@')[2];
+        const node: ArchetypeNodeDto = {
+          id: columnNodeId,
+          data: {
+            label: columName,
+            level: entity.attributes?.level + 1,
+          },
+          position: entity.attributes?.position, // TODO: figure out where to put column, relative to node
+          type: ArchetypeNodeType.Column,
+        };
+        templateInfo.nodes.push(node);
+        const edge: ArchetypeEdgeDto = {
+          source: nodeId,
+          target: columnNodeId,
+          id: `edge_${nodeId}_${columnNodeId}`, // NOTE: maybe use relationship GUID here
+        };
+        templateInfo.edges.push(edge);
+      }
 
-    //     if (entity.typeName != 'archetype_object') {
-    //       const edge = {
-    //         source: splitted[2],
-    //         target: '',
-    //         sourceHandle: null,
-    //         targetHandle: null,
-    //         id: '',
-    //       };
-
-    //       const name =
-    //         entity.typeName == 'archetype_category'
-    //           ? entity.relationshipAttributes.object.qualifiedName
-    //           : entity.relationshipAttributes.category.qualifiedName;
-
-    //       edge.target = name.split('@')[2];
-    //       edge.id = `edge_${edge.source}_${edge.target}`;
-
-    //       templateInfo.edges.push(edge);
-    //     }
-    //   }
-    // }
+      const analysisPermission = (() => {
+        const permission = entity.classifications?.find(
+          (c) => c.typeName === 'archetype_node_analysis_permissions',
+        );
+        return {
+          id: nodeId,
+          permission: (permission?.attributes?.access_level ??
+            'NONE') as ArchetypePermission,
+        };
+      })();
+      templateInfo.permissions.push(analysisPermission);
+    }
 
     return templateInfo;
   }
 
+  // TODO: still need to refactor
   async deleteArchetype(projectId: string, archetypeId: string) {
     return await this.queue.deleteTemplateJob(projectId, archetypeId);
   }
 
+  // TODO: still need to refactor
   async getAnalysisArchetype(projectId: string, token?: string) {
     const activeTemplates = await this.fetchArchetypes(projectId, token);
 

--- a/src/archetype/dto/archetype.dto.ts
+++ b/src/archetype/dto/archetype.dto.ts
@@ -26,9 +26,9 @@ export enum ArchetypeNodeType {
 }
 
 export enum ArchetypePermission {
-  None = 'NONE',
-  HighLevel = 'HIGH_LEVEL',
-  Detailed = 'DETAILED',
+  NONE = 'NONE',
+  HIGH_LEVEL = 'HIGH_LEVEL',
+  DETAILED = 'DETAILED',
 }
 
 export class ArchetypeNodePermissionDto {
@@ -139,10 +139,24 @@ export class ArchetypeDto {
   permissions?: ArchetypeNodePermissionDto[];
 
   @IsOptional()
-  @Transform(
-    ({ value }) => (typeof value === 'string' ? new Date(value) : value),
-    { toClassOnly: true },
-  )
   @IsDate()
+  @Transform(({ value }) => transformToDateString(value), { toClassOnly: true })
   lastModified?: Date;
+}
+
+function transformToDateString(value: any): Date {
+  if (value == null || value === '') return undefined;
+
+  if (typeof value === 'string') {
+    const timestamp = Number(value);
+    // handle numeric string =
+    if (!isNaN(timestamp)) return new Date(timestamp);
+    return new Date(value);
+  }
+  // handle epoch as number
+  if (typeof value === 'number') {
+    return new Date(value);
+  }
+  // already a Date or invalid input
+  return value;
 }

--- a/src/archetype/dto/archetype.dto.ts
+++ b/src/archetype/dto/archetype.dto.ts
@@ -1,3 +1,4 @@
+// TODO: cleanup DTOs
 import { Transform, Type } from 'class-transformer';
 import {
   IsArray,
@@ -15,8 +16,8 @@ import {
 } from 'class-validator';
 
 export enum ArchetypeStatus {
-  Draft = 'DRAFT',
-  Published = 'PUBLISHED',
+  DRAFT = 'DRAFT',
+  PUBLISHED = 'PUBLISHED',
 }
 
 export enum ArchetypeNodeType {
@@ -130,7 +131,7 @@ export class ArchetypeDto {
 
   @IsOptional()
   @IsEnum(ArchetypeStatus)
-  status: ArchetypeStatus = ArchetypeStatus.Draft;
+  status: ArchetypeStatus = ArchetypeStatus.DRAFT;
 
   @IsOptional()
   @IsArray()

--- a/src/archetype/dto/archetype.dto.ts
+++ b/src/archetype/dto/archetype.dto.ts
@@ -26,47 +26,62 @@ export enum ArchetypeNodeType {
 }
 
 export class ArchetypeNodeDataDto {
+  @IsDefined()
   @IsString()
   @IsNotEmpty()
   label!: string;
 
+  @IsDefined()
   @IsInt()
   @Min(0)
   level!: number;
 }
 
 export class ArchetypeNodePositionDto {
+  @IsDefined()
   @IsNumber({ allowNaN: false, allowInfinity: false })
   x!: number;
 
+  @IsDefined()
   @IsNumber({ allowNaN: false, allowInfinity: false })
   y!: number;
 }
 
 export class ArchetypeNodeDto {
+  @IsDefined()
   @IsString()
+  @IsNotEmpty()
   id!: string;
 
+  @IsDefined()
   @IsEnum(ArchetypeNodeType)
-  type: ArchetypeNodeType;
+  type!: ArchetypeNodeType;
 
+  @IsDefined()
   @ValidateNested()
   @Type(() => ArchetypeNodeDataDto)
   data!: ArchetypeNodeDataDto;
 
+  @IsDefined()
   @ValidateNested()
   @Type(() => ArchetypeNodePositionDto)
   position!: ArchetypeNodePositionDto;
 }
 
 export class ArchetypeEdgeDto {
+  @IsDefined()
   @IsString()
+  @IsNotEmpty()
   id!: string;
 
+  @IsDefined()
   @IsString()
+  @IsNotEmpty()
   source!: string;
 
+  @IsDefined()
   @IsString()
+  @IsNotEmpty()
   target!: string;
 }
 

--- a/src/archetype/dto/archetype.dto.ts
+++ b/src/archetype/dto/archetype.dto.ts
@@ -25,6 +25,23 @@ export enum ArchetypeNodeType {
   Column = 'column',
 }
 
+export enum ArchetypePermission {
+  None = 'NONE',
+  HighLevel = 'HIGH_LEVEL',
+  Detailed = 'DETAILED',
+}
+
+export class ArchetypeNodePermissionDto {
+  @IsDefined()
+  @IsString()
+  @IsNotEmpty()
+  id!: string;
+
+  @IsDefined()
+  @IsEnum(ArchetypePermission)
+  permission!: ArchetypePermission;
+}
+
 export class ArchetypeNodeDataDto {
   @IsDefined()
   @IsString()
@@ -99,21 +116,27 @@ export class ArchetypeDto {
   @IsNotEmpty()
   name!: string;
 
-  @IsDefined()
+  @IsOptional()
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => ArchetypeNodeDto)
-  nodes!: ArchetypeNodeDto[];
+  nodes?: ArchetypeNodeDto[];
 
-  @IsDefined()
+  @IsOptional()
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => ArchetypeEdgeDto)
-  edges!: ArchetypeEdgeDto[];
+  edges?: ArchetypeEdgeDto[];
 
   @IsOptional()
   @IsEnum(ArchetypeStatus)
   status: ArchetypeStatus = ArchetypeStatus.Draft;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ArchetypeNodePermissionDto)
+  permissions?: ArchetypeNodePermissionDto[];
 
   @IsOptional()
   @Transform(

--- a/src/archetype/dto/archetype.dto.ts
+++ b/src/archetype/dto/archetype.dto.ts
@@ -1,34 +1,101 @@
+import { Transform, Type } from 'class-transformer';
 import {
+  IsArray,
+  IsDate,
   IsDefined,
-  IsJSON,
+  IsEnum,
+  IsInt,
   IsNotEmpty,
+  IsNumber,
   IsOptional,
   IsString,
   IsUUID,
+  Min,
+  ValidateNested,
 } from 'class-validator';
+
+export enum ArchetypeStatus {
+  Draft = 'DRAFT',
+  Published = 'PUBLISHED',
+}
+
+export class ArchetypeNodeDataDto {
+  @IsString()
+  @IsNotEmpty()
+  label!: string;
+
+  @IsInt()
+  @Min(0)
+  level!: number;
+}
+
+export class ArchetypeNodePositionDto {
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  x!: number;
+
+  @IsNumber({ allowNaN: false, allowInfinity: false })
+  y!: number;
+}
+
+export class ArchetypeNodeDto {
+  @IsString()
+  id!: string;
+
+  @ValidateNested()
+  @Type(() => ArchetypeNodeDataDto)
+  data!: ArchetypeNodeDataDto;
+
+  @ValidateNested()
+  @Type(() => ArchetypeNodePositionDto)
+  position!: ArchetypeNodePositionDto;
+}
+
+export class ArchetypeEdgeDto {
+  @IsString()
+  id!: string;
+
+  @IsString()
+  source!: string;
+
+  @IsString()
+  target!: string;
+}
 
 export class ArchetypeDto {
   @IsDefined()
   @IsUUID()
-  @IsNotEmpty()
-  projectId: string;
+  projectId!: string;
 
   @IsOptional()
+  @IsUUID()
+  archetypeId?: string;
+
+  @IsDefined()
   @IsString()
   @IsNotEmpty()
-  name: string;
+  name!: string;
+
+  @IsDefined()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ArchetypeNodeDto)
+  nodes!: ArchetypeNodeDto[];
+
+  @IsDefined()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ArchetypeEdgeDto)
+  edges!: ArchetypeEdgeDto[];
 
   @IsOptional()
-  @IsString()
-  @IsJSON()
-  archetype: string;
+  @IsEnum(ArchetypeStatus)
+  status: ArchetypeStatus = ArchetypeStatus.Draft;
 
   @IsOptional()
-  @IsString()
-  @IsJSON()
-  columnMapping: string;
-
-  @IsOptional()
-  @IsString()
-  archetypeId: string;
+  @Transform(
+    ({ value }) => (typeof value === 'string' ? new Date(value) : value),
+    { toClassOnly: true },
+  )
+  @IsDate()
+  lastModified?: Date;
 }

--- a/src/archetype/dto/archetype.dto.ts
+++ b/src/archetype/dto/archetype.dto.ts
@@ -19,6 +19,12 @@ export enum ArchetypeStatus {
   Published = 'PUBLISHED',
 }
 
+export enum ArchetypeNodeType {
+  Root = 'root',
+  Category = 'category',
+  Column = 'column',
+}
+
 export class ArchetypeNodeDataDto {
   @IsString()
   @IsNotEmpty()
@@ -40,6 +46,9 @@ export class ArchetypeNodePositionDto {
 export class ArchetypeNodeDto {
   @IsString()
   id!: string;
+
+  @IsEnum(ArchetypeNodeType)
+  type: ArchetypeNodeType;
 
   @ValidateNested()
   @Type(() => ArchetypeNodeDataDto)

--- a/src/atlas/atlas.service.ts
+++ b/src/atlas/atlas.service.ts
@@ -112,9 +112,4 @@ export class AtlasService {
       throw error;
     }
   }
-
-  getCurrentDate() {
-    // YYYY-MM-DD
-    return new Date().toISOString().slice(0, 10);
-  }
 }

--- a/src/atlas/atlas.service.ts
+++ b/src/atlas/atlas.service.ts
@@ -25,7 +25,7 @@ export class AtlasService {
     return `Bearer ${tokenString}`;
   }
 
-  async get(endpoint: string, params?: any, token?: string): Promise<any> {
+  async get<T>(endpoint: string, params?: any, token?: string): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`;
     const authHeader =
       token && !this.basicAuth
@@ -44,12 +44,12 @@ export class AtlasService {
     }
   }
 
-  async post(
+  async post<T>(
     endpoint: string,
     body: any,
     params?: any,
     token?: string,
-  ): Promise<any> {
+  ): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`;
     const authHeader =
       token && !this.basicAuth
@@ -68,12 +68,12 @@ export class AtlasService {
     }
   }
 
-  async put(
+  async put<T>(
     endpoint: string,
     body: any,
     params?: any,
     token?: string,
-  ): Promise<any> {
+  ): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`;
     const authHeader =
       token && !this.basicAuth
@@ -94,7 +94,7 @@ export class AtlasService {
     }
   }
 
-  async delete(endpoint: string, params?: any, token?: string): Promise<any> {
+  async delete<T>(endpoint: string, params?: any, token?: string): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`;
     const authHeader =
       token && !this.basicAuth

--- a/src/atlas/atlas.service.ts
+++ b/src/atlas/atlas.service.ts
@@ -47,8 +47,8 @@ export class AtlasService {
   async post<T>(
     endpoint: string,
     body: any,
-    params?: any,
     token?: string,
+    params?: any,
   ): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`;
     const authHeader =

--- a/src/atlas/dto/atlas.dto.ts
+++ b/src/atlas/dto/atlas.dto.ts
@@ -10,11 +10,135 @@ import {
   ValidateNested,
   IsInt,
   IsUUID,
+  IsNotEmpty,
+  IsDefined,
 } from 'class-validator';
+import {
+  ArchetypeNodePositionDto,
+  ArchetypePermission,
+} from 'src/archetype/dto';
 
 export enum AtlasQueryType {
   BASIC = 'BASIC',
   DSL = 'DSL',
+}
+
+export enum AtlasArchetypeNodeTypeName {
+  Root = 'root_node',
+  Branch = 'branch_node',
+  Leaf = 'leaf_node',
+}
+export enum AtlasArchetypeTypeName {
+  Template = 'archetype_template',
+  Node = 'archetype_node',
+}
+
+export class AtlasArchetypeNodeAttributesDto {
+  @IsString()
+  owner: string;
+
+  @IsString()
+  replicatedTo: string | null;
+
+  @IsString()
+  userDescription: string | null;
+
+  @IsString()
+  replicatedFrom: string | null;
+
+  @IsString()
+  qualifiedName: string;
+
+  @IsString()
+  displayName: string | null;
+
+  @IsString()
+  name: string;
+
+  @IsString()
+  description: string | null;
+
+  @IsOptional()
+  @IsString()
+  projectId?: string;
+
+  @IsOptional()
+  @IsNumber()
+  level?: number;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ArchetypeNodePositionDto)
+  position?: ArchetypeNodePositionDto;
+
+  @IsOptional()
+  @IsString()
+  label?: string;
+
+  @IsOptional()
+  @IsString()
+  status?: string;
+}
+
+export class AtlasSimpleClassificationDto {
+  @IsDefined()
+  @IsString()
+  @IsNotEmpty()
+  typeName!: string;
+
+  @IsOptional()
+  @IsBoolean()
+  propagate?: boolean = true;
+
+  @IsBoolean()
+  @IsOptional()
+  removePropagationsOnEntityDelete?: boolean = false;
+}
+
+export class AtlasArchetypeAnalysisPermissionClassificationDto extends AtlasSimpleClassificationDto {
+  @IsString()
+  override typeName: 'archetype_node_analysis_permissions';
+
+  @IsDefined()
+  @IsObject()
+  attributes!: {
+    access_level: ArchetypePermission;
+  };
+}
+
+export class AtlasClassificationDto {
+  @IsDefined()
+  @IsString()
+  @IsNotEmpty()
+  typeName!: string;
+
+  @IsOptional()
+  @IsBoolean()
+  propagate?: boolean = true;
+
+  @IsBoolean()
+  @IsOptional()
+  removePropagationsOnEntityDelete?: boolean = false;
+  @IsOptional()
+  @IsObject()
+  attributes?: Record<string, unknown>;
+}
+
+export class AtlasMutatedEntitiesDto {
+  @IsOptional()
+  @ValidateNested({ each: true })
+  @Type(() => AtlasEntityDto)
+  CREATE?: AtlasEntityDto[];
+
+  @IsOptional()
+  @ValidateNested({ each: true })
+  @Type(() => AtlasEntityDto)
+  UPDATE?: AtlasEntityDto[];
+
+  @IsOptional()
+  @ValidateNested({ each: true })
+  @Type(() => AtlasEntityDto)
+  DELETE?: AtlasEntityDto[];
 }
 
 export class AtlasEntityHeaderDto {
@@ -39,7 +163,7 @@ export class AtlasRelationshipMetaDto {
 }
 
 export class AtlasRelatedEntityRefDto {
-  @IsUUID()
+  @IsString()
   guid!: string;
 
   @IsString()
@@ -77,14 +201,34 @@ export class AtlasRelationshipAttributesDto {
   @IsOptional()
   @ValidateNested()
   @Type(() => AtlasRelatedEntityRefDto)
+  template?: AtlasRelatedEntityRefDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => AtlasRelatedEntityRefDto)
   instance?: AtlasRelatedEntityRefDto;
 
-  // Glossary meanings; sample shows an empty array. Keep generic unless you know the structure.
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => AtlasRelatedEntityRefDto)
+  parent_node?: AtlasRelatedEntityRefDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => AtlasRelatedEntityRefDto)
+  column?: AtlasRelatedEntityRefDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => AtlasRelatedEntityRefDto)
+  child_nodes?: AtlasRelatedEntityRefDto[];
+
+  // Glossary meanings
   @IsArray()
   meanings!: unknown[];
 }
 
-export class AtlasEntityDto {
+export class AtlasEntityDto<Attributes = Record<string, unknown>> {
   @IsUUID()
   guid!: string;
 
@@ -122,12 +266,63 @@ export class AtlasEntityDto {
 
   @IsOptional()
   @IsObject()
-  attributes?: Record<string, unknown>;
+  attributes?: Attributes;
 
   @IsOptional()
   @ValidateNested()
   @Type(() => AtlasRelationshipAttributesDto)
   relationshipAttributes?: AtlasRelationshipAttributesDto;
+}
+
+export class AtlasSubmitArchetypeEntityDto {
+  @IsOptional()
+  @IsString()
+  guid?: string;
+
+  @IsString()
+  typeName!: string;
+
+  @IsOptional()
+  @IsString()
+  status?: string = 'ACTIVE';
+
+  @IsOptional()
+  @IsObject()
+  attributes?: Record<string, unknown>;
+
+  @IsOptional()
+  @IsObject()
+  relationshipAttributes?: Record<string, unknown>;
+}
+
+export class AtlasArchetypeEntityClassificationDto {
+  @IsDefined()
+  @IsString()
+  @IsNotEmpty()
+  typeName!: string;
+
+  @IsString()
+  entityGuid?: string;
+
+  @IsOptional()
+  @IsObject()
+  attributes?: Record<string, unknown>;
+}
+
+export class AtlasArchetypeEntityDto extends AtlasEntityDto<AtlasArchetypeNodeAttributesDto> {
+  @IsEnum(AtlasArchetypeTypeName)
+  override typeName!: AtlasArchetypeTypeName;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => AtlasArchetypeNodeAttributesDto)
+  override attributes?: AtlasArchetypeNodeAttributesDto;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => AtlasArchetypeEntityClassificationDto)
+  classifications?: AtlasArchetypeEntityClassificationDto[];
 }
 
 export class AtlasSearchBasicResponseDto {
@@ -189,4 +384,23 @@ export class AtlasEntityResponseDto {
   @ValidateNested()
   @Type(() => AtlasEntityDto)
   entity!: AtlasEntityDto;
+}
+
+export class AtlasArchetypeEntityResponseDto {
+  @IsObject()
+  referredEntities!: Record<string, AtlasArchetypeEntityDto>;
+
+  @ValidateNested()
+  @Type(() => AtlasArchetypeEntityDto)
+  entity!: AtlasArchetypeEntityDto;
+}
+
+export class AtlasPostEntityResponseDto {
+  @ValidateNested()
+  @Type(() => AtlasMutatedEntitiesDto)
+  mutatedEntities: AtlasMutatedEntitiesDto;
+
+  @IsOptional()
+  @IsObject()
+  guidAssignments?: Record<string, string>;
 }

--- a/src/atlas/dto/atlas.dto.ts
+++ b/src/atlas/dto/atlas.dto.ts
@@ -1,3 +1,4 @@
+// TODO: cleanup DTOs
 import { Type } from 'class-transformer';
 import {
   IsArray,
@@ -184,15 +185,15 @@ export class AtlasRelatedEntityRefDto {
   @IsString()
   relationshipStatus!: string;
 
-  @ValidateNested()
-  @Type(() => AtlasRelationshipMetaDto)
-  relationshipAttributes!: AtlasRelationshipMetaDto;
+  @IsOptional()
+  @IsObject()
+  relationshipAttributes!: Record<string, unknown>;
 
   @IsString()
   qualifiedName!: string;
 }
 
-export class AtlasRelationshipAttributesDto {
+export class AtlasArchetypeRelationshipMetaDto {
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => AtlasRelatedEntityRefDto)
@@ -228,7 +229,10 @@ export class AtlasRelationshipAttributesDto {
   meanings!: unknown[];
 }
 
-export class AtlasEntityDto<Attributes = Record<string, unknown>> {
+export class AtlasEntityDto<
+  Attributes = Record<string, unknown>,
+  RelationshipAttributes = Record<string, unknown>,
+> {
   @IsUUID()
   guid!: string;
 
@@ -269,9 +273,8 @@ export class AtlasEntityDto<Attributes = Record<string, unknown>> {
   attributes?: Attributes;
 
   @IsOptional()
-  @ValidateNested()
-  @Type(() => AtlasRelationshipAttributesDto)
-  relationshipAttributes?: AtlasRelationshipAttributesDto;
+  @IsObject()
+  relationshipAttributes?: RelationshipAttributes;
 }
 
 export class AtlasSubmitArchetypeEntityDto {
@@ -309,7 +312,10 @@ export class AtlasArchetypeEntityClassificationDto {
   attributes?: Record<string, unknown>;
 }
 
-export class AtlasArchetypeEntityDto extends AtlasEntityDto<AtlasArchetypeNodeAttributesDto> {
+export class AtlasArchetypeEntityDto extends AtlasEntityDto<
+  AtlasArchetypeNodeAttributesDto,
+  AtlasArchetypeRelationshipMetaDto
+> {
   @IsEnum(AtlasArchetypeTypeName)
   override typeName!: AtlasArchetypeTypeName;
 
@@ -317,6 +323,11 @@ export class AtlasArchetypeEntityDto extends AtlasEntityDto<AtlasArchetypeNodeAt
   @ValidateNested()
   @Type(() => AtlasArchetypeNodeAttributesDto)
   override attributes?: AtlasArchetypeNodeAttributesDto;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => AtlasArchetypeRelationshipMetaDto)
+  override relationshipAttributes?: AtlasArchetypeRelationshipMetaDto;
 
   @IsOptional()
   @IsArray()
@@ -359,7 +370,7 @@ export class AtlasSearchDslResponseDto {
   approximateCount!: number;
 }
 
-export class AtlasSearchDslAttributesBlockDto {
+export class AtlasSearchAttributesBlockDto {
   @IsArray()
   @IsString({ each: true })
   name!: string[];
@@ -368,10 +379,25 @@ export class AtlasSearchDslAttributesBlockDto {
   values!: string[][];
 }
 
+export class AtlasSearchBasicHeadlessResponseDto {
+  @IsEnum(AtlasQueryType)
+  queryType!: AtlasQueryType.BASIC;
+
+  @IsObject()
+  searchParameters!: Record<string, unknown>;
+
+  @ValidateNested()
+  @Type(() => AtlasSearchAttributesBlockDto)
+  attributes!: AtlasSearchAttributesBlockDto;
+
+  @IsNumber()
+  approximateCount!: number;
+}
+
 export class AtlasSearchDslAttributesResponseDto {
   @ValidateNested()
-  @Type(() => AtlasSearchDslAttributesBlockDto)
-  attributes!: AtlasSearchDslAttributesBlockDto;
+  @Type(() => AtlasSearchAttributesBlockDto)
+  attributes!: AtlasSearchAttributesBlockDto;
 
   @IsNumber()
   approximateCount!: number;

--- a/src/atlas/dto/atlas.dto.ts
+++ b/src/atlas/dto/atlas.dto.ts
@@ -9,6 +9,7 @@ import {
   IsNumber,
   ValidateNested,
   IsInt,
+  IsUUID,
 } from 'class-validator';
 
 export enum AtlasQueryType {
@@ -32,8 +33,59 @@ export class AtlasEntityHeaderDto {
   attributes?: Record<string, unknown>;
 }
 
-export class AtlasEntityDto {
+export class AtlasRelationshipMetaDto {
   @IsString()
+  typeName!: string;
+}
+
+export class AtlasRelatedEntityRefDto {
+  @IsUUID()
+  guid!: string;
+
+  @IsString()
+  typeName!: string;
+
+  @IsString()
+  entityStatus!: string;
+
+  @IsString()
+  displayText!: string;
+
+  @IsString()
+  relationshipType!: string;
+
+  @IsUUID()
+  relationshipGuid!: string;
+
+  @IsString()
+  relationshipStatus!: string;
+
+  @ValidateNested()
+  @Type(() => AtlasRelationshipMetaDto)
+  relationshipAttributes!: AtlasRelationshipMetaDto;
+
+  @IsString()
+  qualifiedName!: string;
+}
+
+export class AtlasRelationshipAttributesDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => AtlasRelatedEntityRefDto)
+  nodes!: AtlasRelatedEntityRefDto[];
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => AtlasRelatedEntityRefDto)
+  instance?: AtlasRelatedEntityRefDto;
+
+  // Glossary meanings; sample shows an empty array. Keep generic unless you know the structure.
+  @IsArray()
+  meanings!: unknown[];
+}
+
+export class AtlasEntityDto {
+  @IsUUID()
   guid!: string;
 
   @IsBoolean()
@@ -73,11 +125,12 @@ export class AtlasEntityDto {
   attributes?: Record<string, unknown>;
 
   @IsOptional()
-  @IsObject()
-  relationshipAttributes?: Record<string, unknown>;
+  @ValidateNested()
+  @Type(() => AtlasRelationshipAttributesDto)
+  relationshipAttributes?: AtlasRelationshipAttributesDto;
 }
 
-export class AtlasSearchAttributeResponseDto {
+export class AtlasSearchBasicResponseDto {
   @IsEnum(AtlasQueryType)
   queryType!: AtlasQueryType.BASIC;
 

--- a/src/atlas/dto/atlas.dto.ts
+++ b/src/atlas/dto/atlas.dto.ts
@@ -1,0 +1,139 @@
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsObject,
+  IsOptional,
+  IsString,
+  IsNumber,
+  ValidateNested,
+  IsInt,
+} from 'class-validator';
+
+export enum AtlasQueryType {
+  BASIC = 'BASIC',
+  DSL = 'DSL',
+}
+
+export class AtlasEntityHeaderDto {
+  @IsString()
+  guid!: string;
+
+  @IsString()
+  typeName!: string;
+
+  @IsOptional()
+  @IsString()
+  displayText?: string;
+
+  @IsOptional()
+  @IsObject()
+  attributes?: Record<string, unknown>;
+}
+
+export class AtlasEntityDto {
+  @IsString()
+  guid!: string;
+
+  @IsBoolean()
+  isIncomplete!: boolean;
+
+  @IsString()
+  typeName!: string;
+
+  @IsOptional()
+  @IsString()
+  displayText?: string;
+
+  @IsString()
+  status!: string; // Atlas built in entity status
+
+  @IsString()
+  createdBy!: string;
+
+  @IsString()
+  updatedBy!: string;
+
+  @IsInt()
+  createTime!: number; // epoch millis
+
+  @IsInt()
+  updateTime!: number; // epoch millis
+
+  @IsInt()
+  version!: number;
+
+  @IsArray()
+  @IsString({ each: true })
+  labels!: string[];
+
+  @IsOptional()
+  @IsObject()
+  attributes?: Record<string, unknown>;
+
+  @IsOptional()
+  @IsObject()
+  relationshipAttributes?: Record<string, unknown>;
+}
+
+export class AtlasSearchAttributeResponseDto {
+  @IsEnum(AtlasQueryType)
+  queryType!: AtlasQueryType.BASIC;
+
+  @IsObject()
+  searchParameters!: Record<string, unknown>;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => AtlasEntityHeaderDto)
+  entities?: AtlasEntityHeaderDto[];
+
+  @IsNumber()
+  approximateCount!: number;
+}
+
+export class AtlasSearchDslResponseDto {
+  @IsEnum(AtlasQueryType)
+  queryType!: AtlasQueryType.DSL;
+
+  @IsString()
+  queryText!: string;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => AtlasEntityHeaderDto)
+  entities?: AtlasEntityHeaderDto[];
+
+  @IsNumber()
+  approximateCount!: number;
+}
+
+export class AtlasSearchDslAttributesBlockDto {
+  @IsArray()
+  @IsString({ each: true })
+  name!: string[];
+
+  @IsArray()
+  values!: string[][];
+}
+
+export class AtlasSearchDslAttributesResponseDto {
+  @ValidateNested()
+  @Type(() => AtlasSearchDslAttributesBlockDto)
+  attributes!: AtlasSearchDslAttributesBlockDto;
+
+  @IsNumber()
+  approximateCount!: number;
+}
+
+export class AtlasEntityResponseDto {
+  @IsObject()
+  referredEntities!: Record<string, AtlasEntityDto>;
+
+  @ValidateNested()
+  @Type(() => AtlasEntityDto)
+  entity!: AtlasEntityDto;
+}

--- a/src/atlas/dto/index.ts
+++ b/src/atlas/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './atlas.dto';

--- a/src/common/guards/resource.guard.ts
+++ b/src/common/guards/resource.guard.ts
@@ -13,13 +13,13 @@ import {
   ConditionalScopeFn,
   META_CONDITIONAL_SCOPES,
 } from '../decorators/scopes.decorator';
-import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants';
-type RouteParamMetadata = {
-  index: number;
-  data: any;
-  pipes: any[];
-  type: string;
-};
+// import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants';
+// type RouteParamMetadata = {
+//   index: number;
+//   data: any;
+//   pipes: any[];
+//   type: string;
+// };
 
 @Injectable()
 export class ResourceGuard implements CanActivate {
@@ -61,18 +61,9 @@ export class ResourceGuard implements CanActivate {
       this.reflector.get<string>(META_RESOURCE, context.getHandler()) ||
       this.reflector.get<string>(META_RESOURCE, context.getClass());
 
-    // get parameterName
-    const parameterName = (
-      Object.values(
-        this.reflector.get<RouteParamMetadata>(
-          ROUTE_ARGS_METADATA,
-          context.getHandler(),
-        ) || {},
-      ).find((p: RouteParamMetadata) => p.type === 'param') || {}
-    ).data;
-
-    const resource = request.params[parameterName]
-      ? `${metaResource} ${request.params[parameterName]}`
+    // get parameter if exists
+    const resource = Object.values(request.params)
+      ? `${metaResource}:${Object.values(request.params)[0]}`
       : metaResource;
 
     // get explicit scopes
@@ -104,6 +95,7 @@ export class ResourceGuard implements CanActivate {
       permissions: [permission],
       response_mode: 'decision', // can be 'permissions'
     };
+    this.logger.debug(authzRequest);
 
     const res = await this.keycloakConnect.checkPermission(
       authzRequest,

--- a/src/common/guards/resource.guard.ts
+++ b/src/common/guards/resource.guard.ts
@@ -95,7 +95,6 @@ export class ResourceGuard implements CanActivate {
       permissions: [permission],
       response_mode: 'decision', // can be 'permissions'
     };
-    this.logger.debug(authzRequest);
 
     const res = await this.keycloakConnect.checkPermission(
       authzRequest,

--- a/src/common/guards/resource.guard.ts
+++ b/src/common/guards/resource.guard.ts
@@ -95,6 +95,7 @@ export class ResourceGuard implements CanActivate {
       permissions: [permission],
       response_mode: 'decision', // can be 'permissions'
     };
+    this.logger.debug(authzRequest);
 
     const res = await this.keycloakConnect.checkPermission(
       authzRequest,

--- a/src/database/database.service.ts
+++ b/src/database/database.service.ts
@@ -1,24 +1,18 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { AtlasService } from 'src/atlas/atlas.service';
-import { FileStorageService } from 'src/file_storage/file_storage.service';
-import { QueueService } from 'src/queue/queue.service';
-import { ArchetypeService } from 'src/archetype/archetype.service';
 import {
   AtlasEntityResponseDto,
   AtlasSearchDslAttributesResponseDto,
   AtlasSearchDslResponseDto,
 } from 'src/atlas/dto';
 
+// TODO: needs refactoring and simplifying
 @Injectable()
 export class DatabaseService {
   constructor(
     private prisma: PrismaService,
     private atlas: AtlasService,
-    private fileStorage: FileStorageService,
-    private readonly queue: QueueService,
-    @Inject(forwardRef(() => ArchetypeService))
-    private archetype: ArchetypeService,
   ) {}
 
   async summary(projectId: string, token?: string) {

--- a/src/database/database.service.ts
+++ b/src/database/database.service.ts
@@ -4,6 +4,11 @@ import { AtlasService } from 'src/atlas/atlas.service';
 import { FileStorageService } from 'src/file_storage/file_storage.service';
 import { QueueService } from 'src/queue/queue.service';
 import { ArchetypeService } from 'src/archetype/archetype.service';
+import {
+  AtlasEntityResponseDto,
+  AtlasSearchDslAttributesResponseDto,
+  AtlasSearchDslResponseDto,
+} from 'src/atlas/dto';
 
 @Injectable()
 export class DatabaseService {
@@ -20,17 +25,22 @@ export class DatabaseService {
     const tableParams = {
       query: `from rdbms_db where instance.projectId = "${projectId}" select tables`,
     };
-    const tableResult = await this.atlas.get('/search/dsl', tableParams, token);
+    const tableResult = await this.atlas.get<AtlasSearchDslResponseDto>(
+      '/search/dsl',
+      tableParams,
+      token,
+    );
 
     const schemaParams = {
       query: `from rdbms_db where instance.projectId = "${projectId}" select __guid, __state`,
     };
 
-    const schemaResult = await this.atlas.get(
-      '/search/dsl',
-      schemaParams,
-      token,
-    );
+    const schemaResult =
+      await this.atlas.get<AtlasSearchDslAttributesResponseDto>(
+        '/search/dsl',
+        schemaParams,
+        token,
+      );
 
     const activeTables = tableResult.entities.filter(
       (entity: any) => entity.status === 'ACTIVE',
@@ -44,7 +54,11 @@ export class DatabaseService {
       const params = {
         query: `from rdbms_table where __guid = "${guid}" select columns`,
       };
-      const result = await this.atlas.get('/search/dsl', params, token);
+      const result = await this.atlas.get<AtlasSearchDslResponseDto>(
+        '/search/dsl',
+        params,
+        token,
+      );
 
       if (result.entities) {
         const activeColumns = result.entities.filter(
@@ -73,7 +87,7 @@ export class DatabaseService {
       query: `from rdbms_db where instance.projectId = "${projectId}" select tables`,
     };
 
-    const tablesResult = await this.atlas.get(
+    const tablesResult = await this.atlas.get<AtlasSearchDslResponseDto>(
       '/search/dsl',
       tableParams,
       token,
@@ -95,7 +109,7 @@ export class DatabaseService {
       const columnsParams = {
         query: `from rdbms_table where __guid = "${guid}" select columns`,
       };
-      const columnsResult = await this.atlas.get(
+      const columnsResult = await this.atlas.get<AtlasSearchDslResponseDto>(
         '/search/dsl',
         columnsParams,
         token,
@@ -113,14 +127,17 @@ export class DatabaseService {
       const schemaParams = {
         query: `from rdbms_table where __guid = "${guid}" select db`,
       };
-      const schemaResult = await this.atlas.get('/search/dsl', schemaParams);
+      const schemaResult = await this.atlas.get<AtlasSearchDslResponseDto>(
+        '/search/dsl',
+        schemaParams,
+      );
 
       const columns = await Promise.all(
         activeColumns.map(async (column) => {
           const params = {
             ignoreRelationships: true,
           };
-          const result = await this.atlas.get(
+          const result = await this.atlas.get<AtlasEntityResponseDto>(
             '/entity/guid/' + column.guid,
             params,
             token,
@@ -152,7 +169,11 @@ export class DatabaseService {
     const tableParams = {
       query: `from rdbms_db where instance.projectId = "${projectId}" select tables`,
     };
-    const tableResult = await this.atlas.get('/search/dsl', tableParams, token);
+    const tableResult = await this.atlas.get<AtlasSearchDslResponseDto>(
+      '/search/dsl',
+      tableParams,
+      token,
+    );
 
     const activeTables = tableResult.entities.filter(
       (entity: any) => entity.status === 'ACTIVE',
@@ -167,7 +188,11 @@ export class DatabaseService {
       const params = {
         query: `from rdbms_table where __guid = "${guid}" select columns`,
       };
-      const result = await this.atlas.get('/search/dsl', params, token);
+      const result = await this.atlas.get<AtlasSearchDslResponseDto>(
+        '/search/dsl',
+        params,
+        token,
+      );
 
       if (result.entities) {
         const activeColumns = result.entities.filter(
@@ -301,13 +326,18 @@ export class DatabaseService {
     const params = {
       ignoreRelationships: true,
     };
-    const result = await this.atlas.get(
+    const result = await this.atlas.get<AtlasEntityResponseDto>(
       `/entity/uniqueAttribute/type/rdbms_instance?attr:projectId=${projectId}`,
       params,
       token,
     );
+
     if (result.entity.attributes.erd) {
-      const diagramCode = result.entity.attributes.erd.replace(
+      const erdText =
+        typeof result.entity.attributes.erd === 'string'
+          ? result.entity.attributes.erd
+          : JSON.stringify(result.entity.attributes.erd ?? '');
+      const diagramCode = erdText.replace(
         /"FOREIGN KEY \(.*\) REFERENCES .*\(.*\) ON UPDATE CASCADE ON DELETE CASCADE"/g,
         '""',
       );

--- a/src/docker/docker.service.ts
+++ b/src/docker/docker.service.ts
@@ -36,7 +36,9 @@ export class DockerService {
     database?: DatabaseInfoDto,
     requestId?: string,
   ): Promise<string> {
-    this.logger.log(`Preparing to run container for request: ${requestId}.`);
+    this.logger.log(
+      `Preparing to run crawler container for request ${requestId}...`,
+    );
     const envArgs = [
       `ATLAS_URI=${this.isDev ? this.atlasUrl.replace('localhost', 'host.docker.internal') : this.atlasUrl}`,
       `ATLAS_ADMIN_USER=${this.username}`,
@@ -80,6 +82,9 @@ export class DockerService {
           );
         }
         //  4. Crawling done, container run successfully
+        this.logger.log(
+          `Container ${instanceName} run successfully for request ${requestId}.`,
+        );
         // set project status to active (e.g. ready for mapping)
         await this.prisma.project.update({
           where: { projectId },
@@ -88,6 +93,7 @@ export class DockerService {
       } catch (err) {
         throw err; // rethrow errors because async
       } finally {
+        //  5. Run cleanup for the container instance
         this.logger.debug(`Removing container ${instanceName}...`);
         await container.remove({ force: true });
         this.logger.debug(`Container ${instanceName} removed successfully.`);

--- a/src/docker/docker.service.ts
+++ b/src/docker/docker.service.ts
@@ -35,7 +35,7 @@ export class DockerService {
     projectId: string,
     database?: DatabaseInfoDto,
     requestId?: string,
-  ): Promise<string> {
+  ) {
     this.logger.log(
       `Preparing to run crawler container for request ${requestId}...`,
     );
@@ -106,10 +106,6 @@ export class DockerService {
         },
       });
       this.logger.error(`Error running container ${instanceName}: `, error);
-    } finally {
-      // pretty pointless return here
-      // maybe should return information if success of failure
-      return projectId;
     }
   }
 

--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -85,7 +85,9 @@ export class ProjectController {
   @Post()
   @ApiOperation({ summary: 'Create project' })
   createProject(@Req() request: Request, @Body() dto: ProjectDto) {
-    return this.projectService.createProject(dto);
+    // TODO: we need to make sure that we actually use usernames because these will be needed for atlas authorization as emails will change which break ownership lookups and Ranger policies
+    const owner = request.auth.payload.preferred_username.toString();
+    return this.projectService.createProject(owner, dto);
   }
 
   @Get(':projectId')

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -145,7 +145,7 @@ export class ProjectService {
     return requestList;
   }
 
-  async createProject(dto: ProjectDto) {
+  async createProject(owner: string, dto: ProjectDto) {
     const memberData = JSON.parse(dto.members);
     const customId = nanoid(12);
     const packageName = dto.name
@@ -219,7 +219,7 @@ export class ProjectService {
         },
       });
       await this.queue.dataBrokerJob(
-        dto.ownerId,
+        owner,
         project.projectId,
         project.connection.requestId,
         dto.connection.tempDbDetails,

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -4,7 +4,15 @@ import { Injectable, Logger } from '@nestjs/common';
 import { AtlasService } from 'src/atlas/atlas.service';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { DockerService } from 'src/docker/docker.service';
-import { ArchetypeDto } from 'src/archetype/dto';
+
+import { customAlphabet } from 'nanoid';
+
+import {
+  ArchetypeNodeDto,
+  ArchetypeNodePermissionDto,
+  ArchetypeEdgeDto,
+  ArchetypeDto,
+} from 'src/archetype/dto';
 import {
   AtlasEntityResponseDto,
   AtlasSearchDslResponseDto,
@@ -15,6 +23,24 @@ type ArchetypeJobData = {
   projectId: string;
   archetype: ArchetypeDto;
 };
+
+interface AtlasEntity {
+  typeName: string;
+  guid: string; // negative placeholder in bulk request
+  status: string;
+  attributes?: Record<string, unknown>;
+  relationshipAttributes?: Record<string, unknown>;
+  classifications?: Array<
+    | { typeName: string }
+    | {
+        typeName: 'archetype_node_analysis_permissions';
+        attributes: { access_level: 'NONE' | 'HIGH_LEVEL' | 'DETAILED' };
+      }
+  >;
+}
+
+// TODO: move to somewhere sensible
+const customNanoidAlphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
 @Injectable()
 @Processor('atlas-queue')
@@ -36,234 +62,119 @@ export class AtlasProcessor {
   async handleAddArchetypeJob(job: Job<ArchetypeJobData>, token?: string) {
     const { owner, projectId, archetype } = job.data;
 
-    const archetypeBody = {
-      entity: {
-        typeName: 'archetype',
-        status: 'ACTIVE',
-        attributes: {
-          owner: owner,
-          name: archetype.name,
-          label: archetype.nodes[0].data.label,
-          // TODO: is this needed?
-          projectId: projectId,
-          // TODO: decide what is best to have as the name here
-          qualifiedName: `${projectId}@${archetype.name.replace(' ', '_').toLowerCase()}`,
-          status: 'DRAFT',
-        },
-        relationshipAttributes: {
-          instance: {
-            typeName: 'rdbms_instance',
-            uniqueAttributes: {
-              projectId,
-            },
+    // init negative guid
+    let negativeGuid = -2;
+    // store initial guid id as archetypeId
+    archetype.archetypeId = '-1';
+    // nextGuid function
+    const nextGuid = () => String(negativeGuid--);
+
+    // Accumulators for entities and relationships
+    const entities: AtlasEntity[] = [];
+    const parentLookup: Record<string, string> = {};
+
+    const archetypeCustomId = customAlphabet(customNanoidAlphabet, 10)();
+
+    // Add archetype_template entity
+    entities.push({
+      typeName: 'archetype_template',
+      status: 'ACTIVE',
+      guid: archetype.archetypeId,
+      attributes: {
+        owner: owner,
+        name: archetype.name,
+        // TODO: is this needed?
+        projectId: projectId,
+        // TODO: decide what is best to have as the name here
+        qualifiedName: `${projectId}@${archetypeCustomId}@${archetype.name.replace(/\s+/g, '_').toLowerCase()}`,
+        status: 'DRAFT',
+      },
+      relationshipAttributes: {
+        instance: {
+          typeName: 'rdbms_instance',
+          uniqueAttributes: {
+            projectId,
           },
         },
       },
-    };
+    });
 
-    const result = await this.atlas.post('/entity', archetypeBody, token);
-    this.logger.debug(result);
-    // const archetypeId = Object.values(result.guidAssignments)[0];
+    const [columns, nodes] = archetype.nodes.reduce<
+      [ArchetypeNodeDto[], ArchetypeNodeDto[]]
+    >(
+      (acc, node) => {
+        if (node.type === 'column') acc[0].push(node);
+        else acc[1].push(node);
+        return acc;
+      },
+      [[], []],
+    );
+    const columnEdges = archetype.edges.filter((edge: ArchetypeEdgeDto) =>
+      columns.find((e) => e.id === edge.target),
+    );
+    const archetypeNodes = nodes.map((node: ArchetypeNodeDto) => {
+      const columnGuid = columnEdges.find((e) => e.source === node.id)?.target;
+      const parentId = archetype.edges.find(
+        (e) => e.target === node.id,
+      )?.source;
+      const currentGuid = nextGuid(); // increase neg guid
+      parentLookup[node.id] = currentGuid;
+      return {
+        guid: currentGuid,
+        typeName: 'archetype_node',
+        status: 'ACTIVE',
+        attributes: {
+          label: node.data.label,
+          name: `${archetype.name} ${node.id}`,
+          owner: owner,
+          level: node.data.level,
+          qualifiedName: `${projectId}@${archetypeCustomId}@${node.id}`,
+          position: {
+            x: node.position.x,
+            y: node.position.y,
+          },
+        },
+        classifications: mergeClassifications(
+          columnGuid ? true : false, // isLeaf node
+          node.id,
+          node.type,
+          archetype.permissions,
+        ),
+        relationshipAttributes: {
+          template: {
+            guid: archetype.archetypeId,
+            typeName: 'archetype_template',
+          },
+          ...(parentId
+            ? {
+                parent_node: {
+                  typeName: 'archetype_node',
+                  guid: parentLookup[parentId],
+                },
+              }
+            : {}),
+          ...(columnGuid
+            ? { column: { guid: columnGuid, typeName: 'rdbms_column' } }
+            : {}),
+        },
+      };
+    });
 
-    // const entities = [];
-    // let initialGuid = -1;
+    entities.push(...archetypeNodes);
 
-    // const object = archetype.nodes.filter(
-    //   (node: ArchetypeNodeDto) => node.type === 'object',
-    // );
-    // const catList = archetype.nodes.filter(
-    //   (node: any) => node.type === 'category',
-    // );
-    // const subcatList = template.nodes.filter(
-    //   (node: any) => node.type === 'subcategory',
-    // );
+    await this.atlas.post(
+      '/entity/bulk',
+      {
+        entities: entities,
+      },
+      token,
+    );
+    // this.logger.debug(response);
 
-    // const objectBody = {
-    //   guid: initialGuid.toString(),
-    //   typeName: 'archetype_object',
-    //   status: 'ACTIVE',
-    //   attributes: {
-    //     displayName: object[0].data.label,
-    //     name: object[0].data.label,
-    //     owner: 'user',
-    //     qualifiedName: `${archetypeId}@${object[0].data.label.replace(' ', '_')}@${object[0].id}`,
-    //     position: {
-    //       x: object[0].position.x,
-    //       y: object[0].position.y,
-    //     },
-    //     label: object[0].data.label,
-    //     width: object[0].width,
-    //     height: object[0].height,
-    //     selected: false,
-    //     dragging: false,
-    //   },
-    //   relationshipAttributes: {
-    //     archetype: {
-    //       guid: archetypeId,
-    //       typeName: 'archetype',
-    //     },
-    //   },
-    // };
-
-    // entities.push(objectBody);
-
-    // const catBodyList = catList.map((node: any) => {
-    //   initialGuid -= 1;
-    //   return {
-    //     guid: initialGuid.toString(),
-    //     typeName: 'archetype_category',
-    //     status: 'ACTIVE',
-    //     attributes: {
-    //       displayName: node.data.label,
-    //       name: node.data.label,
-    //       owner: 'user',
-    //       qualifiedName: `${archetypeId}@${node.data.label.replace(' ', '_')}@${node.id}`,
-    //       position: {
-    //         x: node.position.x,
-    //         y: node.position.y,
-    //       },
-    //       label: node.data.label,
-    //       width: node.width,
-    //       height: node.height,
-    //       selected: false,
-    //       dragging: false,
-    //     },
-    //     relationshipAttributes: {
-    //       archetype: {
-    //         guid: archetypeId,
-    //         typeName: 'archetype',
-    //       },
-    //       object: {
-    //         guid: '-1',
-    //         typeName: 'archetype_object',
-    //       },
-    //     },
-    //   };
-    // });
-
-    // entities.push(...catBodyList);
-
-    // const catIdList: { [key: string]: string } = {};
-    // for (const cat of catBodyList) {
-    //   const name = cat.attributes.qualifiedName.split('@');
-    //   catIdList[name[2]] = cat.guid;
-    // }
-
-    // for (const node of subcatList) {
-    //   const relatedEdge = template.edges.filter(
-    //     (edge: any) => edge.source == node.id || edge.target == node.id,
-    //   );
-
-    //   const categoryId =
-    //     relatedEdge[0].source == node.id
-    //       ? catIdList[relatedEdge[0].target]
-    //       : catIdList[relatedEdge[0].source];
-
-    //   const subcatBody = {
-    //     typeName: 'archetype_subcategory',
-    //     status: 'ACTIVE',
-    //     attributes: {
-    //       displayName: node.data.label,
-    //       name: node.data.label,
-    //       owner: 'user',
-    //       qualifiedName: `${archetypeId}@${node.data.label.replace(' ', '_')}@${node.id}`,
-    //       position: {
-    //         x: node.position.x,
-    //         y: node.position.y,
-    //       },
-    //       label: node.data.label,
-    //       width: node.width,
-    //       height: node.height,
-    //       selected: false,
-    //       dragging: false,
-    //     },
-    //     relationshipAttributes: {
-    //       archetype: {
-    //         guid: archetypeId,
-    //         typeName: 'archetype',
-    //       },
-    //       category: {
-    //         guid: categoryId,
-    //         type: 'archetype_category',
-    //       },
-    //     },
-    //   };
-
-    //   entities.push(subcatBody);
-    // }
-
-    // await this.atlas.post('/entity/bulk', { entities: entities });
-
-    // await this.prisma.project.update({
-    //   where: { projectId: projectId },
-    //   data: { lastModified: new Date() },
-    // });
-
-    // const tableParams = {
-    //   query: `from rdbms_db where instance.__guid = "${dbId}" select tables`,
-    // };
-
-    // const tableResult = await this.atlas.get('/search/dsl', tableParams, token);
-
-    // const activeTables = tableResult.entities.filter(
-    //   (entity: any) => entity.status === 'ACTIVE',
-    // );
-
-    // for (const node of columnMapping) {
-    //   const params = {
-    //     'attr:qualifiedName': `${archetypeId}@${node.nodeName.replace(' ', '_')}@${node.nodeId}`,
-    //   };
-
-    //   const result = await this.atlas.get(
-    //     `/entity/uniqueAttribute/type/archetype_${node.nodeType}`,
-    //     params,
-    //     token,
-    //   );
-
-    //   if (result.entity.relationshipAttributes.columns.length !== 0) {
-    //     continue;
-    //   }
-
-    //   result.entity.relationshipAttributes.columns = [];
-
-    //   for (const col of node.columns) {
-    //     const tableGuid = activeTables.find(
-    //       (table: any) => table.attributes.name === col.table,
-    //     ).guid;
-
-    //     const colParams = {
-    //       query: `from rdbms_column where table.__guid = "${tableGuid}"`,
-    //     };
-    //     const colResult = await this.atlas.get('/search/dsl', colParams, token);
-
-    //     const activeColumns = colResult.entities.filter(
-    //       (entity: any) => entity.status === 'ACTIVE',
-    //     );
-
-    //     const columnEntity = activeColumns.find(
-    //       (column: any) => column.attributes.name === col.name,
-    //     );
-
-    //     const relationship = await this.atlas.get(
-    //       `/types/relationshipdef/name/archetype_${node.nodeType}_rdbms_columns`,
-    //       undefined,
-    //       token,
-    //     );
-
-    //     const columnInfo = {
-    //       guid: columnEntity.guid,
-    //       typeName: 'rdbms_column',
-    //       entityStatus: 'ACTIVE',
-    //       relationshipType: `archetype_${node.nodeType}_rdbms_columns`,
-    //       relationshipGuid: relationship.guid,
-    //       relationshipStatus: 'ACTIVE',
-    //     };
-
-    //     result.entity.relationshipAttributes.columns.push(columnInfo);
-    //   }
-
-    //   await this.atlas.post('/entity', result, undefined, token);
-    // }
+    return await this.prisma.project.update({
+      where: { projectId: projectId },
+      data: { lastModified: new Date() },
+    });
   }
 
   @Process('process-delete-archetype')
@@ -281,6 +192,7 @@ export class AtlasProcessor {
     });
   }
 
+  // TODO: remove redundant function as using classifiers for permissions now
   @Process('process-add-permissions')
   async handleAddPermissionsJob(job: Job, token?: string) {
     const { projectId, permissions } = job.data;
@@ -504,3 +416,61 @@ export class AtlasProcessor {
     });
   }
 }
+
+function mergeClassifications(
+  isLeaf: boolean,
+  nodeId: string,
+  type: string,
+  permissions: ArchetypeNodePermissionDto[],
+): AtlasEntity['classifications'] {
+  const classifications: AtlasEntity['classifications'] = [];
+  classifications.push({
+    typeName: isLeaf
+      ? 'leaf_node'
+      : type === 'root'
+        ? 'root_node'
+        : 'branch_node',
+  });
+  const permission = permissions.find((p) => p.id === nodeId)?.permission;
+  if (permission) {
+    classifications.push({
+      typeName: 'archetype_node_analysis_permissions',
+      attributes: { access_level: permission },
+    });
+  }
+  return classifications;
+}
+
+// function addParent(
+//   archetypeId: string,
+//   nodeId: string,
+//   edges: ArchetypeEdgeDto[],
+// ) {
+//   const parent = edges.find((e) => e.target === nodeId)?.source;
+//   return parent
+//     ? {
+//         parent_node: {
+//           typeName: 'archetype_node',
+//           uniqueAttributes: {
+//             qualifiedName: `${archetypeId}@${parent}`,
+//           },
+//         },
+//       }
+//     : {};
+// }
+
+// function addColumn(
+//   archetypeId: string,
+//   nodeId: string,
+//   columnEdges: ArchetypeEdgeDto[],
+// ) {
+//   const columnGuid = columnEdges.find((e) => e.source === nodeId)?.target;
+//   return parent
+//     ? {
+//         column: {
+//           typeName: 'column',
+//           guid: columnGuid,
+//         },
+//       }
+//     : {};
+// }

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -30,7 +30,7 @@ type ArchetypeJobData = {
   projectId: string;
   archetype: ArchetypeDto;
 };
-
+// TODO: we need properly handle failed request for all these processors
 @Injectable()
 @Processor('atlas-queue')
 export class AtlasProcessor {
@@ -49,7 +49,6 @@ export class AtlasProcessor {
     this.logger.log(
       `Handling 'process-data-broker' job for requestId: ${requestId}...`,
     );
-
     return await this.docker.runDataBroker(
       ownerId,
       projectId,
@@ -59,115 +58,126 @@ export class AtlasProcessor {
   }
 
   @Process('process-update-archetype')
-  async handleUpdateArchetypeJob(job: Job): Promise<string> {
+  async handleUpdateArchetypeJob(job: Job) {
     const { owner, projectId, archetype }: ArchetypeJobData = job.data;
     this.logger.log(
       `Handling 'process-update-archetype' job for projectId: ${projectId}...`,
     );
+    try {
+      const entities: AtlasSubmitArchetypeEntityDto[] = [];
 
-    const entities: AtlasSubmitArchetypeEntityDto[] = [];
-
-    // Add archetype_template entity
-    const archetypeTemplateBody: AtlasSubmitArchetypeEntityDto = {
-      typeName: AtlasArchetypeTypeName.Template,
-      guid: archetype.archetypeId,
-      attributes: {
-        owner: owner,
-        name: archetype.name,
-        // TODO: is this needed?
-        projectId: projectId,
-        // TODO: decide what is best to have as the name here
-        qualifiedName: `${projectId}@${customAlphabet(this.customNanoidAlphabet, 6)()}`,
-        status: archetype.status,
-      },
-      relationshipAttributes: {
-        instance: {
-          typeName: 'rdbms_instance',
-          uniqueAttributes: {
-            projectId,
+      // Add archetype_template entity
+      const archetypeTemplateBody: AtlasSubmitArchetypeEntityDto = {
+        typeName: AtlasArchetypeTypeName.Template,
+        guid: archetype.archetypeId,
+        attributes: {
+          owner: owner,
+          name: archetype.name,
+          // TODO: is this needed?
+          projectId: projectId,
+          // TODO: decide what is best to have as the name here
+          qualifiedName: `${projectId}@${customAlphabet(this.customNanoidAlphabet, 6)()}`,
+          status: archetype.status,
+        },
+        relationshipAttributes: {
+          instance: {
+            typeName: 'rdbms_instance',
+            uniqueAttributes: {
+              projectId,
+            },
           },
         },
-      },
-    };
-    entities.push(
-      archetypeTemplateBody,
-      ...this.archetypeTemplateToAtlasEntitities(
-        owner,
-        projectId,
-        archetype,
-        true,
-      ),
-    );
-
-    // // TODO: Proper error handling
-    await this.atlas.post<AtlasPostEntityResponseDto>('/entity/bulk', {
-      entities: entities,
-    });
-
-    await this.prisma.project.update({
-      where: { projectId: projectId },
-      data: { lastModified: new Date() },
-    });
-    this.logger.log(
-      `Handling 'process-update-archetype' job for arechetypeId ${archetype.archetypeId} DONE!`,
-    );
-    return archetype.archetypeId;
+      };
+      entities.push(
+        archetypeTemplateBody,
+        ...this.archetypeTemplateToAtlasEntitities(
+          owner,
+          projectId,
+          archetype,
+          true,
+        ),
+      );
+      await this.atlas.post<AtlasPostEntityResponseDto>('/entity/bulk', {
+        entities: entities,
+      });
+      await this.prisma.project.update({
+        where: { projectId: projectId },
+        data: { lastModified: new Date() },
+      });
+      this.logger.log(
+        `Handling 'process-update-archetype' job for archetypeId ${archetype.archetypeId} DONE!`,
+      );
+      return archetype.archetypeId;
+    } catch (error) {
+      this.logger.error(
+        `Error updating archetype ${archetype.archetypeId}: `,
+        error,
+      );
+    }
   }
 
   @Process('process-add-archetype')
-  async handleAddArchetypeJob(job: Job): Promise<string> {
+  async handleAddArchetypeJob(job: Job) {
     const { owner, projectId, archetype }: ArchetypeJobData = job.data;
     this.logger.log(
       `Handling 'process-add-archetype' job for projectId: ${projectId}...`,
     );
-
-    // Add archetype_template entity
-    const archetypeTemplateBody: AtlasSubmitArchetypeEntityDto = {
-      typeName: AtlasArchetypeTypeName.Template,
-      attributes: {
-        owner: owner,
-        name: archetype.name,
-        // TODO: is this needed?
-        projectId: projectId,
-        // TODO: decide what is best to have as the name here
-        qualifiedName: `${projectId}@${customAlphabet(this.customNanoidAlphabet, 6)()}`,
-        status: archetype.status,
-      },
-      relationshipAttributes: {
-        instance: {
-          typeName: 'rdbms_instance',
-          uniqueAttributes: {
-            projectId,
+    try {
+      //  1. create archetype_template entity
+      const archetypeTemplateBody: AtlasSubmitArchetypeEntityDto = {
+        typeName: AtlasArchetypeTypeName.Template,
+        attributes: {
+          owner: owner,
+          name: archetype.name,
+          // TODO: is this needed?
+          projectId: projectId,
+          // TODO: decide what is best to have as the name here
+          qualifiedName: `${projectId}@${customAlphabet(this.customNanoidAlphabet, 6)()}`,
+          status: archetype.status,
+        },
+        relationshipAttributes: {
+          instance: {
+            typeName: 'rdbms_instance',
+            uniqueAttributes: {
+              projectId,
+            },
           },
         },
-      },
-    };
-
-    // TODO: Proper error handling
-    const templateResponse = await this.atlas.post<AtlasPostEntityResponseDto>(
-      '/entity',
-      { entity: archetypeTemplateBody },
-      undefined,
-    );
-
-    // store real archetypeId ref (Atlas GUID)
-    archetype.archetypeId = Object.values(templateResponse?.guidAssignments)[0];
-
-    const entities: AtlasSubmitArchetypeEntityDto[] =
-      this.archetypeTemplateToAtlasEntitities(owner, projectId, archetype);
-    // TODO: Proper error handling
-    await this.atlas.post<AtlasPostEntityResponseDto>('/entity/bulk', {
-      entities: entities,
-    });
-
-    await this.prisma.project.update({
-      where: { projectId: projectId },
-      data: { lastModified: new Date() },
-    });
-    this.logger.log(
-      `Handling 'process-add-archetype' job for projectId ${projectId} DONE!\nCreated archetype: ${archetype.archetypeId}`,
-    );
-    return archetype.archetypeId;
+      };
+      const templateResponse =
+        await this.atlas.post<AtlasPostEntityResponseDto>(
+          '/entity',
+          { entity: archetypeTemplateBody },
+          undefined,
+        );
+      // 2. store real archetypeId ref (Atlas GUID)
+      archetype.archetypeId = Object.values(
+        templateResponse?.guidAssignments,
+      )[0];
+      // this.logger.debug(
+      //   `Template CREATE response:\n${JSON.stringify(templateResponse)}`,
+      // );
+      // 3. create archetype_node entities
+      const entities: AtlasSubmitArchetypeEntityDto[] =
+        this.archetypeTemplateToAtlasEntitities(owner, projectId, archetype);
+      await this.atlas.post<AtlasPostEntityResponseDto>('/entity/bulk', {
+        entities: entities,
+      });
+      // 4. update project
+      await this.prisma.project.update({
+        where: { projectId: projectId },
+        data: { lastModified: new Date() },
+      });
+      this.logger.log(
+        `Handling 'process-add-archetype' job for projectId ${projectId} SUCCEEDED!\nCreated archetype: ${archetype.archetypeId}`,
+      );
+      return archetype.archetypeId;
+    } catch (error) {
+      this.logger.error(
+        `Error creating archetype for project ${archetype.projectId}: `,
+        error,
+      );
+    }
   }
 
   @Process('process-delete-archetype')
@@ -176,22 +186,27 @@ export class AtlasProcessor {
     this.logger.log(
       `Handling 'process-delete-archetype' job archetype ${archetypeId}...`,
     );
-    await this.atlas.delete('/entity/guid/' + archetypeId);
-    await this.prisma.project.update({
-      where: {
-        projectId: projectId,
-      },
-      data: {
-        lastModified: new Date(),
-      },
-    });
-    this.logger.log(
-      `Handling 'process-delete-archetype' job archetype ${archetypeId} DONE!`,
-    );
+    try {
+      await this.atlas.delete('/entity/guid/' + archetypeId);
+      await this.prisma.project.update({
+        where: {
+          projectId: projectId,
+        },
+        data: {
+          lastModified: new Date(),
+        },
+      });
+      this.logger.log(
+        `Handling 'process-delete-archetype' job archetype ${archetypeId} DONE!`,
+      );
+      return projectId;
+    } catch (error) {
+      this.logger.error(`Error deleting archetype ${archetypeId}: `, error);
+    }
   }
 
   // TODO: remove redundant function as using classifiers for permissions now
-  // Remove after settling an update function
+  // Remove after settling an update
   @Process('process-add-permissions')
   async handleAddPermissionsJob(job: Job) {
     const { projectId, permissions } = job.data;
@@ -470,7 +485,7 @@ export class AtlasProcessor {
           columnGuid ? true : false, // isLeaf node
           node.id,
           node.type,
-          archetype.permissions,
+          archetype.permissions || [],
         ),
         relationshipAttributes: {
           template: {
@@ -514,7 +529,7 @@ export class AtlasProcessor {
           : 'branch_node') as AtlasArchetypeNodeTypeName,
       propagate: false,
     } as AtlasSimpleClassificationDto);
-    const permission = permissions.find((p) => p.id === nodeId)?.permission;
+    const permission = permissions?.find((p) => p.id === nodeId)?.permission;
     if (permission) {
       classifications.push({
         typeName: 'archetype_node_analysis_permissions',

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -1,13 +1,21 @@
 import { Processor, Process } from '@nestjs/bull';
 import { Job } from 'bull';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { AtlasService } from 'src/atlas/atlas.service';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { DockerService } from 'src/docker/docker.service';
+import { ArchetypeDto } from 'src/archetype/dto';
+
+type ArchetypeJobData = {
+  owner: string;
+  projectId: string;
+  archetype: ArchetypeDto;
+};
 
 @Injectable()
 @Processor('atlas-queue')
 export class AtlasProcessor {
+  private readonly logger = new Logger(AtlasProcessor.name);
   constructor(
     private readonly docker: DockerService,
     private readonly atlas: AtlasService,
@@ -21,8 +29,8 @@ export class AtlasProcessor {
   }
 
   @Process('process-add-archetype')
-  async handleAddArchetypeJob(job: Job, token?: string) {
-    const { owner, dbId, projectId, columnMapping, template } = job.data;
+  async handleAddArchetypeJob(job: Job<ArchetypeJobData>, token?: string) {
+    const { owner, projectId, archetype } = job.data;
 
     const archetypeBody = {
       entity: {
@@ -30,225 +38,233 @@ export class AtlasProcessor {
         status: 'ACTIVE',
         attributes: {
           owner: owner,
-          qualifiedName: `${dbId}@${template.name}`,
-          is_active: true,
+          name: archetype.name,
+          label: archetype.nodes[0].data.label,
+          // TODO: decide what is best to have as the name here
+          qualifiedName: `${projectId}@${archetype.name.replace(' ', '_').toLowerCase()}`,
+          status: 'DRAFT',
         },
         relationshipAttributes: {
           instance: {
-            guid: dbId,
             typeName: 'rdbms_instance',
+            uniqueAttributes: {
+              projectId,
+            },
           },
         },
       },
     };
 
     const result = await this.atlas.post('/entity', archetypeBody, token);
-    const archetypeId = Object.values(result.guidAssignments)[0];
+    this.logger.debug(result);
+    // const archetypeId = Object.values(result.guidAssignments)[0];
 
-    const entities = [];
-    let initialGuid = -1;
+    // const entities = [];
+    // let initialGuid = -1;
 
-    const object = template.nodes.filter((node: any) => node.type === 'object');
-    const catList = template.nodes.filter(
-      (node: any) => node.type === 'category',
-    );
-    const subcatList = template.nodes.filter(
-      (node: any) => node.type === 'subcategory',
-    );
+    // const object = archetype.nodes.filter(
+    //   (node: ArchetypeNodeDto) => node.type === 'object',
+    // );
+    // const catList = archetype.nodes.filter(
+    //   (node: any) => node.type === 'category',
+    // );
+    // const subcatList = template.nodes.filter(
+    //   (node: any) => node.type === 'subcategory',
+    // );
 
-    const objectBody = {
-      guid: initialGuid.toString(),
-      typeName: 'archetype_object',
-      status: 'ACTIVE',
-      attributes: {
-        displayName: object[0].data.label,
-        name: object[0].data.label,
-        owner: 'user',
-        qualifiedName: `${archetypeId}@${object[0].data.label.replace(' ', '_')}@${object[0].id}`,
-        position: {
-          x: object[0].position.x,
-          y: object[0].position.y,
-        },
-        label: object[0].data.label,
-        width: object[0].width,
-        height: object[0].height,
-        selected: false,
-        dragging: false,
-      },
-      relationshipAttributes: {
-        archetype: {
-          guid: archetypeId,
-          typeName: 'archetype',
-        },
-      },
-    };
+    // const objectBody = {
+    //   guid: initialGuid.toString(),
+    //   typeName: 'archetype_object',
+    //   status: 'ACTIVE',
+    //   attributes: {
+    //     displayName: object[0].data.label,
+    //     name: object[0].data.label,
+    //     owner: 'user',
+    //     qualifiedName: `${archetypeId}@${object[0].data.label.replace(' ', '_')}@${object[0].id}`,
+    //     position: {
+    //       x: object[0].position.x,
+    //       y: object[0].position.y,
+    //     },
+    //     label: object[0].data.label,
+    //     width: object[0].width,
+    //     height: object[0].height,
+    //     selected: false,
+    //     dragging: false,
+    //   },
+    //   relationshipAttributes: {
+    //     archetype: {
+    //       guid: archetypeId,
+    //       typeName: 'archetype',
+    //     },
+    //   },
+    // };
 
-    entities.push(objectBody);
+    // entities.push(objectBody);
 
-    const catBodyList = catList.map((node: any) => {
-      initialGuid -= 1;
-      return {
-        guid: initialGuid.toString(),
-        typeName: 'archetype_category',
-        status: 'ACTIVE',
-        attributes: {
-          displayName: node.data.label,
-          name: node.data.label,
-          owner: 'user',
-          qualifiedName: `${archetypeId}@${node.data.label.replace(' ', '_')}@${node.id}`,
-          position: {
-            x: node.position.x,
-            y: node.position.y,
-          },
-          label: node.data.label,
-          width: node.width,
-          height: node.height,
-          selected: false,
-          dragging: false,
-        },
-        relationshipAttributes: {
-          archetype: {
-            guid: archetypeId,
-            typeName: 'archetype',
-          },
-          object: {
-            guid: '-1',
-            typeName: 'archetype_object',
-          },
-        },
-      };
-    });
+    // const catBodyList = catList.map((node: any) => {
+    //   initialGuid -= 1;
+    //   return {
+    //     guid: initialGuid.toString(),
+    //     typeName: 'archetype_category',
+    //     status: 'ACTIVE',
+    //     attributes: {
+    //       displayName: node.data.label,
+    //       name: node.data.label,
+    //       owner: 'user',
+    //       qualifiedName: `${archetypeId}@${node.data.label.replace(' ', '_')}@${node.id}`,
+    //       position: {
+    //         x: node.position.x,
+    //         y: node.position.y,
+    //       },
+    //       label: node.data.label,
+    //       width: node.width,
+    //       height: node.height,
+    //       selected: false,
+    //       dragging: false,
+    //     },
+    //     relationshipAttributes: {
+    //       archetype: {
+    //         guid: archetypeId,
+    //         typeName: 'archetype',
+    //       },
+    //       object: {
+    //         guid: '-1',
+    //         typeName: 'archetype_object',
+    //       },
+    //     },
+    //   };
+    // });
 
-    entities.push(...catBodyList);
+    // entities.push(...catBodyList);
 
-    const catIdList: { [key: string]: string } = {};
-    for (const cat of catBodyList) {
-      const name = cat.attributes.qualifiedName.split('@');
-      catIdList[name[2]] = cat.guid;
-    }
+    // const catIdList: { [key: string]: string } = {};
+    // for (const cat of catBodyList) {
+    //   const name = cat.attributes.qualifiedName.split('@');
+    //   catIdList[name[2]] = cat.guid;
+    // }
 
-    for (const node of subcatList) {
-      const relatedEdge = template.edges.filter(
-        (edge: any) => edge.source == node.id || edge.target == node.id,
-      );
+    // for (const node of subcatList) {
+    //   const relatedEdge = template.edges.filter(
+    //     (edge: any) => edge.source == node.id || edge.target == node.id,
+    //   );
 
-      const categoryId =
-        relatedEdge[0].source == node.id
-          ? catIdList[relatedEdge[0].target]
-          : catIdList[relatedEdge[0].source];
+    //   const categoryId =
+    //     relatedEdge[0].source == node.id
+    //       ? catIdList[relatedEdge[0].target]
+    //       : catIdList[relatedEdge[0].source];
 
-      const subcatBody = {
-        typeName: 'archetype_subcategory',
-        status: 'ACTIVE',
-        attributes: {
-          displayName: node.data.label,
-          name: node.data.label,
-          owner: 'user',
-          qualifiedName: `${archetypeId}@${node.data.label.replace(' ', '_')}@${node.id}`,
-          position: {
-            x: node.position.x,
-            y: node.position.y,
-          },
-          label: node.data.label,
-          width: node.width,
-          height: node.height,
-          selected: false,
-          dragging: false,
-        },
-        relationshipAttributes: {
-          archetype: {
-            guid: archetypeId,
-            typeName: 'archetype',
-          },
-          category: {
-            guid: categoryId,
-            type: 'archetype_category',
-          },
-        },
-      };
+    //   const subcatBody = {
+    //     typeName: 'archetype_subcategory',
+    //     status: 'ACTIVE',
+    //     attributes: {
+    //       displayName: node.data.label,
+    //       name: node.data.label,
+    //       owner: 'user',
+    //       qualifiedName: `${archetypeId}@${node.data.label.replace(' ', '_')}@${node.id}`,
+    //       position: {
+    //         x: node.position.x,
+    //         y: node.position.y,
+    //       },
+    //       label: node.data.label,
+    //       width: node.width,
+    //       height: node.height,
+    //       selected: false,
+    //       dragging: false,
+    //     },
+    //     relationshipAttributes: {
+    //       archetype: {
+    //         guid: archetypeId,
+    //         typeName: 'archetype',
+    //       },
+    //       category: {
+    //         guid: categoryId,
+    //         type: 'archetype_category',
+    //       },
+    //     },
+    //   };
 
-      entities.push(subcatBody);
-    }
+    //   entities.push(subcatBody);
+    // }
 
-    await this.atlas.post('/entity/bulk', { entities: entities });
+    // await this.atlas.post('/entity/bulk', { entities: entities });
 
-    await this.prisma.project.update({
-      where: { projectId: projectId },
-      data: { lastModified: new Date() },
-    });
+    // await this.prisma.project.update({
+    //   where: { projectId: projectId },
+    //   data: { lastModified: new Date() },
+    // });
 
-    const tableParams = {
-      query: `from rdbms_db where instance.__guid = "${dbId}" select tables`,
-    };
+    // const tableParams = {
+    //   query: `from rdbms_db where instance.__guid = "${dbId}" select tables`,
+    // };
 
-    const tableResult = await this.atlas.get('/search/dsl', tableParams, token);
+    // const tableResult = await this.atlas.get('/search/dsl', tableParams, token);
 
-    const activeTables = tableResult.entities.filter(
-      (entity: any) => entity.status === 'ACTIVE',
-    );
+    // const activeTables = tableResult.entities.filter(
+    //   (entity: any) => entity.status === 'ACTIVE',
+    // );
 
-    for (const node of columnMapping) {
-      const params = {
-        'attr:qualifiedName': `${archetypeId}@${node.nodeName.replace(' ', '_')}@${node.nodeId}`,
-      };
+    // for (const node of columnMapping) {
+    //   const params = {
+    //     'attr:qualifiedName': `${archetypeId}@${node.nodeName.replace(' ', '_')}@${node.nodeId}`,
+    //   };
 
-      const result = await this.atlas.get(
-        `/entity/uniqueAttribute/type/archetype_${node.nodeType}`,
-        params,
-        token,
-      );
+    //   const result = await this.atlas.get(
+    //     `/entity/uniqueAttribute/type/archetype_${node.nodeType}`,
+    //     params,
+    //     token,
+    //   );
 
-      if (result.entity.relationshipAttributes.columns.length !== 0) {
-        continue;
-      }
+    //   if (result.entity.relationshipAttributes.columns.length !== 0) {
+    //     continue;
+    //   }
 
-      result.entity.relationshipAttributes.columns = [];
+    //   result.entity.relationshipAttributes.columns = [];
 
-      for (const col of node.columns) {
-        const tableGuid = activeTables.find(
-          (table: any) => table.attributes.name === col.table,
-        ).guid;
+    //   for (const col of node.columns) {
+    //     const tableGuid = activeTables.find(
+    //       (table: any) => table.attributes.name === col.table,
+    //     ).guid;
 
-        const colParams = {
-          query: `from rdbms_column where table.__guid = "${tableGuid}"`,
-        };
-        const colResult = await this.atlas.get('/search/dsl', colParams, token);
+    //     const colParams = {
+    //       query: `from rdbms_column where table.__guid = "${tableGuid}"`,
+    //     };
+    //     const colResult = await this.atlas.get('/search/dsl', colParams, token);
 
-        const activeColumns = colResult.entities.filter(
-          (entity: any) => entity.status === 'ACTIVE',
-        );
+    //     const activeColumns = colResult.entities.filter(
+    //       (entity: any) => entity.status === 'ACTIVE',
+    //     );
 
-        const columnEntity = activeColumns.find(
-          (column: any) => column.attributes.name === col.name,
-        );
+    //     const columnEntity = activeColumns.find(
+    //       (column: any) => column.attributes.name === col.name,
+    //     );
 
-        const relationship = await this.atlas.get(
-          `/types/relationshipdef/name/archetype_${node.nodeType}_rdbms_columns`,
-          undefined,
-          token,
-        );
+    //     const relationship = await this.atlas.get(
+    //       `/types/relationshipdef/name/archetype_${node.nodeType}_rdbms_columns`,
+    //       undefined,
+    //       token,
+    //     );
 
-        const columnInfo = {
-          guid: columnEntity.guid,
-          typeName: 'rdbms_column',
-          entityStatus: 'ACTIVE',
-          relationshipType: `archetype_${node.nodeType}_rdbms_columns`,
-          relationshipGuid: relationship.guid,
-          relationshipStatus: 'ACTIVE',
-        };
+    //     const columnInfo = {
+    //       guid: columnEntity.guid,
+    //       typeName: 'rdbms_column',
+    //       entityStatus: 'ACTIVE',
+    //       relationshipType: `archetype_${node.nodeType}_rdbms_columns`,
+    //       relationshipGuid: relationship.guid,
+    //       relationshipStatus: 'ACTIVE',
+    //     };
 
-        result.entity.relationshipAttributes.columns.push(columnInfo);
-      }
+    //     result.entity.relationshipAttributes.columns.push(columnInfo);
+    //   }
 
-      await this.atlas.post('/entity', result, undefined, token);
-    }
+    //   await this.atlas.post('/entity', result, undefined, token);
+    // }
   }
 
   @Process('process-delete-archetype')
   async handleDeleteTemplateJob(job: Job, token?: string) {
-    const { templateId, projectId } = job.data;
+    const { archetypeId, projectId } = job.data;
 
-    await this.atlas.delete('/entity/guid/' + templateId, undefined, token);
+    await this.atlas.delete('/entity/guid/' + archetypeId, undefined, token);
     await this.prisma.project.update({
       where: {
         projectId: projectId,

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -44,6 +44,8 @@ export class AtlasProcessor {
           owner: owner,
           name: archetype.name,
           label: archetype.nodes[0].data.label,
+          // TODO: is this needed?
+          projectId: projectId,
           // TODO: decide what is best to have as the name here
           qualifiedName: `${projectId}@${archetype.name.replace(' ', '_').toLowerCase()}`,
           status: 'DRAFT',

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -5,6 +5,10 @@ import { AtlasService } from 'src/atlas/atlas.service';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { DockerService } from 'src/docker/docker.service';
 import { ArchetypeDto } from 'src/archetype/dto';
+import {
+  AtlasEntityResponseDto,
+  AtlasSearchDslResponseDto,
+} from 'src/atlas/dto';
 
 type ArchetypeJobData = {
   owner: string;
@@ -282,7 +286,7 @@ export class AtlasProcessor {
     for (const p of permissions) {
       const templateGuid = p.templateId;
 
-      const templateEntity = await this.atlas.get(
+      const templateEntity = await this.atlas.get<AtlasEntityResponseDto>(
         `/entity/guid/${templateGuid}`,
         undefined,
         token,
@@ -293,24 +297,22 @@ export class AtlasProcessor {
       for (const key in templateEntity.referredEntities) {
         const entity = templateEntity.referredEntities[key];
 
-        if (
-          entity.typeName.includes('archetype_') &&
-          entity.status === 'ACTIVE'
-        ) {
+        if (entity.typeName.includes('archetype_')) {
           templateNodesGuid.push(key);
         }
       }
 
-      const getGuid = (name: string) => {
-        for (const key in templateEntity.referredEntities) {
-          if (
-            templateEntity.referredEntities[key].attributes.qualifiedName ==
-            name
-          ) {
-            return key;
-          }
-        }
-      };
+      // FIXME: change this
+      // const getGuid = (name: string) => {
+      //   for (const key in templateEntity.referredEntities) {
+      //     if (
+      //       templateEntity.referredEntities[key].attributes.qualifiedName ==
+      //       name
+      //     ) {
+      //       return key;
+      //     }
+      //   }
+      // };
 
       const params = { name: 'is_active' };
       await this.atlas.put(
@@ -325,162 +327,168 @@ export class AtlasProcessor {
           query: `from permission where __state = "ACTIVE"`,
         };
 
-        const activeResult = await this.atlas.get(
+        const activeResult = await this.atlas.get<AtlasSearchDslResponseDto>(
           '/search/dsl',
           activeParams,
           token,
         );
+        return activeResult;
+        // FIXME: change this
+        // if (activeResult.entities) {
+        //   let guidList = [];
+        //   for (const entity of activeResult.entities) {
+        //     const params = {
+        //       minExtInfo: true,
+        //     };
 
-        if (activeResult.entities) {
-          let guidList = [];
-          for (const entity of activeResult.entities) {
-            const params = {
-              minExtInfo: true,
-            };
+        //     const permissionEntity =
+        //       await this.atlas.get<AtlasEntityResponseDto>(
+        //         `/entity/guid/${entity.guid}`,
+        //         params,
+        //         token,
+        //       );
 
-            const permissionEntity = await this.atlas.get(
-              `/entity/guid/${entity.guid}`,
-              params,
-              token,
-            );
+        //     const objects =
+        //       permissionEntity.entity.relationshipAttributes.object.filter(
+        //         (o) =>
+        //           templateNodesGuid.includes(o.guid) &&
+        //           o.relationshipStatus === 'ACTIVE',
+        //       );
 
-            const objects =
-              permissionEntity.entity.relationshipAttributes.object.filter(
-                (o) =>
-                  templateNodesGuid.includes(o.guid) &&
-                  o.relationshipStatus === 'ACTIVE',
-              );
+        //     const categories =
+        //       permissionEntity.entity.relationshipAttributes.category.filter(
+        //         (s) =>
+        //           templateNodesGuid.includes(s.guid) &&
+        //           s.relationshipStatus === 'ACTIVE',
+        //       );
+        //     const subcategories =
+        //       permissionEntity.entity.relationshipAttributes.subcategory.filter(
+        //         (c) =>
+        //           templateNodesGuid.includes(c.guid) &&
+        //           c.relationshipStatus === 'ACTIVE',
+        //       );
 
-            const categories =
-              permissionEntity.entity.relationshipAttributes.category.filter(
-                (s) =>
-                  templateNodesGuid.includes(s.guid) &&
-                  s.relationshipStatus === 'ACTIVE',
-              );
-            const subcategories =
-              permissionEntity.entity.relationshipAttributes.subcategory.filter(
-                (c) =>
-                  templateNodesGuid.includes(c.guid) &&
-                  c.relationshipStatus === 'ACTIVE',
-              );
+        //     const combined = [...objects, ...categories, ...subcategories];
+        //     guidList = [
+        //       ...guidList,
+        //       ...combined.map((c) => c.relationshipGuid),
+        //     ];
+        //   }
 
-            const combined = [...objects, ...categories, ...subcategories];
-            guidList = [
-              ...guidList,
-              ...combined.map((c) => c.relationshipGuid),
-            ];
-          }
+        //   guidList = Array.from(new Set(guidList));
 
-          guidList = Array.from(new Set(guidList));
+        //   for (const guid of guidList) {
+        //     await this.atlas.delete(
+        //       `/relationship/guid/${guid}`,
+        //       undefined,
+        //       token,
+        //     );
+        //   }
+        // }
 
-          for (const guid of guidList) {
-            await this.atlas.delete(
-              `/relationship/guid/${guid}`,
-              undefined,
-              token,
-            );
-          }
-        }
+        // for (const setting of p.settings) {
+        //   const role = setting.role;
 
-        for (const setting of p.settings) {
-          const role = setting.role;
+        //   for (const node of setting.access) {
+        //     const nodeType = `archetype_${node.nodeType}`;
+        //     const nodeGuid = await getGuid(
+        //       `${templateGuid}@${node.nodeName.replace(' ', '_')}@${node.nodeId}`,
+        //     );
 
-          for (const node of setting.access) {
-            const nodeType = `archetype_${node.nodeType}`;
-            const nodeGuid = await getGuid(
-              `${templateGuid}@${node.nodeName.replace(' ', '_')}@${node.nodeId}`,
-            );
+        //     const uniquePermissions = [...new Set(node.permissions)];
 
-            const uniquePermissions = [...new Set(node.permissions)];
+        //     for (const permission of uniquePermissions) {
+        //       const permissionName = `permission_${permission}@${role}`;
+        //       const permissionParams = {
+        //         query: `from permission where qualifiedName = "${permissionName}" and __state = "ACTIVE" limit 1`,
+        //       };
 
-            for (const permission of uniquePermissions) {
-              const permissionName = `permission_${permission}@${role}`;
-              const permissionParams = {
-                query: `from permission where qualifiedName = "${permissionName}" and __state = "ACTIVE" limit 1`,
-              };
+        //       const permissionResult =
+        //         await this.atlas.get<AtlasSearchDslResponseDto>(
+        //           '/search/dsl',
+        //           permissionParams,
+        //           token,
+        //         );
 
-              const permissionResult = await this.atlas.get(
-                '/search/dsl',
-                permissionParams,
-                token,
-              );
+        //       if (permissionResult.entities) {
+        //         const permissionGuid = permissionResult.entities[0].guid;
 
-              if (permissionResult.entities) {
-                const permissionGuid = permissionResult.entities[0].guid;
+        //         const permissionEntity =
+        //           await this.atlas.get<AtlasEntityResponseDto>(
+        //             `/entity/guid/${permissionGuid}`,
+        //             undefined,
+        //             token,
+        //           );
 
-                const permissionEntity = await this.atlas.get(
-                  `/entity/guid/${permissionGuid}`,
-                  undefined,
-                  token,
-                );
+        //         const hasRelationship = false;
+        //         // FIXME: needs attention
+        //         // permissionEntity.entity.relationshipAttributes[
+        //         //   `${node.nodeType}`
+        //         // ].some(
+        //         //   (p: any) =>
+        //         //     p.guid === nodeGuid && p.relationshipStatus === 'ACTIVE',
+        //         // );
 
-                const hasRelationship =
-                  permissionEntity.entity.relationshipAttributes[
-                    `${node.nodeType}`
-                  ].some(
-                    (p: any) =>
-                      p.guid === nodeGuid && p.relationshipStatus === 'ACTIVE',
-                  );
+        //         if (!hasRelationship) {
+        //           const relationshipBody = {
+        //             typeName: `${nodeType}_permissions`,
+        //             end1: {
+        //               guid: nodeGuid,
+        //             },
+        //             end2: {
+        //               guid: permissionGuid,
+        //             },
+        //             status: 'ACTIVE',
+        //           };
 
-                if (!hasRelationship) {
-                  const relationshipBody = {
-                    typeName: `${nodeType}_permissions`,
-                    end1: {
-                      guid: nodeGuid,
-                    },
-                    end2: {
-                      guid: permissionGuid,
-                    },
-                    status: 'ACTIVE',
-                  };
+        //           await this.atlas.post(
+        //             '/relationship',
+        //             relationshipBody,
+        //             token,
+        //           );
+        //         }
+        //       } else {
+        //         const permissionBody = {
+        //           entity: {
+        //             typeName: 'permission',
+        //             status: 'ACTIVE',
+        //             attributes: {
+        //               owner: 'user',
+        //               qualifiedName: `permission_${permission}@${role}`,
+        //               name: permission,
+        //             },
+        //             relationshipAttributes: {
+        //               object: [],
+        //               category: [],
+        //               subcategory: [],
+        //             },
+        //           },
+        //         };
 
-                  await this.atlas.post(
-                    '/relationship',
-                    relationshipBody,
-                    token,
-                  );
-                }
-              } else {
-                const permissionBody = {
-                  entity: {
-                    typeName: 'permission',
-                    status: 'ACTIVE',
-                    attributes: {
-                      owner: 'user',
-                      qualifiedName: `permission_${permission}@${role}`,
-                      name: permission,
-                    },
-                    relationshipAttributes: {
-                      object: [],
-                      category: [],
-                      subcategory: [],
-                    },
-                  },
-                };
+        //         const relationship = await this.atlas.get(
+        //           `/types/relationshipdef/name/${nodeType}_permissions`,
+        //           undefined,
+        //           token,
+        //         );
+        //         const relationshipInfo = {
+        //           guid: nodeGuid,
+        //           typeName: nodeType,
+        //           entityStatus: 'ACTIVE',
+        //           relationshipType: `${nodeType}_permissions`,
+        //           // FIME: change this
+        //           // relationshipGuid: relationship.guid,
+        //           relationshipStatus: 'ACTIVE',
+        //         };
 
-                const relationship = await this.atlas.get(
-                  `/types/relationshipdef/name/${nodeType}_permissions`,
-                  undefined,
-                  token,
-                );
-                const relationshipInfo = {
-                  guid: nodeGuid,
-                  typeName: nodeType,
-                  entityStatus: 'ACTIVE',
-                  relationshipType: `${nodeType}_permissions`,
-                  relationshipGuid: relationship.guid,
-                  relationshipStatus: 'ACTIVE',
-                };
+        //         permissionBody.entity.relationshipAttributes[
+        //           node.nodeType
+        //         ].push(relationshipInfo);
 
-                permissionBody.entity.relationshipAttributes[
-                  node.nodeType
-                ].push(relationshipInfo);
-
-                await this.atlas.post('/entity', permissionBody, token);
-              }
-            }
-          }
-        }
+        //         await this.atlas.post('/entity', permissionBody, token);
+        //       }
+        //     }
+        //   }
+        // }
       }
     }
 

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -5,8 +5,6 @@ import { AtlasService } from 'src/atlas/atlas.service';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { DockerService } from 'src/docker/docker.service';
 
-import { customAlphabet } from 'nanoid';
-
 import {
   ArchetypeNodeDto,
   ArchetypeNodePermissionDto,
@@ -14,8 +12,15 @@ import {
   ArchetypeDto,
 } from 'src/archetype/dto';
 import {
+  AtlasArchetypeAnalysisPermissionClassificationDto,
+  AtlasArchetypeEntityDto,
+  AtlasArchetypeNodeTypeName,
+  AtlasArchetypeTypeName,
   AtlasEntityResponseDto,
+  AtlasPostEntityResponseDto,
   AtlasSearchDslResponseDto,
+  AtlasSimpleClassificationDto,
+  AtlasSubmitArchetypeEntityDto,
 } from 'src/atlas/dto';
 
 type ArchetypeJobData = {
@@ -23,24 +28,6 @@ type ArchetypeJobData = {
   projectId: string;
   archetype: ArchetypeDto;
 };
-
-interface AtlasEntity {
-  typeName: string;
-  guid: string; // negative placeholder in bulk request
-  status: string;
-  attributes?: Record<string, unknown>;
-  relationshipAttributes?: Record<string, unknown>;
-  classifications?: Array<
-    | { typeName: string }
-    | {
-        typeName: 'archetype_node_analysis_permissions';
-        attributes: { access_level: 'NONE' | 'HIGH_LEVEL' | 'DETAILED' };
-      }
-  >;
-}
-
-// TODO: move to somewhere sensible
-const customNanoidAlphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
 @Injectable()
 @Processor('atlas-queue')
@@ -55,38 +42,45 @@ export class AtlasProcessor {
   @Process('process-data-broker')
   async handleDataBrokerJob(job: Job) {
     const { ownerId, projectId, requestId, database } = job.data;
-    await this.docker.runDataBroker(ownerId, projectId, database, requestId);
+    this.logger.log(
+      `Handling 'process-data-broker' job for requestId: ${requestId}...`,
+    );
+
+    return await this.docker.runDataBroker(
+      ownerId,
+      projectId,
+      database,
+      requestId,
+    );
   }
 
   @Process('process-add-archetype')
-  async handleAddArchetypeJob(job: Job<ArchetypeJobData>, token?: string) {
-    const { owner, projectId, archetype } = job.data;
+  async handleAddArchetypeJob(job: Job): Promise<string> {
+    const { owner, projectId, archetype }: ArchetypeJobData = job.data;
+    this.logger.log(
+      `Handling 'process-add-archetype' job for projectId: ${projectId}...`,
+    );
 
     // init negative guid
     let negativeGuid = -2;
-    // store initial guid id as archetypeId
-    archetype.archetypeId = '-1';
+
     // nextGuid function
     const nextGuid = () => String(negativeGuid--);
 
     // Accumulators for entities and relationships
-    const entities: AtlasEntity[] = [];
+    const entities: AtlasSubmitArchetypeEntityDto[] = [];
     const parentLookup: Record<string, string> = {};
 
-    const archetypeCustomId = customAlphabet(customNanoidAlphabet, 10)();
-
     // Add archetype_template entity
-    entities.push({
-      typeName: 'archetype_template',
-      status: 'ACTIVE',
-      guid: archetype.archetypeId,
+    const archetypeTemplateBody: AtlasSubmitArchetypeEntityDto = {
+      typeName: AtlasArchetypeTypeName.Template,
       attributes: {
         owner: owner,
         name: archetype.name,
         // TODO: is this needed?
         projectId: projectId,
         // TODO: decide what is best to have as the name here
-        qualifiedName: `${projectId}@${archetypeCustomId}@${archetype.name.replace(/\s+/g, '_').toLowerCase()}`,
+        qualifiedName: `${projectId}@${archetype.name.replace(/\s+/g, '_').toLowerCase()}`,
         status: 'DRAFT',
       },
       relationshipAttributes: {
@@ -97,7 +91,24 @@ export class AtlasProcessor {
           },
         },
       },
-    });
+    };
+    // this.logger.debug(
+    //   `Submitting new template:\n ${JSON.stringify(archetypeTemplateBody, null, 2)}`,
+    // );
+
+    // TODO: Proper error handling
+    const templateResponse = await this.atlas.post<AtlasPostEntityResponseDto>(
+      '/entity',
+      { entity: archetypeTemplateBody },
+      undefined,
+    );
+
+    // this.logger.debug(
+    //   `POST template response:\n ${JSON.stringify(templateResponse, null, 2)}`,
+    // );
+
+    // store real archetypeId ref (Atlas GUID)
+    archetype.archetypeId = Object.values(templateResponse?.guidAssignments)[0];
 
     const [columns, nodes] = archetype.nodes.reduce<
       [ArchetypeNodeDto[], ArchetypeNodeDto[]]
@@ -121,14 +132,14 @@ export class AtlasProcessor {
       parentLookup[node.id] = currentGuid;
       return {
         guid: currentGuid,
-        typeName: 'archetype_node',
+        typeName: AtlasArchetypeTypeName.Node,
         status: 'ACTIVE',
         attributes: {
           label: node.data.label,
           name: `${archetype.name} ${node.id}`,
           owner: owner,
           level: node.data.level,
-          qualifiedName: `${projectId}@${archetypeCustomId}@${node.id}`,
+          qualifiedName: `${projectId}@${archetype.archetypeId}@${node.id}`,
           position: {
             x: node.position.x,
             y: node.position.y,
@@ -162,26 +173,30 @@ export class AtlasProcessor {
 
     entities.push(...archetypeNodes);
 
-    await this.atlas.post(
-      '/entity/bulk',
-      {
-        entities: entities,
-      },
-      token,
-    );
-    // this.logger.debug(response);
+    // this.logger.debug(
+    //   `Submitting entities:\n ${JSON.stringify(entities, null, 2)}`,
+    // );
 
-    return await this.prisma.project.update({
+    // TODO: Proper error handling
+    await this.atlas.post<AtlasPostEntityResponseDto>('/entity/bulk', {
+      entities: entities,
+    });
+
+    await this.prisma.project.update({
       where: { projectId: projectId },
       data: { lastModified: new Date() },
     });
+    this.logger.log(
+      `Handling 'process-add-archetype' job for projectId ${projectId} done!`,
+    );
+    return archetype.archetypeId;
   }
 
   @Process('process-delete-archetype')
-  async handleDeleteTemplateJob(job: Job, token?: string) {
+  async handleDeleteTemplateJob(job: Job) {
     const { archetypeId, projectId } = job.data;
 
-    await this.atlas.delete('/entity/guid/' + archetypeId, undefined, token);
+    await this.atlas.delete('/entity/guid/' + archetypeId);
     await this.prisma.project.update({
       where: {
         projectId: projectId,
@@ -194,7 +209,7 @@ export class AtlasProcessor {
 
   // TODO: remove redundant function as using classifiers for permissions now
   @Process('process-add-permissions')
-  async handleAddPermissionsJob(job: Job, token?: string) {
+  async handleAddPermissionsJob(job: Job) {
     const { projectId, permissions } = job.data;
 
     for (const p of permissions) {
@@ -202,8 +217,6 @@ export class AtlasProcessor {
 
       const templateEntity = await this.atlas.get<AtlasEntityResponseDto>(
         `/entity/guid/${templateGuid}`,
-        undefined,
-        token,
       );
 
       const templateNodesGuid = [];
@@ -233,7 +246,6 @@ export class AtlasProcessor {
         `/entity/guid/${templateGuid}`,
         JSON.stringify(p.active ? 'true' : 'false'),
         params,
-        token,
       );
 
       if (p.active) {
@@ -244,9 +256,8 @@ export class AtlasProcessor {
         const activeResult = await this.atlas.get<AtlasSearchDslResponseDto>(
           '/search/dsl',
           activeParams,
-          token,
         );
-        return activeResult;
+        this.logger.debug(activeResult);
         // FIXME: change this
         // if (activeResult.entities) {
         //   let guidList = [];
@@ -422,21 +433,24 @@ function mergeClassifications(
   nodeId: string,
   type: string,
   permissions: ArchetypeNodePermissionDto[],
-): AtlasEntity['classifications'] {
-  const classifications: AtlasEntity['classifications'] = [];
+): AtlasArchetypeEntityDto['classifications'] {
+  const classifications: AtlasArchetypeEntityDto['classifications'] = [];
   classifications.push({
-    typeName: isLeaf
+    typeName: (isLeaf
       ? 'leaf_node'
       : type === 'root'
         ? 'root_node'
-        : 'branch_node',
-  });
+        : 'branch_node') as AtlasArchetypeNodeTypeName,
+    propagate: false,
+  } as AtlasSimpleClassificationDto);
   const permission = permissions.find((p) => p.id === nodeId)?.permission;
   if (permission) {
     classifications.push({
       typeName: 'archetype_node_analysis_permissions',
+      propagate: true,
+      removePropagationsOnEntityDelete: true,
       attributes: { access_level: permission },
-    });
+    } as AtlasArchetypeAnalysisPermissionClassificationDto);
   }
   return classifications;
 }

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -23,6 +23,8 @@ import {
   AtlasSubmitArchetypeEntityDto,
 } from 'src/atlas/dto';
 
+import { customAlphabet } from 'nanoid';
+
 type ArchetypeJobData = {
   owner: string;
   projectId: string;
@@ -33,6 +35,8 @@ type ArchetypeJobData = {
 @Processor('atlas-queue')
 export class AtlasProcessor {
   private readonly logger = new Logger(AtlasProcessor.name);
+  private readonly customNanoidAlphabet =
+    '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
   constructor(
     private readonly docker: DockerService,
     private readonly atlas: AtlasService,
@@ -54,34 +58,27 @@ export class AtlasProcessor {
     );
   }
 
-  @Process('process-add-archetype')
-  async handleAddArchetypeJob(job: Job): Promise<string> {
+  @Process('process-update-archetype')
+  async handleUpdateArchetypeJob(job: Job): Promise<string> {
     const { owner, projectId, archetype }: ArchetypeJobData = job.data;
     this.logger.log(
-      `Handling 'process-add-archetype' job for projectId: ${projectId}...`,
+      `Handling 'process-update-archetype' job for projectId: ${projectId}...`,
     );
 
-    // init negative guid
-    let negativeGuid = -2;
-
-    // nextGuid function
-    const nextGuid = () => String(negativeGuid--);
-
-    // Accumulators for entities and relationships
     const entities: AtlasSubmitArchetypeEntityDto[] = [];
-    const parentLookup: Record<string, string> = {};
 
     // Add archetype_template entity
     const archetypeTemplateBody: AtlasSubmitArchetypeEntityDto = {
       typeName: AtlasArchetypeTypeName.Template,
+      guid: archetype.archetypeId,
       attributes: {
         owner: owner,
         name: archetype.name,
         // TODO: is this needed?
         projectId: projectId,
         // TODO: decide what is best to have as the name here
-        qualifiedName: `${projectId}@${archetype.name.replace(/\s+/g, '_').toLowerCase()}`,
-        status: 'DRAFT',
+        qualifiedName: `${projectId}@${customAlphabet(this.customNanoidAlphabet, 6)()}`,
+        status: archetype.status,
       },
       relationshipAttributes: {
         instance: {
@@ -92,9 +89,59 @@ export class AtlasProcessor {
         },
       },
     };
-    // this.logger.debug(
-    //   `Submitting new template:\n ${JSON.stringify(archetypeTemplateBody, null, 2)}`,
-    // );
+    entities.push(
+      archetypeTemplateBody,
+      ...this.archetypeTemplateToAtlasEntitities(
+        owner,
+        projectId,
+        archetype,
+        true,
+      ),
+    );
+
+    // // TODO: Proper error handling
+    await this.atlas.post<AtlasPostEntityResponseDto>('/entity/bulk', {
+      entities: entities,
+    });
+
+    await this.prisma.project.update({
+      where: { projectId: projectId },
+      data: { lastModified: new Date() },
+    });
+    this.logger.log(
+      `Handling 'process-update-archetype' job for arechetypeId ${archetype.archetypeId} DONE!`,
+    );
+    return archetype.archetypeId;
+  }
+
+  @Process('process-add-archetype')
+  async handleAddArchetypeJob(job: Job): Promise<string> {
+    const { owner, projectId, archetype }: ArchetypeJobData = job.data;
+    this.logger.log(
+      `Handling 'process-add-archetype' job for projectId: ${projectId}...`,
+    );
+
+    // Add archetype_template entity
+    const archetypeTemplateBody: AtlasSubmitArchetypeEntityDto = {
+      typeName: AtlasArchetypeTypeName.Template,
+      attributes: {
+        owner: owner,
+        name: archetype.name,
+        // TODO: is this needed?
+        projectId: projectId,
+        // TODO: decide what is best to have as the name here
+        qualifiedName: `${projectId}@${customAlphabet(this.customNanoidAlphabet, 6)()}`,
+        status: archetype.status,
+      },
+      relationshipAttributes: {
+        instance: {
+          typeName: 'rdbms_instance',
+          uniqueAttributes: {
+            projectId,
+          },
+        },
+      },
+    };
 
     // TODO: Proper error handling
     const templateResponse = await this.atlas.post<AtlasPostEntityResponseDto>(
@@ -103,80 +150,11 @@ export class AtlasProcessor {
       undefined,
     );
 
-    // this.logger.debug(
-    //   `POST template response:\n ${JSON.stringify(templateResponse, null, 2)}`,
-    // );
-
     // store real archetypeId ref (Atlas GUID)
     archetype.archetypeId = Object.values(templateResponse?.guidAssignments)[0];
 
-    const [columns, nodes] = archetype.nodes.reduce<
-      [ArchetypeNodeDto[], ArchetypeNodeDto[]]
-    >(
-      (acc, node) => {
-        if (node.type === 'column') acc[0].push(node);
-        else acc[1].push(node);
-        return acc;
-      },
-      [[], []],
-    );
-    const columnEdges = archetype.edges.filter((edge: ArchetypeEdgeDto) =>
-      columns.find((e) => e.id === edge.target),
-    );
-    const archetypeNodes = nodes.map((node: ArchetypeNodeDto) => {
-      const columnGuid = columnEdges.find((e) => e.source === node.id)?.target;
-      const parentId = archetype.edges.find(
-        (e) => e.target === node.id,
-      )?.source;
-      const currentGuid = nextGuid(); // increase neg guid
-      parentLookup[node.id] = currentGuid;
-      return {
-        guid: currentGuid,
-        typeName: AtlasArchetypeTypeName.Node,
-        status: 'ACTIVE',
-        attributes: {
-          label: node.data.label,
-          name: `${archetype.name} ${node.id}`,
-          owner: owner,
-          level: node.data.level,
-          qualifiedName: `${projectId}@${archetype.archetypeId}@${node.id}`,
-          position: {
-            x: node.position.x,
-            y: node.position.y,
-          },
-        },
-        classifications: mergeClassifications(
-          columnGuid ? true : false, // isLeaf node
-          node.id,
-          node.type,
-          archetype.permissions,
-        ),
-        relationshipAttributes: {
-          template: {
-            guid: archetype.archetypeId,
-            typeName: 'archetype_template',
-          },
-          ...(parentId
-            ? {
-                parent_node: {
-                  typeName: 'archetype_node',
-                  guid: parentLookup[parentId],
-                },
-              }
-            : {}),
-          ...(columnGuid
-            ? { column: { guid: columnGuid, typeName: 'rdbms_column' } }
-            : {}),
-        },
-      };
-    });
-
-    entities.push(...archetypeNodes);
-
-    // this.logger.debug(
-    //   `Submitting entities:\n ${JSON.stringify(entities, null, 2)}`,
-    // );
-
+    const entities: AtlasSubmitArchetypeEntityDto[] =
+      this.archetypeTemplateToAtlasEntitities(owner, projectId, archetype);
     // TODO: Proper error handling
     await this.atlas.post<AtlasPostEntityResponseDto>('/entity/bulk', {
       entities: entities,
@@ -187,15 +165,17 @@ export class AtlasProcessor {
       data: { lastModified: new Date() },
     });
     this.logger.log(
-      `Handling 'process-add-archetype' job for projectId ${projectId} done!`,
+      `Handling 'process-add-archetype' job for projectId ${projectId} DONE!\nCreated archetype: ${archetype.archetypeId}`,
     );
     return archetype.archetypeId;
   }
 
   @Process('process-delete-archetype')
-  async handleDeleteTemplateJob(job: Job) {
+  async handleDeleteArchetypeJob(job: Job) {
     const { archetypeId, projectId } = job.data;
-
+    this.logger.log(
+      `Handling 'process-delete-archetype' job archetype ${archetypeId}...`,
+    );
     await this.atlas.delete('/entity/guid/' + archetypeId);
     await this.prisma.project.update({
       where: {
@@ -205,9 +185,13 @@ export class AtlasProcessor {
         lastModified: new Date(),
       },
     });
+    this.logger.log(
+      `Handling 'process-delete-archetype' job archetype ${archetypeId} DONE!`,
+    );
   }
 
   // TODO: remove redundant function as using classifiers for permissions now
+  // Remove after settling an update function
   @Process('process-add-permissions')
   async handleAddPermissionsJob(job: Job) {
     const { projectId, permissions } = job.data;
@@ -426,65 +410,153 @@ export class AtlasProcessor {
       },
     });
   }
-}
 
-function mergeClassifications(
-  isLeaf: boolean,
-  nodeId: string,
-  type: string,
-  permissions: ArchetypeNodePermissionDto[],
-): AtlasArchetypeEntityDto['classifications'] {
-  const classifications: AtlasArchetypeEntityDto['classifications'] = [];
-  classifications.push({
-    typeName: (isLeaf
-      ? 'leaf_node'
-      : type === 'root'
-        ? 'root_node'
-        : 'branch_node') as AtlasArchetypeNodeTypeName,
-    propagate: false,
-  } as AtlasSimpleClassificationDto);
-  const permission = permissions.find((p) => p.id === nodeId)?.permission;
-  if (permission) {
-    classifications.push({
-      typeName: 'archetype_node_analysis_permissions',
-      propagate: true,
-      removePropagationsOnEntityDelete: true,
-      attributes: { access_level: permission },
-    } as AtlasArchetypeAnalysisPermissionClassificationDto);
+  private archetypeTemplateToAtlasEntitities(
+    owner: string,
+    projectId: string,
+    archetype: ArchetypeDto,
+    isUpdate: boolean = false,
+  ): AtlasSubmitArchetypeEntityDto[] {
+    // init negative guid
+    let negativeGuid = -2;
+
+    // nextGuid function
+    const nextGuid = () => String(negativeGuid--);
+
+    // Lookup for parent entities
+    const parentLookup: Record<string, string> = {};
+
+    const [columns, nodes] = archetype.nodes.reduce<
+      [ArchetypeNodeDto[], ArchetypeNodeDto[]]
+    >(
+      (acc, node) => {
+        if (node.type === 'column') acc[0].push(node);
+        else acc[1].push(node);
+        return acc;
+      },
+      [[], []],
+    );
+    const columnEdges = archetype.edges.filter((edge: ArchetypeEdgeDto) =>
+      columns.find((e) => e.id === edge.target),
+    );
+    return nodes.map((node: ArchetypeNodeDto) => {
+      const columnGuid = columnEdges.find((e) => e.source === node.id)?.target;
+      const parentId = archetype.edges.find(
+        (e) => e.target === node.id,
+      )?.source;
+      const currentGuid = nextGuid(); // increase neg guid
+
+      // Lookup for parent-child relationship
+      parentLookup[node.id] = isUpdate
+        ? `${projectId}@${archetype.archetypeId}@${node.id}`
+        : currentGuid;
+      return {
+        ...(isUpdate ? {} : { guid: currentGuid }),
+        typeName: AtlasArchetypeTypeName.Node,
+        status: 'ACTIVE',
+        attributes: {
+          label: node.data.label,
+          // NOTE: needed for analysis SDK JSONSchema
+          name: node.data.label,
+          owner: owner,
+          level: node.data.level,
+          qualifiedName: `${projectId}@${archetype.archetypeId}@${node.id}`,
+          position: {
+            x: node.position.x,
+            y: node.position.y,
+          },
+        },
+        classifications: this.mergeClassifications(
+          columnGuid ? true : false, // isLeaf node
+          node.id,
+          node.type,
+          archetype.permissions,
+        ),
+        relationshipAttributes: {
+          template: {
+            guid: archetype.archetypeId,
+            typeName: 'archetype_template',
+          },
+          ...(parentId
+            ? {
+                parent_node: {
+                  typeName: 'archetype_node',
+                  ...(isUpdate
+                    ? {
+                        uniqueAttributes: {
+                          qualifiedName: parentLookup[parentId],
+                        },
+                      }
+                    : { guid: parentLookup[parentId] }),
+                },
+              }
+            : {}),
+          ...(columnGuid
+            ? { column: { guid: columnGuid, typeName: 'rdbms_column' } }
+            : {}),
+        },
+      };
+    });
   }
-  return classifications;
+
+  private mergeClassifications(
+    isLeaf: boolean,
+    nodeId: string,
+    type: string,
+    permissions: ArchetypeNodePermissionDto[],
+  ): AtlasArchetypeEntityDto['classifications'] {
+    const classifications: AtlasArchetypeEntityDto['classifications'] = [];
+    classifications.push({
+      typeName: (isLeaf
+        ? 'leaf_node'
+        : type === 'root'
+          ? 'root_node'
+          : 'branch_node') as AtlasArchetypeNodeTypeName,
+      propagate: false,
+    } as AtlasSimpleClassificationDto);
+    const permission = permissions.find((p) => p.id === nodeId)?.permission;
+    if (permission) {
+      classifications.push({
+        typeName: 'archetype_node_analysis_permissions',
+        propagate: true,
+        removePropagationsOnEntityDelete: true,
+        attributes: { access_level: permission },
+      } as AtlasArchetypeAnalysisPermissionClassificationDto);
+    }
+    return classifications;
+  }
+
+  private addParent(
+    archetypeId: string,
+    nodeId: string,
+    edges: ArchetypeEdgeDto[],
+  ) {
+    const parent = edges.find((e) => e.target === nodeId)?.source;
+    return parent
+      ? {
+          parent_node: {
+            typeName: 'archetype_node',
+            uniqueAttributes: {
+              qualifiedName: `${archetypeId}@${parent}`,
+            },
+          },
+        }
+      : {};
+  }
+
+  private addColumn(
+    archetypeId: string,
+    nodeId: string,
+    columnEdges: ArchetypeEdgeDto[],
+  ) {
+    const columnGuid = columnEdges.find((e) => e.source === nodeId)?.target;
+    return parent
+      ? {
+          column: {
+            typeName: 'column',
+            guid: columnGuid,
+          },
+        }
+      : {};
+  }
 }
-
-// function addParent(
-//   archetypeId: string,
-//   nodeId: string,
-//   edges: ArchetypeEdgeDto[],
-// ) {
-//   const parent = edges.find((e) => e.target === nodeId)?.source;
-//   return parent
-//     ? {
-//         parent_node: {
-//           typeName: 'archetype_node',
-//           uniqueAttributes: {
-//             qualifiedName: `${archetypeId}@${parent}`,
-//           },
-//         },
-//       }
-//     : {};
-// }
-
-// function addColumn(
-//   archetypeId: string,
-//   nodeId: string,
-//   columnEdges: ArchetypeEdgeDto[],
-// ) {
-//   const columnGuid = columnEdges.find((e) => e.source === nodeId)?.target;
-//   return parent
-//     ? {
-//         column: {
-//           typeName: 'column',
-//           guid: columnGuid,
-//         },
-//       }
-//     : {};
-// }

--- a/src/queue/queue.service.ts
+++ b/src/queue/queue.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bull';
 import { Queue } from 'bull';
 import { ArchetypeDto } from 'src/archetype/dto';
@@ -6,6 +6,7 @@ import { DatabaseInfoDto } from 'src/connection_request/dto';
 
 @Injectable()
 export class QueueService {
+  private readonly logger = new Logger(QueueService.name);
   constructor(@InjectQueue('atlas-queue') private atlasQueue: Queue) {}
 
   async dataBrokerJob(
@@ -14,6 +15,9 @@ export class QueueService {
     requestId: string,
     database: DatabaseInfoDto,
   ) {
+    this.logger.log(
+      `New 'process-data-broker' submitted to queue with requestId: ${requestId}`,
+    );
     return await this.atlasQueue.add(
       'process-data-broker',
       {
@@ -23,7 +27,7 @@ export class QueueService {
         database,
       },
       {
-        jobId: `process-data-broker:${projectId}`,
+        jobId: `process-data-broker:${requestId}`,
         attempts: 5,
         backoff: 10000,
       },
@@ -31,6 +35,9 @@ export class QueueService {
   }
 
   async addArchetypeJob(owner: string, archetype: ArchetypeDto) {
+    this.logger.log(
+      `New 'process-add-archetype' submitted to queue for projectId: ${archetype.projectId}`,
+    );
     return await this.atlasQueue.add(
       'process-add-archetype',
       {
@@ -46,6 +53,9 @@ export class QueueService {
   }
 
   async deleteTemplateJob(projectId: string, archetypeId: string) {
+    this.logger.log(
+      `New 'process-delete-archetype' submitted to queue with archetypeId: ${archetypeId}`,
+    );
     return await this.atlasQueue.add(
       'process-delete-archetype',
       {

--- a/src/queue/queue.service.ts
+++ b/src/queue/queue.service.ts
@@ -14,55 +14,63 @@ export class QueueService {
     requestId: string,
     database: DatabaseInfoDto,
   ) {
-    const postData = {
-      ownerId: ownerId,
-      projectId: projectId,
-      requestId: requestId,
-      database: database,
-    };
-    return await this.atlasQueue.add('process-data-broker', postData, {
-      jobId: `process-data-broker:${projectId}`,
-      attempts: 5,
-      backoff: 10000,
-    });
+    return await this.atlasQueue.add(
+      'process-data-broker',
+      {
+        ownerId,
+        projectId,
+        requestId,
+        database,
+      },
+      {
+        jobId: `process-data-broker:${projectId}`,
+        attempts: 5,
+        backoff: 10000,
+      },
+    );
   }
 
-  async addArchetypeJob(owner: string, dbId: string, archetype: ArchetypeDto) {
-    const parsedMapping = JSON.parse(archetype.columnMapping);
-    const parsedTemplate = JSON.parse(archetype.archetype);
-    const postData = {
-      owner: owner,
-      dbId: dbId,
-      projectId: archetype.projectId,
-      columnMapping: parsedMapping,
-      template: parsedTemplate,
-    };
-    return await this.atlasQueue.add('process-add-archetype', postData, {
-      attempts: 5,
-      backoff: 10000,
-    });
+  async addArchetypeJob(owner: string, archetype: ArchetypeDto) {
+    return await this.atlasQueue.add(
+      'process-add-archetype',
+      {
+        owner,
+        projectId: archetype.projectId,
+        archetype,
+      },
+      {
+        attempts: 5,
+        backoff: 10000,
+      },
+    );
   }
 
-  async deleteTemplateJob(archetype: ArchetypeDto) {
-    const postData = {
-      templateId: archetype.archetypeId,
-      projectId: archetype.projectId,
-    };
-    return await this.atlasQueue.add('process-delete-archetype', postData, {
-      attempts: 5,
-      backoff: 10000,
-    });
+  async deleteTemplateJob(projectId: string, archetypeId: string) {
+    return await this.atlasQueue.add(
+      'process-delete-archetype',
+      {
+        projectId,
+        archetypeId,
+      },
+      {
+        attempts: 5,
+        backoff: 10000,
+      },
+    );
   }
 
   async addPermissionsJob(permissions: string, projectId: string) {
-    const postData = {
-      permissions: permissions,
-      projectId: projectId,
-    };
-    return await this.atlasQueue.add('process-add-permissions', postData, {
-      attempts: 5,
-      backoff: 10000,
-    });
+    return await this.atlasQueue.add(
+      'process-add-permissions',
+      {
+        permissions,
+        projectId,
+      },
+      {
+        attempts: 5,
+        backoff: 10000,
+      },
+    );
   }
 
   async getJobResult(jobId: number | string) {

--- a/src/queue/queue.service.ts
+++ b/src/queue/queue.service.ts
@@ -16,7 +16,7 @@ export class QueueService {
     database: DatabaseInfoDto,
   ) {
     this.logger.log(
-      `New 'process-data-broker' submitted to queue with requestId: ${requestId}`,
+      `Submitting 'process-data-broker' job to queue with requestId ${requestId}`,
     );
     return await this.atlasQueue.add(
       'process-data-broker',
@@ -36,7 +36,7 @@ export class QueueService {
 
   async addArchetypeJob(owner: string, archetype: ArchetypeDto) {
     this.logger.log(
-      `New 'process-add-archetype' submitted to queue for projectId: ${archetype.projectId}`,
+      `Submitting 'process-add-archetype' job to queue for projectId ${archetype.projectId}`,
     );
     return await this.atlasQueue.add(
       'process-add-archetype',
@@ -52,9 +52,28 @@ export class QueueService {
     );
   }
 
-  async deleteTemplateJob(projectId: string, archetypeId: string) {
+  async updateArchetypeJob(owner: string, archetype: ArchetypeDto) {
     this.logger.log(
-      `New 'process-delete-archetype' submitted to queue with archetypeId: ${archetypeId}`,
+      `Submitting 'process-update-archetype' job to queue for archetypeId ${archetype.archetypeId}`,
+    );
+    return await this.atlasQueue.add(
+      'process-update-archetype',
+      {
+        owner,
+        projectId: archetype.projectId,
+        archetype,
+      },
+      {
+        // TODO: add jobid?
+        attempts: 5,
+        backoff: 10000,
+      },
+    );
+  }
+
+  async deleteArchetypeJob(projectId: string, archetypeId: string) {
+    this.logger.log(
+      `Submitting 'process-delete-archetype' job to queue with archetypeId ${archetypeId}...`,
     );
     return await this.atlasQueue.add(
       'process-delete-archetype',
@@ -69,6 +88,7 @@ export class QueueService {
     );
   }
 
+  // TODO: remove redundant method
   async addPermissionsJob(permissions: string, projectId: string) {
     return await this.atlasQueue.add(
       'process-add-permissions',


### PR DESCRIPTION
Changes:
- changed all archetype endpoints for fetchAll, get, add, update, delete and changed the corresponding services
- changed Analysis endpoints to work with new archetypes styles
- changed Atlas processor to process Archetype template to Atlas Entities and back
- Added DTOs for type safety

TODO:
- database endpoints also need refactoring
- DTOs can be refactored and simplified