### PR TITLE
feat(archetypes): archetype update implementation

### DIFF
--- a/src/archetype/archetype.controller.ts
+++ b/src/archetype/archetype.controller.ts
@@ -86,7 +86,6 @@ export class ArchetypeController {
 
   @UseGuards(ResourceGuard)
   @Scopes('view, edit')
-  @Get(':projectId')
   @Delete(':projectId/:archetypeId')
   @ApiOperation({ summary: 'Delete archetype for a project' })
   async deleteArchetype(

--- a/src/archetype/archetype.controller.ts
+++ b/src/archetype/archetype.controller.ts
@@ -6,6 +6,7 @@ import {
   Logger,
   Param,
   ParseUUIDPipe,
+  Patch,
   Post,
   Put,
   Req,
@@ -53,28 +54,34 @@ export class ArchetypeController {
   @Scopes('view, edit')
   @Post(':projectId')
   @ApiOperation({ summary: 'Create archetype for a project' })
-  createArchetype(
-    @Param('projectId', ParseUUIDPipe) projectId: string,
-    @Body() archetype: ArchetypeDto,
-    @Req() request: Request,
-  ) {
+  createArchetype(@Body() archetype: ArchetypeDto, @Req() request: Request) {
     const username = request.auth.payload.preferred_username.toString();
     return this.archetypeService.createArchetype(username, archetype);
   }
 
-  // TODO: needs further investigation of how best to update an archetype in atlas
+  // TODO: classifications needs to be updated in a separate classification call
   @UseGuards(ResourceGuard)
   @Scopes('view, edit')
   @Put(':projectId/:archetypeId')
   @ApiOperation({ summary: 'Update archetype for a project' })
-  updateArchetype(
+  updateArchetype(@Body() archetype: ArchetypeDto) {
+    return this.archetypeService.updateArchetype(archetype);
+  }
+
+  @UseGuards(ResourceGuard)
+  @Scopes('view, edit')
+  @Patch(':projectId/:archetypeId')
+  @ApiOperation({ summary: 'Update archetype details for a project' })
+  updateArchetypeDetails(
     @Param('projectId', ParseUUIDPipe) projectId: string,
     @Param('archetypeId', ParseUUIDPipe) archetypeId: string,
-    @Body() archetype: ArchetypeDto,
-    @Req() request: Request,
+    @Body() attributes: unknown,
   ) {
-    const username = request.auth.payload.preferred_username.toString();
-    return this.archetypeService.updateArchetype(username, archetype);
+    return this.archetypeService.updateArchetypeDetails(
+      projectId,
+      archetypeId,
+      attributes,
+    );
   }
 
   @UseGuards(ResourceGuard)

--- a/src/archetype/archetype.controller.ts
+++ b/src/archetype/archetype.controller.ts
@@ -13,194 +13,13 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ArchetypeService } from './archetype.service';
-import { ArchetypeDto, ArchetypeStatus } from './dto';
+import { ArchetypeDto } from './dto';
 import { Request } from 'express';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 
 import { Resource } from 'src/common/decorators/resource.decorator';
 import { Scopes } from 'src/common/decorators/scopes.decorator';
 import { ResourceGuard } from 'src/common/guards/resource.guard';
-
-const testArchetype = {
-  projectId: '638c6f81-00c8-47f4-82ec-6b94240e757d',
-  name: 'Test Draft Update 4',
-  archetypeId: 'Xa7BAIWZCA8u',
-  status: ArchetypeStatus.DRAFT,
-  nodes: [
-    {
-      id: 'node_5',
-      data: {
-        label: 'Heart rate',
-        level: 2,
-      },
-      position: {
-        x: 242,
-        y: 415.85938,
-      },
-      type: 'category',
-    },
-    {
-      id: '2697b3ce-937e-47bd-b719-b2bd5a3ee481',
-      data: {
-        label: 'heart_rate',
-        level: 3,
-      },
-      position: {
-        x: 242,
-        y: 615.85938,
-      },
-      type: 'column',
-    },
-    {
-      id: 'node_0',
-      data: {
-        label: 'Person',
-        level: 0,
-      },
-      position: {
-        x: 320,
-        y: 200,
-      },
-      type: 'root',
-    },
-    {
-      id: 'node_2',
-      data: {
-        label: 'Health',
-        level: 1,
-      },
-      position: {
-        x: 346,
-        y: 316.85938,
-      },
-      type: 'category',
-    },
-    {
-      id: 'node_3',
-      data: {
-        label: 'Diagnosis',
-        level: 1,
-      },
-      position: {
-        x: 722,
-        y: 326.85938,
-      },
-      type: 'category',
-    },
-    {
-      id: '320eec06-b6d3-40b6-9567-1a7aed31ec00',
-      data: {
-        label: 'diagnosis',
-        level: 2,
-      },
-      position: {
-        x: 722,
-        y: 526.85938,
-      },
-      type: 'column',
-    },
-    {
-      id: 'node_1',
-      data: {
-        label: 'Demographics',
-        level: 1,
-      },
-      position: {
-        x: -9,
-        y: 321.85938,
-      },
-      type: 'category',
-    },
-    {
-      id: 'node_4',
-      data: {
-        label: 'Blood pressure',
-        level: 2,
-      },
-      position: {
-        x: 497,
-        y: 406.85938,
-      },
-      type: 'category',
-    },
-    {
-      id: '35dbb951-d8fb-4580-b8de-09d763d31a27',
-      data: {
-        label: 'blood_pressure',
-        level: 3,
-      },
-      position: {
-        x: 497,
-        y: 606.85938,
-      },
-      type: 'column',
-    },
-  ],
-  edges: [
-    {
-      id: 'edge_node_2_node_5',
-      source: 'node_2',
-      target: 'node_5',
-    },
-    {
-      source: 'node_5',
-      target: '2697b3ce-937e-47bd-b719-b2bd5a3ee481',
-      id: 'edge_node_5_2697b3ce-937e-47bd-b719-b2bd5a3ee481',
-    },
-    {
-      id: 'edge_node_0_node_2',
-      source: 'node_0',
-      target: 'node_2',
-    },
-    {
-      id: 'edge_node_0_node_3',
-      source: 'node_0',
-      target: 'node_3',
-    },
-    {
-      source: 'node_3',
-      target: '320eec06-b6d3-40b6-9567-1a7aed31ec00',
-      id: 'edge_node_3_320eec06-b6d3-40b6-9567-1a7aed31ec00',
-    },
-    {
-      id: 'edge_node_0_node_1',
-      source: 'node_0',
-      target: 'node_1',
-    },
-    {
-      id: 'edge_node_2_node_4',
-      source: 'node_2',
-      target: 'node_4',
-    },
-    {
-      source: 'node_4',
-      target: '35dbb951-d8fb-4580-b8de-09d763d31a27',
-      id: 'edge_node_4_35dbb951-d8fb-4580-b8de-09d763d31a27',
-    },
-  ],
-  permissions: [
-    {
-      id: 'node_5',
-      permission: 'DETAILED',
-    },
-    {
-      id: 'node_2',
-      permission: 'DETAILED',
-    },
-    {
-      id: 'node_3',
-      permission: 'HIGH_LEVEL',
-    },
-    {
-      id: 'node_1',
-      permission: 'DETAILED',
-    },
-    {
-      id: 'node_4',
-      permission: 'DETAILED',
-    },
-  ],
-} as ArchetypeDto;
 
 @ApiTags('Archetype')
 @Controller('archetype')
@@ -214,10 +33,6 @@ export class ArchetypeController {
   @Get(':projectId')
   @ApiOperation({ summary: 'Get list of archetypes for a project' })
   async getArchetypes(@Param('projectId', ParseUUIDPipe) projectId: string) {
-    await this.archetypeService.updateArchetype(testArchetype);
-    // const response =
-    //   await this.archetypeService.getAnalysisArchetype(projectId);
-    // this.logger.debug(response);
     return await this.archetypeService.fetchArchetypes(projectId);
   }
 

--- a/src/archetype/archetype.controller.ts
+++ b/src/archetype/archetype.controller.ts
@@ -13,13 +13,194 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ArchetypeService } from './archetype.service';
-import { ArchetypeDto } from './dto';
+import { ArchetypeDto, ArchetypeStatus } from './dto';
 import { Request } from 'express';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 
 import { Resource } from 'src/common/decorators/resource.decorator';
 import { Scopes } from 'src/common/decorators/scopes.decorator';
 import { ResourceGuard } from 'src/common/guards/resource.guard';
+
+const testArchetype = {
+  projectId: '638c6f81-00c8-47f4-82ec-6b94240e757d',
+  name: 'Test Draft Update 4',
+  archetypeId: 'Xa7BAIWZCA8u',
+  status: ArchetypeStatus.DRAFT,
+  nodes: [
+    {
+      id: 'node_5',
+      data: {
+        label: 'Heart rate',
+        level: 2,
+      },
+      position: {
+        x: 242,
+        y: 415.85938,
+      },
+      type: 'category',
+    },
+    {
+      id: '2697b3ce-937e-47bd-b719-b2bd5a3ee481',
+      data: {
+        label: 'heart_rate',
+        level: 3,
+      },
+      position: {
+        x: 242,
+        y: 615.85938,
+      },
+      type: 'column',
+    },
+    {
+      id: 'node_0',
+      data: {
+        label: 'Person',
+        level: 0,
+      },
+      position: {
+        x: 320,
+        y: 200,
+      },
+      type: 'root',
+    },
+    {
+      id: 'node_2',
+      data: {
+        label: 'Health',
+        level: 1,
+      },
+      position: {
+        x: 346,
+        y: 316.85938,
+      },
+      type: 'category',
+    },
+    {
+      id: 'node_3',
+      data: {
+        label: 'Diagnosis',
+        level: 1,
+      },
+      position: {
+        x: 722,
+        y: 326.85938,
+      },
+      type: 'category',
+    },
+    {
+      id: '320eec06-b6d3-40b6-9567-1a7aed31ec00',
+      data: {
+        label: 'diagnosis',
+        level: 2,
+      },
+      position: {
+        x: 722,
+        y: 526.85938,
+      },
+      type: 'column',
+    },
+    {
+      id: 'node_1',
+      data: {
+        label: 'Demographics',
+        level: 1,
+      },
+      position: {
+        x: -9,
+        y: 321.85938,
+      },
+      type: 'category',
+    },
+    {
+      id: 'node_4',
+      data: {
+        label: 'Blood pressure',
+        level: 2,
+      },
+      position: {
+        x: 497,
+        y: 406.85938,
+      },
+      type: 'category',
+    },
+    {
+      id: '35dbb951-d8fb-4580-b8de-09d763d31a27',
+      data: {
+        label: 'blood_pressure',
+        level: 3,
+      },
+      position: {
+        x: 497,
+        y: 606.85938,
+      },
+      type: 'column',
+    },
+  ],
+  edges: [
+    {
+      id: 'edge_node_2_node_5',
+      source: 'node_2',
+      target: 'node_5',
+    },
+    {
+      source: 'node_5',
+      target: '2697b3ce-937e-47bd-b719-b2bd5a3ee481',
+      id: 'edge_node_5_2697b3ce-937e-47bd-b719-b2bd5a3ee481',
+    },
+    {
+      id: 'edge_node_0_node_2',
+      source: 'node_0',
+      target: 'node_2',
+    },
+    {
+      id: 'edge_node_0_node_3',
+      source: 'node_0',
+      target: 'node_3',
+    },
+    {
+      source: 'node_3',
+      target: '320eec06-b6d3-40b6-9567-1a7aed31ec00',
+      id: 'edge_node_3_320eec06-b6d3-40b6-9567-1a7aed31ec00',
+    },
+    {
+      id: 'edge_node_0_node_1',
+      source: 'node_0',
+      target: 'node_1',
+    },
+    {
+      id: 'edge_node_2_node_4',
+      source: 'node_2',
+      target: 'node_4',
+    },
+    {
+      source: 'node_4',
+      target: '35dbb951-d8fb-4580-b8de-09d763d31a27',
+      id: 'edge_node_4_35dbb951-d8fb-4580-b8de-09d763d31a27',
+    },
+  ],
+  permissions: [
+    {
+      id: 'node_5',
+      permission: 'DETAILED',
+    },
+    {
+      id: 'node_2',
+      permission: 'DETAILED',
+    },
+    {
+      id: 'node_3',
+      permission: 'HIGH_LEVEL',
+    },
+    {
+      id: 'node_1',
+      permission: 'DETAILED',
+    },
+    {
+      id: 'node_4',
+      permission: 'DETAILED',
+    },
+  ],
+} as ArchetypeDto;
 
 @ApiTags('Archetype')
 @Controller('archetype')
@@ -33,6 +214,10 @@ export class ArchetypeController {
   @Get(':projectId')
   @ApiOperation({ summary: 'Get list of archetypes for a project' })
   async getArchetypes(@Param('projectId', ParseUUIDPipe) projectId: string) {
+    await this.archetypeService.updateArchetype(testArchetype);
+    // const response =
+    //   await this.archetypeService.getAnalysisArchetype(projectId);
+    // this.logger.debug(response);
     return await this.archetypeService.fetchArchetypes(projectId);
   }
 

--- a/src/archetype/archetype.controller.ts
+++ b/src/archetype/archetype.controller.ts
@@ -42,7 +42,7 @@ export class ArchetypeController {
   @ApiOperation({ summary: 'Get project archetype details' })
   async getArchetype(
     @Param('projectId', ParseUUIDPipe) projectId: string,
-    @Param('archetypeId', ParseUUIDPipe) archetypeId: string,
+    @Param('archetypeId') archetypeId: string,
   ) {
     return await this.archetypeService.getArchetypeDetails(
       projectId,
@@ -74,7 +74,7 @@ export class ArchetypeController {
   @ApiOperation({ summary: 'Update archetype details for a project' })
   updateArchetypeDetails(
     @Param('projectId', ParseUUIDPipe) projectId: string,
-    @Param('archetypeId', ParseUUIDPipe) archetypeId: string,
+    @Param('archetypeId') archetypeId: string,
     @Body() attributes: unknown,
   ) {
     return this.archetypeService.updateArchetypeDetails(
@@ -91,7 +91,7 @@ export class ArchetypeController {
   @ApiOperation({ summary: 'Delete archetype for a project' })
   async deleteArchetype(
     @Param('projectId', ParseUUIDPipe) projectId: string,
-    @Param('archetypeId', ParseUUIDPipe) archetypeId: string,
+    @Param('archetypeId') archetypeId: string,
   ) {
     return await this.archetypeService.deleteArchetype(projectId, archetypeId);
   }

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -234,79 +234,94 @@ export class ArchetypeService {
       },
       attributes: ['name', '__guid'],
     };
+    try {
+      const res = await this.atlas.post<AtlasSearchBasicHeadlessResponseDto>(
+        '/search/basic',
+        body,
+        token,
+      );
+      if (res.approximateCount) {
+        const properties: Record<string, object> = {};
+        const schema = {
+          $schema: 'https://json-schema.org/draft/2020-12/schema#',
+          title: res.attributes?.values[0][0],
+          type: 'object',
+          properties,
+        };
 
-    const res = await this.atlas.post<AtlasSearchBasicHeadlessResponseDto>(
-      '/search/basic',
-      body,
-      token,
-    );
-    if (res.approximateCount) {
-      const properties: Record<string, object> = {};
-      const schema = {
-        $schema: 'https://json-schema.org/draft/2020-12/schema#',
-        title: res.attributes?.values[0][0],
-        type: 'object',
-        properties,
-      };
-
-      const templateGuid = res.attributes?.values[0][1];
-      const templateEntity =
-        await this.atlas.get<AtlasArchetypeEntityResponseDto>(
-          `/entity/guid/${templateGuid}`,
-          undefined,
-          token,
-        );
-
-      // TODO: handle errors
-      for (const key in templateEntity.referredEntities) {
-        const node = templateEntity.referredEntities[key];
-        // TODO: check if this is the best thing to use
-        const objectName = node.attributes?.label
-          .replace(/\s+/g, '_')
-          .toLowerCase();
-        const description = node.attributes?.label;
-        // check for node has children
-        if (node.relationshipAttributes?.child_nodes?.length) {
-          const type = 'object';
-          const properties: Record<string, object> = {};
-          schema.properties[objectName] = { type, properties };
-        }
-        // check if node has a column
-        if (node.relationshipAttributes?.column) {
-          const column = node.relationshipAttributes?.column;
-          const properties: Record<string, object> = {};
-          // TODO: handle errors
-          const { entity } = await this.atlas.get<AtlasEntityResponseDto>(
-            `/entity/guid/${column.guid}`,
+        const templateGuid = res.attributes?.values[0][1];
+        const templateEntity =
+          await this.atlas.get<AtlasArchetypeEntityResponseDto>(
+            `/entity/guid/${templateGuid}`,
             undefined,
             token,
           );
-          const jsonType = this.atlasTypeToJSONType(
-            entity.attributes?.data_type as string,
-          );
-          properties[objectName] = {
-            type: jsonType,
-            description,
-          };
 
-          // add nodes to parent
-          if (node.relationshipAttributes?.parent_node) {
-            const parentRef =
-              node.relationshipAttributes?.parent_node.displayText
-                .replace(/\s+/g, '_')
-                .toLowerCase();
-            schema.properties[parentRef]['properties'] = {
-              ...schema.properties[parentRef]['properties'],
-              ...properties,
+        // TODO: handle errors
+        for (const key in templateEntity.referredEntities) {
+          const node = templateEntity.referredEntities[key];
+          // TODO: check if this is the best thing to use
+          const objectName = node.attributes?.label
+            .replace(/\s+/g, '_')
+            .toLowerCase();
+          const description = node.attributes?.label;
+          // check for node has children
+          if (
+            node.relationshipAttributes?.child_nodes?.length &&
+            !schema.properties[objectName]
+          ) {
+            schema.properties[objectName] = this.initJsonObject();
+          }
+          // check if node has a column
+          if (node.relationshipAttributes?.column) {
+            const column = node.relationshipAttributes?.column;
+            const properties: Record<string, object> = {};
+            // TODO: handle errors
+            // TODO: this can be done parallel or with one bulk request
+            const { entity } = await this.atlas.get<AtlasEntityResponseDto>(
+              `/entity/guid/${column.guid}`,
+              undefined,
+              token,
+            );
+            const jsonType = this.atlasTypeToJSONType(
+              entity.attributes?.data_type as string,
+            );
+            properties[objectName] = {
+              type: jsonType,
+              description,
             };
-          } else {
-            schema.properties = { ...schema.properties, ...properties };
+
+            // add nodes to parent
+            if (node.relationshipAttributes?.parent_node) {
+              const parentRef =
+                node.relationshipAttributes?.parent_node.displayText
+                  .replace(/\s+/g, '_')
+                  .toLowerCase();
+              if (!schema.properties[parentRef]) {
+                schema.properties[parentRef] = this.initJsonObject();
+              }
+              schema.properties[parentRef]['properties'] = {
+                ...schema.properties[parentRef]['properties'],
+                ...properties,
+              };
+            } else {
+              schema.properties = { ...schema.properties, ...properties };
+            }
           }
         }
+        return schema;
       }
-      return schema;
+    } catch (error) {
+      this.logger.error(`Error getting Analysis Archetype structure`, error);
+      throw error;
     }
     return {};
+  }
+
+  private initJsonObject() {
+    const type = 'object';
+    const properties: Record<string, object> = {};
+    return { type, properties };
   }
 
   private atlasTypeToJSONType(dataType: string): string {

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -11,7 +11,9 @@ import {
 } from './dto';
 import {
   AtlasArchetypeEntityResponseDto,
+  AtlasArchetypeTypeName,
   AtlasEntityResponseDto,
+  AtlasPutEntityResponseDto,
   AtlasSearchBasicHeadlessResponseDto,
   AtlasSearchBasicResponseDto,
 } from 'src/atlas/dto';
@@ -27,7 +29,7 @@ export class ArchetypeService {
   async fetchArchetypes(projectId: string, token?: string) {
     // NOTE: can also remove headers to reduce payload
     const body = {
-      typeName: 'archetype_template',
+      typeName: AtlasArchetypeTypeName.Template,
       excludeDeletedEntities: true,
       includeClassificationAttributes: false,
       includeSubTypes: false,
@@ -55,12 +57,15 @@ export class ArchetypeService {
     );
     const entities = res?.entities ?? [];
     return entities.map((entity) => ({
-      id: entity.guid,
+      // use nanoid as the archetypeID
+      id: (entity.attributes?.qualifiedName as string).split('@')[1],
       name: entity.displayText,
       status: entity.attributes?.status,
       createdBy: entity.attributes?.owner,
-      created: entity.attributes?.__timestamp,
-      lastModified: entity.attributes?.__modificationTimestamp,
+      created: new Date(entity.attributes?.__timestamp as number),
+      lastModified: new Date(
+        entity.attributes?.__modificationTimestamp as number,
+      ),
     }));
   }
 
@@ -68,8 +73,30 @@ export class ArchetypeService {
     return await this.queue.addArchetypeJob(username, archetype);
   }
 
-  async updateArchetype(username: string, archetype: ArchetypeDto) {
-    return await this.queue.updateArchetypeJob(username, archetype);
+  async updateArchetype(archetype: ArchetypeDto) {
+    return await this.queue.updateArchetypeJob(archetype);
+  }
+
+  async updateArchetypeDetails(
+    projectId: string,
+    archetypeId: string,
+    attributes: unknown,
+    token?: string,
+  ) {
+    // TODO: handle errors
+    return await this.atlas.put<AtlasPutEntityResponseDto>(
+      `/entity/uniqueAttribute/type/${AtlasArchetypeTypeName.Template}`,
+      {
+        entity: {
+          typeName: AtlasArchetypeTypeName.Template,
+          attributes, // updated attributes
+        },
+      },
+      {
+        'attr:qualifiedName': `${projectId}@${archetypeId}`,
+      },
+      token,
+    );
   }
 
   async getArchetypeDetails(
@@ -79,8 +106,12 @@ export class ArchetypeService {
   ) {
     // TODO: handle errors
     const entityRes = await this.atlas.get<AtlasArchetypeEntityResponseDto>(
-      `/entity/guid/${archetypeId}`,
-      undefined,
+      `/entity/uniqueAttribute/type/${AtlasArchetypeTypeName.Template}`,
+      {
+        'attr:qualifiedName': `${projectId}@${archetypeId}`,
+        ignoreRelationships: false, // default false
+        minExtInfo: false, // default false
+      },
       token,
     );
 
@@ -137,7 +168,11 @@ export class ArchetypeService {
             label: columName,
             level: entity.attributes?.level + 1,
           },
-          position: entity.attributes?.position, // TODO: figure out where to put column, relative to node
+          // TODO: figure out where to put column, relative to node
+          position: {
+            x: entity.attributes?.position?.x,
+            y: entity.attributes?.position?.y + 200,
+          },
           type: ArchetypeNodeType.Column,
         };
         templateInfo.nodes.push(node);
@@ -148,18 +183,23 @@ export class ArchetypeService {
         };
         templateInfo.edges.push(edge);
       }
-
-      const analysisPermission = (() => {
-        const permission = entity.classifications?.find(
-          (c) => c.typeName === 'archetype_node_analysis_permissions',
-        );
-        return {
-          id: nodeId,
-          permission: (permission?.attributes?.access_level ??
-            'NONE') as ArchetypePermission,
-        };
-      })();
-      templateInfo.permissions.push(analysisPermission);
+      // add permissions (skip root)
+      if (entity.attributes?.level !== 0) {
+        const analysisPermission = (() => {
+          const permission = entity.classifications?.find(
+            (c) => c.typeName === 'archetype_node_analysis_permissions',
+          );
+          return permission
+            ? {
+                id: nodeId,
+                permission: permission?.attributes
+                  ?.access_level as ArchetypePermission,
+              }
+            : null;
+        })();
+        if (analysisPermission)
+          templateInfo.permissions.push(analysisPermission);
+      }
     }
 
     return templateInfo;
@@ -172,7 +212,7 @@ export class ArchetypeService {
   async getAnalysisArchetype(projectId: string, token?: string) {
     // get ID of PUBLISHED archetype
     const body = {
-      typeName: 'archetype_template',
+      typeName: AtlasArchetypeTypeName.Template,
       excludeDeletedEntities: true,
       includeSubClassifications: false,
       excludeHeaderAttributes: true,

--- a/src/archetype/dto/archetype.dto.ts
+++ b/src/archetype/dto/archetype.dto.ts
@@ -110,7 +110,7 @@ export class ArchetypeDto {
   projectId!: string;
 
   @IsOptional()
-  @IsUUID()
+  @IsString()
   archetypeId?: string;
 
   @IsDefined()

--- a/src/atlas/dto/atlas.dto.ts
+++ b/src/atlas/dto/atlas.dto.ts
@@ -140,6 +140,11 @@ export class AtlasMutatedEntitiesDto {
   @ValidateNested({ each: true })
   @Type(() => AtlasEntityDto)
   DELETE?: AtlasEntityDto[];
+
+  @IsOptional()
+  @ValidateNested({ each: true })
+  @Type(() => AtlasEntityDto)
+  PARTIAL_UPDATE?: AtlasEntityDto[];
 }
 
 export class AtlasEntityHeaderDto {
@@ -429,4 +434,10 @@ export class AtlasPostEntityResponseDto {
   @IsOptional()
   @IsObject()
   guidAssignments?: Record<string, string>;
+}
+
+export class AtlasPutEntityResponseDto extends AtlasPostEntityResponseDto {
+  @IsDefined()
+  @IsArray()
+  partialUpdatedEntities?: unknown[];
 }

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -36,7 +36,7 @@ type ArchetypeJobData = {
 export class AtlasProcessor {
   private readonly logger = new Logger(AtlasProcessor.name);
   private readonly customNanoidAlphabet =
-    '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz-';
   constructor(
     private readonly docker: DockerService,
     private readonly atlas: AtlasService,
@@ -59,24 +59,22 @@ export class AtlasProcessor {
 
   @Process('process-update-archetype')
   async handleUpdateArchetypeJob(job: Job) {
-    const { owner, projectId, archetype }: ArchetypeJobData = job.data;
+    const { projectId, archetype }: ArchetypeJobData = job.data;
     this.logger.log(
       `Handling 'process-update-archetype' job for projectId: ${projectId}...`,
     );
     try {
       const entities: AtlasSubmitArchetypeEntityDto[] = [];
 
+      const { columns, nodes } = this.separateColumnsNodes(archetype);
       // Add archetype_template entity
       const archetypeTemplateBody: AtlasSubmitArchetypeEntityDto = {
         typeName: AtlasArchetypeTypeName.Template,
-        guid: archetype.archetypeId,
         attributes: {
-          owner: owner,
           name: archetype.name,
-          // TODO: is this needed?
           projectId: projectId,
-          // TODO: decide what is best to have as the name here
-          qualifiedName: `${projectId}@${customAlphabet(this.customNanoidAlphabet, 6)()}`,
+          // using nanoid created in the beginning
+          qualifiedName: `${projectId}@${archetype.archetypeId}`,
           status: archetype.status,
         },
         relationshipAttributes: {
@@ -86,12 +84,21 @@ export class AtlasProcessor {
               projectId,
             },
           },
+          // NOTE: this deletes nodes that have been removed
+          nodes: nodes.map((node) => ({
+            typeName: AtlasArchetypeTypeName.Node,
+            uniqueAttributes: {
+              qualifiedName: `${projectId}@${archetype.archetypeId}@${node.id}`,
+            },
+          })),
         },
       };
+
       entities.push(
         archetypeTemplateBody,
         ...this.archetypeTemplateToAtlasEntitities(
-          owner,
+          columns,
+          nodes,
           projectId,
           archetype,
           true,
@@ -100,6 +107,7 @@ export class AtlasProcessor {
       await this.atlas.post<AtlasPostEntityResponseDto>('/entity/bulk', {
         entities: entities,
       });
+
       await this.prisma.project.update({
         where: { projectId: projectId },
         data: { lastModified: new Date() },
@@ -124,6 +132,8 @@ export class AtlasProcessor {
     );
     try {
       //  1. create archetype_template entity
+      // generate new unique archetypeId (nanoid)
+      archetype.archetypeId = customAlphabet(this.customNanoidAlphabet, 12)();
       const archetypeTemplateBody: AtlasSubmitArchetypeEntityDto = {
         typeName: AtlasArchetypeTypeName.Template,
         attributes: {
@@ -131,8 +141,8 @@ export class AtlasProcessor {
           name: archetype.name,
           // TODO: is this needed?
           projectId: projectId,
-          // TODO: decide what is best to have as the name here
-          qualifiedName: `${projectId}@${customAlphabet(this.customNanoidAlphabet, 6)()}`,
+          // nanoid is used later as archetypeId in frontend
+          qualifiedName: `${projectId}@${archetype.archetypeId}`,
           status: archetype.status,
         },
         relationshipAttributes: {
@@ -150,16 +160,25 @@ export class AtlasProcessor {
           { entity: archetypeTemplateBody },
           undefined,
         );
-      // 2. store real archetypeId ref (Atlas GUID)
-      archetype.archetypeId = Object.values(
-        templateResponse?.guidAssignments,
-      )[0];
+      // 2. store real archetype template ref (Atlas GUID)
+      const templateGuid = Object.values(templateResponse?.guidAssignments)[0];
       // this.logger.debug(
       //   `Template CREATE response:\n${JSON.stringify(templateResponse)}`,
       // );
       // 3. create archetype_node entities
+      const { columns, nodes } = this.separateColumnsNodes(archetype);
       const entities: AtlasSubmitArchetypeEntityDto[] =
-        this.archetypeTemplateToAtlasEntitities(owner, projectId, archetype);
+        this.archetypeTemplateToAtlasEntitities(
+          columns,
+          nodes,
+          projectId,
+          archetype,
+          false,
+          owner,
+          templateGuid,
+        );
+
+      this.logger.debug(JSON.stringify(entities));
       await this.atlas.post<AtlasPostEntityResponseDto>('/entity/bulk', {
         entities: entities,
       });
@@ -187,7 +206,13 @@ export class AtlasProcessor {
       `Handling 'process-delete-archetype' job archetype ${archetypeId}...`,
     );
     try {
-      await this.atlas.delete('/entity/guid/' + archetypeId);
+      await this.atlas.delete(
+        `/entity/uniqueAttribute/type/${AtlasArchetypeTypeName.Template}`,
+        {
+          'attr:qualifiedName': `${projectId}@${archetypeId}`,
+        },
+      );
+
       await this.prisma.project.update({
         where: {
           projectId: projectId,
@@ -427,10 +452,13 @@ export class AtlasProcessor {
   }
 
   private archetypeTemplateToAtlasEntitities(
-    owner: string,
+    columns: ArchetypeNodeDto[],
+    nodes: ArchetypeNodeDto[],
     projectId: string,
     archetype: ArchetypeDto,
     isUpdate: boolean = false,
+    owner?: string,
+    templateGuid?: string,
   ): AtlasSubmitArchetypeEntityDto[] {
     // init negative guid
     let negativeGuid = -2;
@@ -441,30 +469,28 @@ export class AtlasProcessor {
     // Lookup for parent entities
     const parentLookup: Record<string, string> = {};
 
-    const [columns, nodes] = archetype.nodes.reduce<
-      [ArchetypeNodeDto[], ArchetypeNodeDto[]]
-    >(
-      (acc, node) => {
-        if (node.type === 'column') acc[0].push(node);
-        else acc[1].push(node);
-        return acc;
-      },
-      [[], []],
-    );
+    // sort nodes by Id (needed for parent lookup)
+    nodes.sort((a, b) => a.id.localeCompare(b.id));
+
     const columnEdges = archetype.edges.filter((edge: ArchetypeEdgeDto) =>
       columns.find((e) => e.id === edge.target),
     );
+
     return nodes.map((node: ArchetypeNodeDto) => {
+      // get column if exists
       const columnGuid = columnEdges.find((e) => e.source === node.id)?.target;
+
       const parentId = archetype.edges.find(
         (e) => e.target === node.id,
       )?.source;
+
       const currentGuid = nextGuid(); // increase neg guid
 
       // Lookup for parent-child relationship
       parentLookup[node.id] = isUpdate
         ? `${projectId}@${archetype.archetypeId}@${node.id}`
         : currentGuid;
+
       return {
         ...(isUpdate ? {} : { guid: currentGuid }),
         typeName: AtlasArchetypeTypeName.Node,
@@ -481,16 +507,28 @@ export class AtlasProcessor {
             y: node.position.y,
           },
         },
-        classifications: this.mergeClassifications(
-          columnGuid ? true : false, // isLeaf node
-          node.id,
-          node.type,
-          archetype.permissions || [],
-        ),
+        ...(isUpdate
+          ? {}
+          : {
+              classifications: this.mergeClassifications(
+                columnGuid ? true : false, // isLeaf node
+                node.id,
+                node.type,
+                archetype.permissions || [],
+              ),
+            }),
         relationshipAttributes: {
           template: {
-            guid: archetype.archetypeId,
             typeName: 'archetype_template',
+            ...(templateGuid
+              ? {
+                  guid: templateGuid,
+                }
+              : {
+                  uniqueAttributes: {
+                    qualifiedName: `${projectId}@${archetype.archetypeId}`,
+                  },
+                }),
           },
           ...(parentId
             ? {
@@ -530,6 +568,7 @@ export class AtlasProcessor {
       propagate: false,
     } as AtlasSimpleClassificationDto);
     const permission = permissions?.find((p) => p.id === nodeId)?.permission;
+    this.logger.debug(`Node: ${nodeId}, Permission: ${permission}`);
     if (permission) {
       classifications.push({
         typeName: 'archetype_node_analysis_permissions',
@@ -573,5 +612,20 @@ export class AtlasProcessor {
           },
         }
       : {};
+  }
+
+  private separateColumnsNodes(archetype: ArchetypeDto) {
+    // separate columns from actual archetype_nodes
+    const [columns, nodes] = archetype.nodes.reduce<
+      [ArchetypeNodeDto[], ArchetypeNodeDto[]]
+    >(
+      (acc, node) => {
+        if (node.type === 'column') acc[0].push(node);
+        else acc[1].push(node);
+        return acc;
+      },
+      [[], []],
+    );
+    return { columns, nodes };
   }
 }

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -14,6 +14,7 @@ import {
 import {
   AtlasArchetypeAnalysisPermissionClassificationDto,
   AtlasArchetypeEntityDto,
+  AtlasArchetypeEntityResponseDto,
   AtlasArchetypeNodeTypeName,
   AtlasArchetypeTypeName,
   AtlasEntityResponseDto,
@@ -47,7 +48,7 @@ export class AtlasProcessor {
   async handleDataBrokerJob(job: Job) {
     const { ownerId, projectId, requestId, database } = job.data;
     this.logger.log(
-      `Handling 'process-data-broker' job for requestId: ${requestId}...`,
+      `Handling 'process-data-broker' for requestId ${requestId}...`,
     );
     return await this.docker.runDataBroker(
       ownerId,
@@ -57,79 +58,20 @@ export class AtlasProcessor {
     );
   }
 
-  @Process('process-update-archetype')
-  async handleUpdateArchetypeJob(job: Job) {
-    const { projectId, archetype }: ArchetypeJobData = job.data;
-    this.logger.log(
-      `Handling 'process-update-archetype' job for projectId: ${projectId}...`,
-    );
-    try {
-      const entities: AtlasSubmitArchetypeEntityDto[] = [];
-
-      const { columns, nodes } = this.separateColumnsNodes(archetype);
-      // Add archetype_template entity
-      const archetypeTemplateBody: AtlasSubmitArchetypeEntityDto = {
-        typeName: AtlasArchetypeTypeName.Template,
-        attributes: {
-          name: archetype.name,
-          projectId: projectId,
-          // using nanoid created in the beginning
-          qualifiedName: `${projectId}@${archetype.archetypeId}`,
-          status: archetype.status,
-        },
-        relationshipAttributes: {
-          instance: {
-            typeName: 'rdbms_instance',
-            uniqueAttributes: {
-              projectId,
-            },
-          },
-          // NOTE: this deletes nodes that have been removed
-          nodes: nodes.map((node) => ({
-            typeName: AtlasArchetypeTypeName.Node,
-            uniqueAttributes: {
-              qualifiedName: `${projectId}@${archetype.archetypeId}@${node.id}`,
-            },
-          })),
-        },
-      };
-
-      entities.push(
-        archetypeTemplateBody,
-        ...this.archetypeTemplateToAtlasEntitities(
-          columns,
-          nodes,
-          projectId,
-          archetype,
-          true,
-        ),
-      );
-      await this.atlas.post<AtlasPostEntityResponseDto>('/entity/bulk', {
-        entities: entities,
-      });
-
-      await this.prisma.project.update({
-        where: { projectId: projectId },
-        data: { lastModified: new Date() },
-      });
-      this.logger.log(
-        `Handling 'process-update-archetype' job for archetypeId ${archetype.archetypeId} DONE!`,
-      );
-      return archetype.archetypeId;
-    } catch (error) {
-      this.logger.error(
-        `Error updating archetype ${archetype.archetypeId}: `,
-        error,
-      );
-    }
-  }
-
   @Process('process-add-archetype')
   async handleAddArchetypeJob(job: Job) {
     const { owner, projectId, archetype }: ArchetypeJobData = job.data;
     this.logger.log(
-      `Handling 'process-add-archetype' job for projectId: ${projectId}...`,
+      `Handling 'process-add-archetype' for projectId ${projectId}...`,
     );
+    // archetype template already exists use update
+    if (archetype.archetypeId) {
+      this.logger.debug(
+        `Archetype already exists, handing handling over to 'process-add-archetype'...`,
+      );
+      this.handleUpdateArchetypeJob(job);
+      return archetype.archetypeId;
+    }
     try {
       //  1. create archetype_template entity
       // generate new unique archetypeId (nanoid)
@@ -160,32 +102,39 @@ export class AtlasProcessor {
           { entity: archetypeTemplateBody },
           undefined,
         );
+      this.logger.debug(templateResponse);
       // 2. store real archetype template ref (Atlas GUID)
       const templateGuid = Object.values(templateResponse?.guidAssignments)[0];
 
-      // 3. create archetype_node entities
-      const { columns, nodes } = this.separateColumnsNodes(archetype);
-      const entities: AtlasSubmitArchetypeEntityDto[] =
-        this.archetypeTemplateToAtlasEntitities(
-          columns,
-          nodes,
-          projectId,
-          archetype,
-          false,
-          owner,
-          templateGuid,
-        );
-      await this.atlas.post<AtlasPostEntityResponseDto>('/entity/bulk', {
-        entities: entities,
-      });
+      // check if any nodes are added
+      if (archetype.nodes?.length) {
+        // 3. create archetype_node entities
+        const { columns, nodes } = this.separateColumnsNodes(archetype);
+        const entities: AtlasSubmitArchetypeEntityDto[] =
+          this.archetypeTemplateToAtlasEntitities(
+            projectId,
+            archetype,
+            nodes,
+            columns,
+            {}, // no existing nodes should be present
+            false,
+            owner,
+            templateGuid,
+          );
+        await this.atlas.post<AtlasPostEntityResponseDto>('/entity/bulk', {
+          entities: entities,
+        });
+      }
       // 4. update project
       await this.prisma.project.update({
         where: { projectId: projectId },
         data: { lastModified: new Date() },
       });
       this.logger.log(
-        `Handling 'process-add-archetype' job for projectId ${projectId} SUCCEEDED!\nCreated archetype: ${archetype.archetypeId}`,
+        `Handling 'process-add-archetype' for projectId ${projectId} DONE!`,
+        `Created archetype ${archetype.archetypeId} with status ${archetype.status}`,
       );
+
       return archetype.archetypeId;
     } catch (error) {
       this.logger.error(
@@ -195,11 +144,106 @@ export class AtlasProcessor {
     }
   }
 
+  @Process('process-update-archetype')
+  async handleUpdateArchetypeJob(job: Job) {
+    const { projectId, archetype }: ArchetypeJobData = job.data;
+    this.logger.log(
+      `Handling 'process-update-archetype' for archetype ${archetype.archetypeId}...`,
+    );
+    try {
+      const entities: AtlasSubmitArchetypeEntityDto[] = [];
+
+      const { columns, nodes } = archetype.nodes?.length
+        ? this.separateColumnsNodes(archetype)
+        : { columns: [], nodes: [] };
+
+      // check relationships aka nodes
+      const entityRes = await this.atlas.get<AtlasArchetypeEntityResponseDto>(
+        `/entity/uniqueAttribute/type/${AtlasArchetypeTypeName.Template}`,
+        {
+          'attr:qualifiedName': `${projectId}@${archetype.archetypeId}`,
+          ignoreRelationships: false, // default false
+          minExtInfo: true, // default false
+        },
+      );
+
+      // lookup for already existing nodes
+      const existingNodes: Record<string, string> = Object.fromEntries(
+        (entityRes.entity.relationshipAttributes?.nodes ?? [])
+          .filter((node) => node.entityStatus !== 'DELETED')
+          .map((node) => [node.qualifiedName, node.guid]),
+      );
+      // Add archetype_template entity
+      const archetypeTemplateBody: AtlasSubmitArchetypeEntityDto = {
+        typeName: AtlasArchetypeTypeName.Template,
+        attributes: {
+          name: archetype.name,
+          projectId: projectId,
+          // using nanoid created in the beginning
+          qualifiedName: `${projectId}@${archetype.archetypeId}`,
+          status: archetype.status,
+        },
+        relationshipAttributes: {
+          instance: {
+            typeName: 'rdbms_instance',
+            uniqueAttributes: {
+              projectId,
+            },
+          },
+          // NOTE: this deletes nodes that have been removed
+          ...(Object.keys(existingNodes).length
+            ? {
+                nodes: Object.entries(existingNodes).map(([qualifiedName]) => ({
+                  typeName: AtlasArchetypeTypeName.Node,
+                  uniqueAttributes: {
+                    qualifiedName: qualifiedName,
+                  },
+                })),
+              }
+            : {}),
+        },
+      };
+
+      entities.push(
+        archetypeTemplateBody,
+        ...(nodes.length
+          ? this.archetypeTemplateToAtlasEntitities(
+              projectId,
+              archetype,
+              nodes,
+              columns,
+              existingNodes,
+              true,
+            )
+          : []),
+      );
+      await this.atlas.post<AtlasPostEntityResponseDto>('/entity/bulk', {
+        entities: entities,
+      });
+
+      await this.prisma.project.update({
+        where: { projectId: projectId },
+        data: { lastModified: new Date() },
+      });
+      this.logger.log(
+        `Handling 'process-update-archetype' for archetype ${archetype.archetypeId} DONE!`,
+        `Updated archetype ${archetype.archetypeId} with status ${archetype.status}`,
+      );
+
+      return archetype.archetypeId;
+    } catch (error) {
+      this.logger.error(
+        `Error updating archetype ${archetype.archetypeId}: `,
+        error,
+      );
+    }
+  }
+
   @Process('process-delete-archetype')
   async handleDeleteArchetypeJob(job: Job) {
     const { archetypeId, projectId } = job.data;
     this.logger.log(
-      `Handling 'process-delete-archetype' job archetype ${archetypeId}...`,
+      `Handling 'process-delete-archetype' for archetype ${archetypeId}...`,
     );
     try {
       await this.atlas.delete(
@@ -218,7 +262,7 @@ export class AtlasProcessor {
         },
       });
       this.logger.log(
-        `Handling 'process-delete-archetype' job archetype ${archetypeId} DONE!`,
+        `Handling 'process-delete-archetype' for archetype ${archetypeId} DONE!`,
       );
       return projectId;
     } catch (error) {
@@ -448,10 +492,11 @@ export class AtlasProcessor {
   }
 
   private archetypeTemplateToAtlasEntitities(
-    columns: ArchetypeNodeDto[],
-    nodes: ArchetypeNodeDto[],
     projectId: string,
     archetype: ArchetypeDto,
+    nodes: ArchetypeNodeDto[],
+    columns: ArchetypeNodeDto[],
+    existingNodes: Record<string, string> = {},
     isUpdate: boolean = false,
     owner?: string,
     templateGuid?: string,
@@ -476,19 +521,25 @@ export class AtlasProcessor {
       // get column if exists
       const columnGuid = columnEdges.find((e) => e.source === node.id)?.target;
 
+      // find parent node
       const parentId = archetype.edges.find(
         (e) => e.target === node.id,
       )?.source;
 
-      const currentGuid = nextGuid(); // increase neg guid
+      const currentGuid = nextGuid(); // decrease neg guid
 
-      // Lookup for parent-child relationship
-      parentLookup[node.id] = isUpdate
-        ? `${projectId}@${archetype.archetypeId}@${node.id}`
-        : currentGuid;
+      const qualifiedName = `${projectId}@${archetype.archetypeId}@${node.id}`;
+
+      // update lookup for parent-child relationship
+      // use qualifiedName if already existing node or negative guid if not
+      parentLookup[node.id] =
+        isUpdate && existingNodes[qualifiedName] ? qualifiedName : currentGuid;
 
       return {
-        ...(isUpdate ? {} : { guid: currentGuid }),
+        // add GUID if new entity
+        ...(isUpdate && existingNodes[qualifiedName]
+          ? {}
+          : { guid: currentGuid }),
         typeName: AtlasArchetypeTypeName.Node,
         status: 'ACTIVE',
         attributes: {
@@ -497,13 +548,13 @@ export class AtlasProcessor {
           name: node.data.label,
           owner: owner,
           level: node.data.level,
-          qualifiedName: `${projectId}@${archetype.archetypeId}@${node.id}`,
+          qualifiedName,
           position: {
             x: node.position.x,
             y: node.position.y,
           },
         },
-        ...(isUpdate
+        ...(isUpdate // classifications don't update with POST???
           ? {}
           : {
               classifications: this.mergeClassifications(
@@ -515,7 +566,7 @@ export class AtlasProcessor {
             }),
         relationshipAttributes: {
           template: {
-            typeName: 'archetype_template',
+            typeName: AtlasArchetypeTypeName.Template,
             ...(templateGuid
               ? {
                   guid: templateGuid,
@@ -529,8 +580,8 @@ export class AtlasProcessor {
           ...(parentId
             ? {
                 parent_node: {
-                  typeName: 'archetype_node',
-                  ...(isUpdate
+                  typeName: AtlasArchetypeTypeName.Node,
+                  ...(isUpdate && existingNodes[qualifiedName]
                     ? {
                         uniqueAttributes: {
                           qualifiedName: parentLookup[parentId],
@@ -584,7 +635,7 @@ export class AtlasProcessor {
     return parent
       ? {
           parent_node: {
-            typeName: 'archetype_node',
+            typeName: AtlasArchetypeTypeName.Node,
             uniqueAttributes: {
               qualifiedName: `${archetypeId}@${parent}`,
             },
@@ -611,7 +662,7 @@ export class AtlasProcessor {
 
   private separateColumnsNodes(archetype: ArchetypeDto) {
     // separate columns from actual archetype_nodes
-    const [columns, nodes] = archetype.nodes.reduce<
+    const [columns, nodes] = archetype.nodes?.reduce<
       [ArchetypeNodeDto[], ArchetypeNodeDto[]]
     >(
       (acc, node) => {

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -36,7 +36,7 @@ type ArchetypeJobData = {
 export class AtlasProcessor {
   private readonly logger = new Logger(AtlasProcessor.name);
   private readonly customNanoidAlphabet =
-    '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz-';
+    '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
   constructor(
     private readonly docker: DockerService,
     private readonly atlas: AtlasService,

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -162,9 +162,7 @@ export class AtlasProcessor {
         );
       // 2. store real archetype template ref (Atlas GUID)
       const templateGuid = Object.values(templateResponse?.guidAssignments)[0];
-      // this.logger.debug(
-      //   `Template CREATE response:\n${JSON.stringify(templateResponse)}`,
-      // );
+
       // 3. create archetype_node entities
       const { columns, nodes } = this.separateColumnsNodes(archetype);
       const entities: AtlasSubmitArchetypeEntityDto[] =
@@ -177,8 +175,6 @@ export class AtlasProcessor {
           owner,
           templateGuid,
         );
-
-      this.logger.debug(JSON.stringify(entities));
       await this.atlas.post<AtlasPostEntityResponseDto>('/entity/bulk', {
         entities: entities,
       });
@@ -568,7 +564,6 @@ export class AtlasProcessor {
       propagate: false,
     } as AtlasSimpleClassificationDto);
     const permission = permissions?.find((p) => p.id === nodeId)?.permission;
-    this.logger.debug(`Node: ${nodeId}, Permission: ${permission}`);
     if (permission) {
       classifications.push({
         typeName: 'archetype_node_analysis_permissions',

--- a/src/queue/queue.service.ts
+++ b/src/queue/queue.service.ts
@@ -16,7 +16,7 @@ export class QueueService {
     database: DatabaseInfoDto,
   ) {
     this.logger.log(
-      `Submitting 'process-data-broker' job to queue with requestId ${requestId}`,
+      `Submitting 'process-data-broker' to queue with requestId ${requestId}`,
     );
     return await this.atlasQueue.add(
       'process-data-broker',
@@ -36,7 +36,7 @@ export class QueueService {
 
   async addArchetypeJob(owner: string, archetype: ArchetypeDto) {
     this.logger.log(
-      `Submitting 'process-add-archetype' job to queue for projectId ${archetype.projectId}`,
+      `Submitting 'process-add-archetype' to queue for projectId ${archetype.projectId}`,
     );
     return await this.atlasQueue.add(
       'process-add-archetype',
@@ -54,7 +54,7 @@ export class QueueService {
 
   async updateArchetypeJob(archetype: ArchetypeDto) {
     this.logger.log(
-      `Submitting 'process-update-archetype' job to queue for archetypeId ${archetype.archetypeId}`,
+      `Submitting 'process-update-archetype' to queue for archetypeId ${archetype.archetypeId}`,
     );
     return await this.atlasQueue.add(
       'process-update-archetype',
@@ -72,7 +72,7 @@ export class QueueService {
 
   async deleteArchetypeJob(projectId: string, archetypeId: string) {
     this.logger.log(
-      `Submitting 'process-delete-archetype' job to queue with archetypeId ${archetypeId}...`,
+      `Submitting 'process-delete-archetype' to queue with archetypeId ${archetypeId}...`,
     );
     return await this.atlasQueue.add(
       'process-delete-archetype',

--- a/src/queue/queue.service.ts
+++ b/src/queue/queue.service.ts
@@ -52,14 +52,13 @@ export class QueueService {
     );
   }
 
-  async updateArchetypeJob(owner: string, archetype: ArchetypeDto) {
+  async updateArchetypeJob(archetype: ArchetypeDto) {
     this.logger.log(
       `Submitting 'process-update-archetype' job to queue for archetypeId ${archetype.archetypeId}`,
     );
     return await this.atlasQueue.add(
       'process-update-archetype',
       {
-        owner,
         projectId: archetype.projectId,
         archetype,
       },


### PR DESCRIPTION
Changes:
- changed archetypeId to use generated nanoid ID (also in frontend) as it was needed for updates using `qualifiedName`
- changed atlas `qualifiedName` patterns:
       - For `archetype_template` using `${projectId}@${archetype.archetypeId}`
       - For `archetype_node` using `${projectId}@${archetype.archetypeId}@${node.id}`
- added `{/api/v1/hub/archetype/:projectId/:archetypeId, PATCH}` endpoint for partial (i.e. attributes) updating archetype e.g. `{ "name": "New Archetype Name", "status": "PUBLISHED"}`
- refactored `{/api/v1/hub/archetype/:projectId/:archetypeId, PUT}` initiated 'process-update-archetype' process in Atlasprocessor `handleUpdateArchetypeJob` function
- implemented cleanup of deleted archetype_nodes on UPDATE archetype
- changed `created` and `lastModified` from Epoch milliseconds to `new Date(Epoch millis)` when returning from `{/api/v1/hub/archetype/:projectId, GET}`
- added padding position to columns in the backend so no need to do the padding position.y + 200 in the frontend @chuleeshen 


TODO:
- Permissions updates do not work when using Atlas POST `/api/atlas/v2/entity/bulk` endpoint, we need to use classifications endpoint to change entity access permissions. 

@chuleeshen, depending how you do the Edit permissions for template (in the Manage Template view), it might be worth to change the access/permissions via different request from edit/update archetype.