### PR TITLE
57 handle update archetype permissions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-//npm.pkg.github.com/:_authToken=${GITHUB_NPM_TOKEN}
+//npm.pkg.github.com/:_authToken=${GITHUB_NPM_TOKEN:-comes_from_environment}
 @epsilon-data:registry=https://npm.pkg.github.com/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,28 @@
-# Start with a node 20 image with package info
+# Start with a node 24 image
 # Installs *all* pnpm packages and runs build script
-FROM node:20.9.0-alpine AS workspace
+FROM node:24.11.0-alpine AS workspace
 
-# private git packages
+# Install docker CLI (client only, no daemon) for postinstall script
+RUN apk add --no-cache docker-cli
+
+# private git packages creds
 ARG GITHUB_NPM_TOKEN
 ENV GITHUB_NPM_TOKEN=${GITHUB_NPM_TOKEN}
 
+# broker image name
+ARG BROKER_IMAGE
+ENV BROKER_IMAGE=${BROKER_IMAGE}
+
 WORKDIR /app
+# install packages
 RUN npm install -g pnpm
 COPY [".", "/app/"]
-# TODO: add .npmrc file
-# RUN pnpm login --scope=@epsilon-data --registry=https://npm.pkg.github.com
 RUN pnpm install
 
 # build app
 FROM workspace AS build
 WORKDIR /app
-# ARG APP
 ENV NODE_ENV=production
-# RUN pnpm build:${APP}
 RUN pnpm build
 
 CMD pnpm run

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "license": "MIT",
   "engines": {
-    "node": ">=22.0.0",
+    "node": ">=24.0.0",
     "pnpm": ">=10"
   },
   "scripts": {

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 
 @ApiTags('App')
-@Controller('app')
+@Controller('/')
 export class AppController {
   constructor() {}
 

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 
 @ApiTags('App')
 @Controller('app')
@@ -8,6 +8,9 @@ export class AppController {
 
   @ApiOperation({ summary: 'Get application health information' })
   @Get('health')
+  @ApiOkResponse({
+    description: 'Status of API',
+  })
   getHealth() {
     return { status: 'OK', title: 'Epsilon API Hub' };
   }

--- a/src/archetype/archetype.controller.ts
+++ b/src/archetype/archetype.controller.ts
@@ -3,6 +3,8 @@ import {
   Controller,
   Delete,
   Get,
+  HttpCode,
+  HttpStatus,
   Logger,
   Param,
   ParseUUIDPipe,
@@ -13,15 +15,27 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ArchetypeService } from './archetype.service';
-import { ArchetypeDto } from './dto';
+import {
+  ArchetypeDto,
+  ArchetypeSummaryDto,
+  UpdateArchetypeAttributesDto,
+} from './dto';
 import { Request } from 'express';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiAcceptedResponse,
+  ApiBearerAuth,
+  ApiNoContentResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 
 import { Resource } from 'src/common/decorators/resource.decorator';
 import { Scopes } from 'src/common/decorators/scopes.decorator';
 import { ResourceGuard } from 'src/common/guards/resource.guard';
 
 @ApiTags('Archetype')
+@ApiBearerAuth()
 @Controller('archetype')
 @Resource('project')
 export class ArchetypeController {
@@ -32,6 +46,11 @@ export class ArchetypeController {
   @Scopes('view')
   @Get(':projectId')
   @ApiOperation({ summary: 'Get list of archetypes for a project' })
+  @ApiOkResponse({
+    description: 'List of Archetypes for project returned',
+    type: ArchetypeSummaryDto,
+    isArray: true,
+  })
   async getArchetypes(@Param('projectId', ParseUUIDPipe) projectId: string) {
     return await this.archetypeService.fetchArchetypes(projectId);
   }
@@ -40,6 +59,10 @@ export class ArchetypeController {
   @Scopes('view')
   @Get(':projectId/:archetypeId')
   @ApiOperation({ summary: 'Get project archetype details' })
+  @ApiOkResponse({
+    description: 'Archetypes details returned',
+    type: ArchetypeDto,
+  })
   async getArchetype(
     @Param('projectId', ParseUUIDPipe) projectId: string,
     @Param('archetypeId') archetypeId: string,
@@ -51,31 +74,59 @@ export class ArchetypeController {
   }
 
   @UseGuards(ResourceGuard)
-  @Scopes('view, edit')
+  @Scopes('view', 'edit')
   @Post(':projectId')
+  @HttpCode(HttpStatus.ACCEPTED)
   @ApiOperation({ summary: 'Create archetype for a project' })
-  createArchetype(@Body() archetype: ArchetypeDto, @Req() request: Request) {
+  @ApiAcceptedResponse({
+    description: 'Archetype creation accepted for processing',
+  })
+  createArchetype(
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+    @Body() archetype: ArchetypeDto,
+    @Req() request: Request,
+  ) {
     const username = request.auth.payload.preferred_username.toString();
-    return this.archetypeService.createArchetype(username, archetype);
+    return this.archetypeService.createArchetype(
+      username,
+      projectId,
+      archetype,
+    );
   }
 
   // TODO: classifications needs to be updated in a separate classification call
   @UseGuards(ResourceGuard)
   @Scopes('view, edit')
   @Put(':projectId/:archetypeId')
+  @HttpCode(HttpStatus.ACCEPTED)
   @ApiOperation({ summary: 'Update archetype for a project' })
-  updateArchetype(@Body() archetype: ArchetypeDto) {
-    return this.archetypeService.updateArchetype(archetype);
+  @ApiAcceptedResponse({
+    description: 'Archetype update accepted for processing',
+  })
+  updateArchetype(
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+    @Param('archetypeId') archetypeId: string,
+    @Body() archetype: ArchetypeDto,
+  ) {
+    return this.archetypeService.updateArchetype(
+      projectId,
+      archetypeId,
+      archetype,
+    );
   }
 
   @UseGuards(ResourceGuard)
   @Scopes('view, edit')
   @Patch(':projectId/:archetypeId')
   @ApiOperation({ summary: 'Update archetype details for a project' })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiNoContentResponse({
+    description: 'Archetype details updated',
+  })
   updateArchetypeDetails(
     @Param('projectId', ParseUUIDPipe) projectId: string,
     @Param('archetypeId') archetypeId: string,
-    @Body() attributes: unknown,
+    @Body() attributes: UpdateArchetypeAttributesDto,
   ) {
     return this.archetypeService.updateArchetypeDetails(
       projectId,
@@ -87,7 +138,11 @@ export class ArchetypeController {
   @UseGuards(ResourceGuard)
   @Scopes('view, edit')
   @Delete(':projectId/:archetypeId')
+  @HttpCode(HttpStatus.ACCEPTED)
   @ApiOperation({ summary: 'Delete archetype for a project' })
+  @ApiAcceptedResponse({
+    description: 'Archetype delete accepted for processing',
+  })
   async deleteArchetype(
     @Param('projectId', ParseUUIDPipe) projectId: string,
     @Param('archetypeId') archetypeId: string,

--- a/src/archetype/archetype.controller.ts
+++ b/src/archetype/archetype.controller.ts
@@ -107,8 +107,11 @@ export class ArchetypeController {
     @Param('projectId', ParseUUIDPipe) projectId: string,
     @Param('archetypeId') archetypeId: string,
     @Body() archetype: ArchetypeDto,
+    @Req() request: Request,
   ) {
+    const username = request.auth.payload.preferred_username.toString();
     return this.archetypeService.updateArchetype(
+      username,
       projectId,
       archetypeId,
       archetype,

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -95,7 +95,6 @@ export class ArchetypeService {
     attributes: unknown,
     token?: string,
   ) {
-    // TODO: handle errors and return updated entity?
     try {
       await this.atlas.put<AtlasPutEntityResponseDto>(
         `/entity/uniqueAttribute/type/${AtlasArchetypeTypeName.Template}`,

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -69,12 +69,24 @@ export class ArchetypeService {
     }));
   }
 
-  async createArchetype(username: string, archetype: ArchetypeDto) {
-    return await this.queue.addArchetypeJob(username, archetype);
+  async createArchetype(
+    username: string,
+    projectId: string,
+    archetype: ArchetypeDto,
+  ) {
+    return await this.queue.addArchetypeJob(username, projectId, archetype);
   }
 
-  async updateArchetype(archetype: ArchetypeDto) {
-    return await this.queue.updateArchetypeJob(archetype);
+  async updateArchetype(
+    projectId: string,
+    archetypeId: string,
+    archetype: ArchetypeDto,
+  ) {
+    return await this.queue.updateArchetypeJob(
+      projectId,
+      archetypeId,
+      archetype,
+    );
   }
 
   async updateArchetypeDetails(
@@ -83,20 +95,26 @@ export class ArchetypeService {
     attributes: unknown,
     token?: string,
   ) {
-    // TODO: handle errors
-    return await this.atlas.put<AtlasPutEntityResponseDto>(
-      `/entity/uniqueAttribute/type/${AtlasArchetypeTypeName.Template}`,
-      {
-        entity: {
-          typeName: AtlasArchetypeTypeName.Template,
-          attributes, // updated attributes
+    // TODO: handle errors and return updated entity?
+    try {
+      await this.atlas.put<AtlasPutEntityResponseDto>(
+        `/entity/uniqueAttribute/type/${AtlasArchetypeTypeName.Template}`,
+        {
+          entity: {
+            typeName: AtlasArchetypeTypeName.Template,
+            attributes, // updated attributes
+          },
         },
-      },
-      {
-        'attr:qualifiedName': `${projectId}@${archetypeId}`,
-      },
-      token,
-    );
+        {
+          'attr:qualifiedName': `${projectId}@${archetypeId}`,
+        },
+        token,
+      );
+      return;
+    } catch (error) {
+      this.logger.error(`Error updating archetype details`, error);
+      throw error;
+    }
   }
 
   async getArchetypeDetails(

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -148,8 +148,8 @@ export class ArchetypeService {
     // add all archetype_nodes
     for (const key in entityRes.referredEntities) {
       const entity = entityRes.referredEntities[key];
-      if (entity.status === 'DELETED') continue;
-      const nodeId = entity.attributes?.qualifiedName.split('@')[2];
+      if (entity.status !== 'ACTIVE') continue;
+      const nodeId = entity.attributes?.qualifiedName?.split('@')[2];
       // add node itself
       const node: ArchetypeNodeDto = {
         id: nodeId, // NOTE: Maybe use GUID
@@ -215,7 +215,8 @@ export class ArchetypeService {
           const permission = entity.classifications?.find(
             (c) =>
               c.typeName === 'archetype_node_analysis_permissions' &&
-              c.entityStatus === 'ACTIVE',
+              c.entityStatus === 'ACTIVE' &&
+              entity.guid === c.entityGuid, // don't include propagated permissions
           );
           return permission
             ? {

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -78,11 +78,13 @@ export class ArchetypeService {
   }
 
   async updateArchetype(
+    username: string,
     projectId: string,
     archetypeId: string,
     archetype: ArchetypeDto,
   ) {
     return await this.queue.updateArchetypeJob(
+      username,
       projectId,
       archetypeId,
       archetype,

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -167,7 +167,7 @@ export class ArchetypeService {
       // add edge if has parent exists
       if (entity.relationshipAttributes?.parent_node) {
         if (
-          entity.relationshipAttributes?.parent_node?.entityStatus === 'DELETED'
+          entity.relationshipAttributes?.parent_node?.entityStatus !== 'ACTIVE'
         )
           continue;
         const parentNodeId =
@@ -183,11 +183,12 @@ export class ArchetypeService {
       }
       // add column node and edges
       if (entity.relationshipAttributes?.column) {
-        if (entity.relationshipAttributes?.column?.entityStatus === 'DELETED')
+        if (entity.relationshipAttributes?.column?.entityStatus !== 'ACTIVE')
           continue;
         const columnNodeId = entity.relationshipAttributes?.column?.guid;
-        const columName =
-          entity.relationshipAttributes?.column?.qualifiedName.split('@')[2];
+        const columName = entity.relationshipAttributes?.column?.qualifiedName
+          .split('@')
+          .at(-1);
         const node: ArchetypeNodeDto = {
           id: columnNodeId,
           data: {

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -146,6 +146,7 @@ export class ArchetypeService {
     // add all archetype_nodes
     for (const key in entityRes.referredEntities) {
       const entity = entityRes.referredEntities[key];
+      if (entity.status === 'DELETED') continue;
       const nodeId = entity.attributes?.qualifiedName.split('@')[2];
       // add node itself
       const node: ArchetypeNodeDto = {
@@ -163,6 +164,10 @@ export class ArchetypeService {
 
       // add edge if has parent exists
       if (entity.relationshipAttributes?.parent_node) {
+        if (
+          entity.relationshipAttributes?.parent_node?.entityStatus === 'DELETED'
+        )
+          continue;
         const parentNodeId =
           entity.relationshipAttributes?.parent_node?.qualifiedName.split(
             '@',
@@ -176,6 +181,8 @@ export class ArchetypeService {
       }
       // add column node and edges
       if (entity.relationshipAttributes?.column) {
+        if (entity.relationshipAttributes?.column?.entityStatus === 'DELETED')
+          continue;
         const columnNodeId = entity.relationshipAttributes?.column?.guid;
         const columName =
           entity.relationshipAttributes?.column?.qualifiedName.split('@')[2];
@@ -204,7 +211,9 @@ export class ArchetypeService {
       if (entity.attributes?.level !== 0) {
         const analysisPermission = (() => {
           const permission = entity.classifications?.find(
-            (c) => c.typeName === 'archetype_node_analysis_permissions',
+            (c) =>
+              c.typeName === 'archetype_node_analysis_permissions' &&
+              c.entityStatus === 'ACTIVE',
           );
           return permission
             ? {

--- a/src/archetype/dto/archetype.dto.ts
+++ b/src/archetype/dto/archetype.dto.ts
@@ -1,4 +1,9 @@
 // TODO: cleanup DTOs
+import {
+  ApiExtraModels,
+  ApiProperty,
+  ApiPropertyOptional,
+} from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
 import {
   IsArray,
@@ -33,23 +38,62 @@ export enum ArchetypePermission {
   DETAILED = 'DETAILED',
 }
 
+export class UpdateArchetypeAttributesDto {
+  @ApiPropertyOptional({
+    description: 'Update display name of the archetype',
+    example: 'Research 360 — Patient Health Update',
+  })
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiPropertyOptional({
+    description: 'Update status of the archetype',
+    enum: ArchetypeStatus,
+    enumName: 'ArchetypeStatus',
+    example: ArchetypeStatus.ACTIVE,
+  })
+  @IsOptional()
+  @IsEnum(ArchetypeStatus)
+  status?: ArchetypeStatus;
+}
+
 export class ArchetypeNodePermissionDto {
+  @ApiProperty({
+    description: 'Node identifier the permission applies to',
+    example: 'node_1',
+  })
   @IsDefined()
   @IsString()
   @IsNotEmpty()
   id!: string;
 
+  @ApiProperty({
+    description: 'Permission level for this node',
+    enum: ArchetypePermission,
+    enumName: 'ArchetypePermission',
+    example: ArchetypePermission.DETAILED,
+  })
   @IsDefined()
   @IsEnum(ArchetypePermission)
   permission!: ArchetypePermission;
 }
 
 export class ArchetypeNodeDataDto {
+  @ApiProperty({
+    description: 'Display label for the node',
+    example: 'Participant',
+  })
   @IsDefined()
   @IsString()
   @IsNotEmpty()
   label!: string;
 
+  @ApiProperty({
+    description: 'Depth level of the node within the archetype tree',
+    example: 0,
+    minimum: 0,
+  })
   @IsDefined()
   @IsInt()
   @Min(0)
@@ -57,30 +101,57 @@ export class ArchetypeNodeDataDto {
 }
 
 export class ArchetypeNodePositionDto {
+  @ApiProperty({
+    description: 'X coordinate of the node in the tree layout',
+    example: 120.5,
+  })
   @IsDefined()
   @IsNumber({ allowNaN: false, allowInfinity: false })
   x!: number;
 
+  @ApiProperty({
+    description: 'Y coordinate of the node in the tree layout',
+    example: 320.25,
+  })
   @IsDefined()
   @IsNumber({ allowNaN: false, allowInfinity: false })
   y!: number;
 }
 
+@ApiExtraModels(ArchetypeNodeDataDto, ArchetypeNodePositionDto)
 export class ArchetypeNodeDto {
+  @ApiProperty({
+    description: 'Unique node identifier',
+    example: 'node_0',
+  })
   @IsDefined()
   @IsString()
   @IsNotEmpty()
   id!: string;
 
+  @ApiProperty({
+    description: 'Node type',
+    enum: ArchetypeNodeType,
+    enumName: 'ArchetypeNodeType',
+    example: ArchetypeNodeType.Root,
+  })
   @IsDefined()
   @IsEnum(ArchetypeNodeType)
   type!: ArchetypeNodeType;
 
+  @ApiProperty({
+    description: 'Node metadata (label and hierarchy level)',
+    type: () => ArchetypeNodeDataDto,
+  })
   @IsDefined()
   @ValidateNested()
   @Type(() => ArchetypeNodeDataDto)
   data!: ArchetypeNodeDataDto;
 
+  @ApiProperty({
+    description: 'Node position in the tree layout',
+    type: () => ArchetypeNodePositionDto,
+  })
   @IsDefined()
   @ValidateNested()
   @Type(() => ArchetypeNodePositionDto)
@@ -88,58 +159,165 @@ export class ArchetypeNodeDto {
 }
 
 export class ArchetypeEdgeDto {
+  @ApiProperty({
+    description: 'Unique edge identifier',
+    example: 'edge_node_0_node_1',
+  })
   @IsDefined()
   @IsString()
   @IsNotEmpty()
   id!: string;
 
+  @ApiProperty({
+    description: 'Source node ID for this edge',
+    example: 'node_0',
+  })
   @IsDefined()
   @IsString()
   @IsNotEmpty()
   source!: string;
 
+  @ApiProperty({
+    description: 'Target node ID for this edge',
+    example: 'node_1',
+  })
   @IsDefined()
   @IsString()
   @IsNotEmpty()
   target!: string;
 }
 
+export class ArchetypeSummaryDto {
+  @ApiPropertyOptional({
+    description: 'Archetype identifier (system generated 12 char nanoid)',
+    example: 'Xa7BAIWZCA8u',
+  })
+  @IsDefined()
+  @IsNotEmpty()
+  @IsString()
+  id!: string;
+
+  @ApiProperty({
+    description: 'Display name of the archetype',
+    example: 'Research 360 — Patient Health',
+  })
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @ApiProperty({
+    description: 'Current status of the archetype',
+    enum: ArchetypeStatus,
+    enumName: 'ArchetypeStatus',
+    example: ArchetypeStatus.ACTIVE,
+  })
+  @IsEnum(ArchetypeStatus)
+  status!: ArchetypeStatus;
+
+  @ApiProperty({
+    description: 'Username or ID of the user who created this archetype',
+    example: 'data-owner',
+  })
+  @IsString()
+  @IsNotEmpty()
+  createdBy!: string;
+
+  @ApiProperty({
+    description: 'Timestamp when the archetype was created (ISO 8601)',
+    type: String,
+    format: 'date-time',
+    example: '2025-10-30T12:34:56.000Z',
+  })
+  @Type(() => Date)
+  @IsDate()
+  created!: Date;
+
+  @ApiProperty({
+    description: 'Timestamp when the archetype was last modified (ISO 8601)',
+    type: String,
+    format: 'date-time',
+    example: '2025-10-31T08:15:42.000Z',
+  })
+  @Type(() => Date)
+  @IsDate()
+  lastModified!: Date;
+}
+
 export class ArchetypeDto {
+  @ApiProperty({
+    description: 'Project identifier',
+    format: 'uuid',
+    example: '638c6f81-00c8-47f4-82ec-6b94240e757d',
+  })
   @IsDefined()
   @IsUUID()
   projectId!: string;
 
+  @ApiPropertyOptional({
+    description: 'Archetype identifier (system generated 12 char nanoid)',
+    example: 'Xa7BAIWZCA8u',
+  })
   @IsOptional()
   @IsString()
   archetypeId?: string;
 
+  @ApiProperty({
+    description: 'Display name of the archetype',
+    minLength: 1,
+    example: 'Research 360 — Patient Health',
+  })
   @IsDefined()
   @IsString()
   @IsNotEmpty()
   name!: string;
 
+  @ApiPropertyOptional({
+    description: 'Archetype nodes (tree vertices)',
+    type: () => [ArchetypeNodeDto],
+  })
   @IsOptional()
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => ArchetypeNodeDto)
   nodes?: ArchetypeNodeDto[];
 
+  @ApiPropertyOptional({
+    description: 'Archetype edges (tree connections between nodes)',
+    type: () => [ArchetypeEdgeDto],
+  })
   @IsOptional()
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => ArchetypeEdgeDto)
   edges?: ArchetypeEdgeDto[];
 
+  @ApiPropertyOptional({
+    description: 'Publishing status',
+    enum: ArchetypeStatus,
+    enumName: 'ArchetypeStatus',
+    default: ArchetypeStatus.DRAFT,
+    example: ArchetypeStatus.DRAFT,
+  })
   @IsOptional()
   @IsEnum(ArchetypeStatus)
   status: ArchetypeStatus = ArchetypeStatus.DRAFT;
 
+  @ApiPropertyOptional({
+    description: 'Per-node analysis permissions',
+    type: () => [ArchetypeNodePermissionDto],
+  })
   @IsOptional()
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => ArchetypeNodePermissionDto)
   permissions?: ArchetypeNodePermissionDto[];
 
+  @ApiPropertyOptional({
+    description: 'Last modified timestamp (ISO 8601)',
+    type: String,
+    format: 'date-time',
+    example: '2025-10-03T09:42:15.123Z',
+  })
   @IsOptional()
   @IsDate()
   @Transform(({ value }) => transformToDateString(value), { toClassOnly: true })

--- a/src/archetype/dto/archetype.dto.ts
+++ b/src/archetype/dto/archetype.dto.ts
@@ -1,4 +1,3 @@
-// TODO: cleanup DTOs
 import {
   ApiExtraModels,
   ApiProperty,

--- a/src/atlas/dto/atlas.dto.ts
+++ b/src/atlas/dto/atlas.dto.ts
@@ -310,6 +310,9 @@ export class AtlasArchetypeEntityClassificationDto {
   typeName!: string;
 
   @IsString()
+  entityStatus?: string;
+
+  @IsString()
   entityGuid?: string;
 
   @IsOptional()

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -41,9 +41,12 @@ export class AuthModule implements NestModule {
           audience: this.configService.get<string>('auth.audience'),
         }),
       )
-      .exclude({ path: 'health/*path', method: RequestMethod.GET })
-      .exclude({ path: 'docs/*path', method: RequestMethod.GET })
-      .exclude({ path: 'analysis/*path', method: RequestMethod.ALL })
+      .exclude(
+        { path: 'health', method: RequestMethod.GET },
+        { path: 'docs', method: RequestMethod.GET },
+        { path: 'docs/*path', method: RequestMethod.GET },
+        { path: 'analysis/*path', method: RequestMethod.ALL },
+      )
       .forRoutes('*path');
   }
 

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -41,10 +41,10 @@ export class AuthModule implements NestModule {
           audience: this.configService.get<string>('auth.audience'),
         }),
       )
-      .exclude({ path: 'health', method: RequestMethod.GET })
-      .exclude({ path: 'docs', method: RequestMethod.GET })
-      .exclude({ path: 'analysis/(.*)', method: RequestMethod.ALL })
-      .forRoutes('*');
+      .exclude({ path: 'health/*path', method: RequestMethod.GET })
+      .exclude({ path: 'docs/*path', method: RequestMethod.GET })
+      .exclude({ path: 'analysis/*path', method: RequestMethod.ALL })
+      .forRoutes('*path');
   }
 
   static forRoot({

--- a/src/connection_request/connection_request.controller.ts
+++ b/src/connection_request/connection_request.controller.ts
@@ -12,15 +12,20 @@ import {
 import { ConnectionRequestService } from './connection_request.service';
 import { Request } from 'express';
 import { DatabaseInfoDto } from './dto';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 
 // import { Scopes } from 'src/auth/scopes.decorator';
 // import { Resource } from 'src/auth/resource.decorator';
 // import { ResourceGuard } from 'src/auth/resource.guard';
 // import { ScopesGuard } from 'src/common/guards/scopes.guard';
 
-// @Resource('Project')
 @ApiTags('Connection Request')
+// @Resource('project')
 @Controller('connection-request')
 export class ConnectionRequestController {
   constructor(private connectionRequestService: ConnectionRequestService) {}
@@ -38,6 +43,12 @@ export class ConnectionRequestController {
   @Post('test')
   @ApiOperation({
     summary: 'Test connection credentials',
+  })
+  @ApiOkResponse({
+    description: 'Connection test successful',
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Wrong credentials',
   })
   async testConnection(@Body() databaseDto: DatabaseInfoDto) {
     try {

--- a/src/connection_request/dto/connection_request.dto.ts
+++ b/src/connection_request/dto/connection_request.dto.ts
@@ -1,34 +1,71 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsOptional, IsString, IsUUID } from 'class-validator';
 
 export class DatabaseInfoDto {
+  @ApiPropertyOptional({
+    description: 'Logical database name (database)',
+    example: 'analytics_dw',
+  })
   @IsOptional()
   @IsString()
   name?: string;
 
+  @ApiPropertyOptional({
+    description: 'Database engine/type',
+    example: 'postgres', // e.g. postgres | mysql | mssql | oracle | sqlite
+  })
   @IsOptional()
   @IsString()
   type?: string;
 
+  @ApiPropertyOptional({
+    description: 'Hostname or IP address of the database server',
+    example: 'db.internal.company.local',
+  })
   @IsOptional()
   @IsString()
   host?: string;
 
+  @ApiPropertyOptional({
+    description: 'Port the database listens on (as string)',
+    example: '5432',
+  })
   @IsOptional()
   @IsString()
   port?: string;
 
+  @ApiPropertyOptional({
+    description: 'Full connection URL (if provided, may supersede host/port)',
+    type: String,
+    format: 'uri',
+    example: 'postgres://user:pass@db.internal.company.local:5432/analytics_dw',
+  })
   @IsOptional()
   @IsString()
   url?: string;
 
+  @ApiPropertyOptional({
+    description: 'Database username',
+    example: 'etl_service',
+  })
   @IsOptional()
   @IsString()
   username?: string;
 
+  @ApiPropertyOptional({
+    description: 'Database password (write-only; never returned)',
+    writeOnly: true,
+    example: '**********',
+  })
   @IsOptional()
   @IsString()
   password?: string;
 
+  @ApiPropertyOptional({
+    description: 'Associated project identifier',
+    format: 'uuid',
+    example: '638c6f81-00c8-47f4-82ec-6b94240e757d',
+  })
   @IsOptional()
   @IsUUID()
   projectId?: string;

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -17,10 +17,8 @@ import {
   AtlasArchetypeEntityResponseDto,
   AtlasArchetypeNodeTypeName,
   AtlasArchetypeTypeName,
-  AtlasEntityResponseDto,
   AtlasPostEntityResponseDto,
   AtlasRelatedEntityRefDto,
-  AtlasSearchDslResponseDto,
   AtlasSimpleClassificationDto,
   AtlasSubmitArchetypeEntityDto,
 } from 'src/atlas/dto';
@@ -67,7 +65,7 @@ export class AtlasProcessor {
     );
     // archetype template already exists use update
     if (archetype.archetypeId) {
-      this.logger.debug(
+      this.logger.log(
         `Archetype already exists, handing handling over to 'process-add-archetype'...`,
       );
       this.handleUpdateArchetypeJob(job);
@@ -146,7 +144,7 @@ export class AtlasProcessor {
 
   @Process('process-update-archetype')
   async handleUpdateArchetypeJob(job: Job) {
-    const { projectId, archetype }: ArchetypeJobData = job.data;
+    const { owner, projectId, archetype }: ArchetypeJobData = job.data;
     this.logger.log(
       `Handling 'process-update-archetype' for archetype ${archetype.archetypeId}...`,
     );
@@ -167,13 +165,45 @@ export class AtlasProcessor {
         },
       );
 
+      // get all the node ids
+      const nodeIds = new Set(nodes.map((n) => n.id));
+
       // lookup for already existing nodes
       const existingNodes: Record<string, string> = Object.fromEntries(
         (entityRes.entity.relationshipAttributes?.nodes ?? [])
-          .filter((node) => node.entityStatus !== 'DELETED')
+          .filter(
+            (node) =>
+              node.entityStatus !== 'DELETED' &&
+              nodeIds.has(node.qualifiedName.split('@')[2]),
+          )
           .map((node) => [node.qualifiedName, node.guid]),
       );
-      this.logger.debug(`existingNodes`, existingNodes);
+
+      // update existing nodes classifications with permissions
+      // TODO: test if also need to update the node_type (e.g. leaf, root, branch)
+      // TODO: improve so not flooding the API with requests
+      // TODO: improve error handling
+      if (archetype.permissions) {
+        Object.entries(existingNodes).forEach(([qualifiedName, guid]) => {
+          const nodeId = qualifiedName.split('@')[2];
+          const permissions = this.getPermissionClassification(
+            nodeId,
+            archetype.permissions,
+          );
+          if (!permissions.length) return;
+
+          this.atlas
+            .put<AtlasArchetypeEntityResponseDto>(
+              `/entity/guid/${guid}/classifications`,
+              permissions,
+            )
+            .catch((err) =>
+              this.logger.error(
+                `Failed to set classifications for ${guid}: ${err?.message}`,
+              ),
+            );
+        });
+      }
 
       // Add archetype_template entity
       const archetypeTemplateBody: AtlasSubmitArchetypeEntityDto = {
@@ -213,10 +243,11 @@ export class AtlasProcessor {
             columns,
             existingNodes,
             true,
+            owner,
           )
         : { entities: [], guidAssignments: [] };
 
-      // TODO: ADD nodes that are assigned
+      // add new nodes that are assigned (neg guids)
       if (guidAssignments.length) {
         const newNodeRefs = guidAssignments.map((guid) => ({
           guid,
@@ -235,16 +266,15 @@ export class AtlasProcessor {
         archetypeTemplateBody,
         ...(nodes.length ? entities : []),
       );
-      this.logger.debug(`Entities`, JSON.stringify(entities));
 
-      // await this.atlas.post<AtlasPostEntityResponseDto>('/entity/bulk', {
-      //   entities: entities,
-      // });
+      await this.atlas.post<AtlasPostEntityResponseDto>('/entity/bulk', {
+        entities: updateEntities,
+      });
 
-      // await this.prisma.project.update({
-      //   where: { projectId: projectId },
-      //   data: { lastModified: new Date() },
-      // });
+      await this.prisma.project.update({
+        where: { projectId: projectId },
+        data: { lastModified: new Date() },
+      });
       this.logger.log(
         `Handling 'process-update-archetype' for archetype ${archetype.archetypeId} DONE!`,
         `Updated archetype ${archetype.archetypeId} with status ${archetype.status}`,
@@ -288,227 +318,6 @@ export class AtlasProcessor {
     } catch (error) {
       this.logger.error(`Error deleting archetype ${archetypeId}: `, error);
     }
-  }
-
-  // TODO: remove redundant function as using classifiers for permissions now
-  // Remove after settling an update
-  @Process('process-add-permissions')
-  async handleAddPermissionsJob(job: Job) {
-    const { projectId, permissions } = job.data;
-
-    for (const p of permissions) {
-      const templateGuid = p.templateId;
-
-      const templateEntity = await this.atlas.get<AtlasEntityResponseDto>(
-        `/entity/guid/${templateGuid}`,
-      );
-
-      const templateNodesGuid = [];
-
-      for (const key in templateEntity.referredEntities) {
-        const entity = templateEntity.referredEntities[key];
-
-        if (entity.typeName.includes('archetype_')) {
-          templateNodesGuid.push(key);
-        }
-      }
-
-      // FIXME: change this
-      // const getGuid = (name: string) => {
-      //   for (const key in templateEntity.referredEntities) {
-      //     if (
-      //       templateEntity.referredEntities[key].attributes.qualifiedName ==
-      //       name
-      //     ) {
-      //       return key;
-      //     }
-      //   }
-      // };
-
-      const params = { name: 'is_active' };
-      await this.atlas.put(
-        `/entity/guid/${templateGuid}`,
-        JSON.stringify(p.active ? 'true' : 'false'),
-        params,
-      );
-
-      if (p.active) {
-        const activeParams = {
-          query: `from permission where __state = "ACTIVE"`,
-        };
-
-        const activeResult = await this.atlas.get<AtlasSearchDslResponseDto>(
-          '/search/dsl',
-          activeParams,
-        );
-        this.logger.debug(activeResult);
-        // FIXME: change this
-        // if (activeResult.entities) {
-        //   let guidList = [];
-        //   for (const entity of activeResult.entities) {
-        //     const params = {
-        //       minExtInfo: true,
-        //     };
-
-        //     const permissionEntity =
-        //       await this.atlas.get<AtlasEntityResponseDto>(
-        //         `/entity/guid/${entity.guid}`,
-        //         params,
-        //         token,
-        //       );
-
-        //     const objects =
-        //       permissionEntity.entity.relationshipAttributes.object.filter(
-        //         (o) =>
-        //           templateNodesGuid.includes(o.guid) &&
-        //           o.relationshipStatus === 'ACTIVE',
-        //       );
-
-        //     const categories =
-        //       permissionEntity.entity.relationshipAttributes.category.filter(
-        //         (s) =>
-        //           templateNodesGuid.includes(s.guid) &&
-        //           s.relationshipStatus === 'ACTIVE',
-        //       );
-        //     const subcategories =
-        //       permissionEntity.entity.relationshipAttributes.subcategory.filter(
-        //         (c) =>
-        //           templateNodesGuid.includes(c.guid) &&
-        //           c.relationshipStatus === 'ACTIVE',
-        //       );
-
-        //     const combined = [...objects, ...categories, ...subcategories];
-        //     guidList = [
-        //       ...guidList,
-        //       ...combined.map((c) => c.relationshipGuid),
-        //     ];
-        //   }
-
-        //   guidList = Array.from(new Set(guidList));
-
-        //   for (const guid of guidList) {
-        //     await this.atlas.delete(
-        //       `/relationship/guid/${guid}`,
-        //       undefined,
-        //       token,
-        //     );
-        //   }
-        // }
-
-        // for (const setting of p.settings) {
-        //   const role = setting.role;
-
-        //   for (const node of setting.access) {
-        //     const nodeType = `archetype_${node.nodeType}`;
-        //     const nodeGuid = await getGuid(
-        //       `${templateGuid}@${node.nodeName.replace(' ', '_')}@${node.nodeId}`,
-        //     );
-
-        //     const uniquePermissions = [...new Set(node.permissions)];
-
-        //     for (const permission of uniquePermissions) {
-        //       const permissionName = `permission_${permission}@${role}`;
-        //       const permissionParams = {
-        //         query: `from permission where qualifiedName = "${permissionName}" and __state = "ACTIVE" limit 1`,
-        //       };
-
-        //       const permissionResult =
-        //         await this.atlas.get<AtlasSearchDslResponseDto>(
-        //           '/search/dsl',
-        //           permissionParams,
-        //           token,
-        //         );
-
-        //       if (permissionResult.entities) {
-        //         const permissionGuid = permissionResult.entities[0].guid;
-
-        //         const permissionEntity =
-        //           await this.atlas.get<AtlasEntityResponseDto>(
-        //             `/entity/guid/${permissionGuid}`,
-        //             undefined,
-        //             token,
-        //           );
-
-        //         const hasRelationship = false;
-        //         // FIXME: needs attention
-        //         // permissionEntity.entity.relationshipAttributes[
-        //         //   `${node.nodeType}`
-        //         // ].some(
-        //         //   (p: any) =>
-        //         //     p.guid === nodeGuid && p.relationshipStatus === 'ACTIVE',
-        //         // );
-
-        //         if (!hasRelationship) {
-        //           const relationshipBody = {
-        //             typeName: `${nodeType}_permissions`,
-        //             end1: {
-        //               guid: nodeGuid,
-        //             },
-        //             end2: {
-        //               guid: permissionGuid,
-        //             },
-        //             status: 'ACTIVE',
-        //           };
-
-        //           await this.atlas.post(
-        //             '/relationship',
-        //             relationshipBody,
-        //             token,
-        //           );
-        //         }
-        //       } else {
-        //         const permissionBody = {
-        //           entity: {
-        //             typeName: 'permission',
-        //             status: 'ACTIVE',
-        //             attributes: {
-        //               owner: 'user',
-        //               qualifiedName: `permission_${permission}@${role}`,
-        //               name: permission,
-        //             },
-        //             relationshipAttributes: {
-        //               object: [],
-        //               category: [],
-        //               subcategory: [],
-        //             },
-        //           },
-        //         };
-
-        //         const relationship = await this.atlas.get(
-        //           `/types/relationshipdef/name/${nodeType}_permissions`,
-        //           undefined,
-        //           token,
-        //         );
-        //         const relationshipInfo = {
-        //           guid: nodeGuid,
-        //           typeName: nodeType,
-        //           entityStatus: 'ACTIVE',
-        //           relationshipType: `${nodeType}_permissions`,
-        //           // FIME: change this
-        //           // relationshipGuid: relationship.guid,
-        //           relationshipStatus: 'ACTIVE',
-        //         };
-
-        //         permissionBody.entity.relationshipAttributes[
-        //           node.nodeType
-        //         ].push(relationshipInfo);
-
-        //         await this.atlas.post('/entity', permissionBody, token);
-        //       }
-        //     }
-        //   }
-        // }
-      }
-    }
-
-    await this.prisma.project.update({
-      where: {
-        projectId: projectId,
-      },
-      data: {
-        lastModified: new Date(),
-      },
-    });
   }
 
   private archetypeTemplateToAtlasEntities(
@@ -563,7 +372,7 @@ export class AtlasProcessor {
             ? qualifiedName
             : currentGuid;
 
-        if (isUpdate && existingNodes[qualifiedName])
+        if (isUpdate && !existingNodes[qualifiedName])
           guidAssignments.push(currentGuid);
         return {
           // add GUID if new entity
@@ -576,7 +385,7 @@ export class AtlasProcessor {
             label: node.data.label,
             // NOTE: needed for analysis SDK JSONSchema
             name: node.data.label,
-            owner: owner,
+            ...(isUpdate && existingNodes[qualifiedName] ? {} : { owner }),
             level: node.data.level,
             qualifiedName,
             position: {
@@ -584,7 +393,7 @@ export class AtlasProcessor {
               y: node.position.y,
             },
           },
-          ...(isUpdate // classifications don't update with POST???
+          ...(isUpdate && existingNodes[qualifiedName] // existing classifications don't update
             ? {}
             : {
                 classifications: this.mergeClassifications(
@@ -646,6 +455,23 @@ export class AtlasProcessor {
           : 'branch_node') as AtlasArchetypeNodeTypeName,
       propagate: false,
     } as AtlasSimpleClassificationDto);
+    const permission = permissions?.find((p) => p.id === nodeId)?.permission;
+    if (permission) {
+      classifications.push({
+        typeName: 'archetype_node_analysis_permissions',
+        propagate: true,
+        removePropagationsOnEntityDelete: true,
+        attributes: { access_level: permission },
+      } as AtlasArchetypeAnalysisPermissionClassificationDto);
+    }
+    return classifications;
+  }
+
+  private getPermissionClassification(
+    nodeId: string,
+    permissions: ArchetypeNodePermissionDto[],
+  ): AtlasArchetypeEntityDto['classifications'] {
+    const classifications: AtlasArchetypeEntityDto['classifications'] = [];
     const permission = permissions?.find((p) => p.id === nodeId)?.permission;
     if (permission) {
       classifications.push({

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -19,6 +19,7 @@ import {
   AtlasArchetypeTypeName,
   AtlasEntityResponseDto,
   AtlasPostEntityResponseDto,
+  AtlasRelatedEntityRefDto,
   AtlasSearchDslResponseDto,
   AtlasSimpleClassificationDto,
   AtlasSubmitArchetypeEntityDto,
@@ -102,7 +103,7 @@ export class AtlasProcessor {
           { entity: archetypeTemplateBody },
           undefined,
         );
-      this.logger.debug(templateResponse);
+
       // 2. store real archetype template ref (Atlas GUID)
       const templateGuid = Object.values(templateResponse?.guidAssignments)[0];
 
@@ -110,17 +111,16 @@ export class AtlasProcessor {
       if (archetype.nodes?.length) {
         // 3. create archetype_node entities
         const { columns, nodes } = this.separateColumnsNodes(archetype);
-        const entities: AtlasSubmitArchetypeEntityDto[] =
-          this.archetypeTemplateToAtlasEntities(
-            projectId,
-            archetype,
-            nodes,
-            columns,
-            {}, // no existing nodes should be present
-            false,
-            owner,
-            templateGuid,
-          );
+        const { entities } = this.archetypeTemplateToAtlasEntities(
+          projectId,
+          archetype,
+          nodes,
+          columns,
+          {}, // no existing nodes should be present
+          false,
+          owner,
+          templateGuid,
+        );
         await this.atlas.post<AtlasPostEntityResponseDto>('/entity/bulk', {
           entities: entities,
         });
@@ -151,7 +151,7 @@ export class AtlasProcessor {
       `Handling 'process-update-archetype' for archetype ${archetype.archetypeId}...`,
     );
     try {
-      const entities: AtlasSubmitArchetypeEntityDto[] = [];
+      const updateEntities: AtlasSubmitArchetypeEntityDto[] = [];
 
       const { columns, nodes } = archetype.nodes?.length
         ? this.separateColumnsNodes(archetype)
@@ -173,6 +173,8 @@ export class AtlasProcessor {
           .filter((node) => node.entityStatus !== 'DELETED')
           .map((node) => [node.qualifiedName, node.guid]),
       );
+      this.logger.debug(`existingNodes`, existingNodes);
+
       // Add archetype_template entity
       const archetypeTemplateBody: AtlasSubmitArchetypeEntityDto = {
         typeName: AtlasArchetypeTypeName.Template,
@@ -203,28 +205,46 @@ export class AtlasProcessor {
             : {}),
         },
       };
+      const { entities, guidAssignments } = nodes.length
+        ? this.archetypeTemplateToAtlasEntities(
+            projectId,
+            archetype,
+            nodes,
+            columns,
+            existingNodes,
+            true,
+          )
+        : { entities: [], guidAssignments: [] };
 
-      entities.push(
+      // TODO: ADD nodes that are assigned
+      if (guidAssignments.length) {
+        const newNodeRefs = guidAssignments.map((guid) => ({
+          guid,
+          typeName: AtlasArchetypeTypeName.Node,
+        }));
+        archetypeTemplateBody.relationshipAttributes ??= {};
+        archetypeTemplateBody.relationshipAttributes.nodes ??= [];
+        archetypeTemplateBody.relationshipAttributes.nodes = [
+          ...(archetypeTemplateBody.relationshipAttributes
+            .nodes as AtlasRelatedEntityRefDto[]),
+          ...newNodeRefs,
+        ];
+      }
+
+      updateEntities.push(
         archetypeTemplateBody,
-        ...(nodes.length
-          ? this.archetypeTemplateToAtlasEntities(
-              projectId,
-              archetype,
-              nodes,
-              columns,
-              existingNodes,
-              true,
-            )
-          : []),
+        ...(nodes.length ? entities : []),
       );
-      await this.atlas.post<AtlasPostEntityResponseDto>('/entity/bulk', {
-        entities: entities,
-      });
+      this.logger.debug(`Entities`, JSON.stringify(entities));
 
-      await this.prisma.project.update({
-        where: { projectId: projectId },
-        data: { lastModified: new Date() },
-      });
+      // await this.atlas.post<AtlasPostEntityResponseDto>('/entity/bulk', {
+      //   entities: entities,
+      // });
+
+      // await this.prisma.project.update({
+      //   where: { projectId: projectId },
+      //   data: { lastModified: new Date() },
+      // });
       this.logger.log(
         `Handling 'process-update-archetype' for archetype ${archetype.archetypeId} DONE!`,
         `Updated archetype ${archetype.archetypeId} with status ${archetype.status}`,
@@ -500,7 +520,7 @@ export class AtlasProcessor {
     isUpdate: boolean = false,
     owner?: string,
     templateGuid?: string,
-  ): AtlasSubmitArchetypeEntityDto[] {
+  ): { entities: AtlasSubmitArchetypeEntityDto[]; guidAssignments: string[] } {
     // init negative guid
     let negativeGuid = -2;
 
@@ -516,87 +536,99 @@ export class AtlasProcessor {
     const columnEdges = archetype.edges.filter((edge: ArchetypeEdgeDto) =>
       columns.find((e) => e.id === edge.target),
     );
+    const guidAssignments: string[] = [];
 
-    return nodes.map((node: ArchetypeNodeDto) => {
-      // get column if exists
-      const columnGuid = columnEdges.find((e) => e.source === node.id)?.target;
+    return {
+      entities: nodes.map((node: ArchetypeNodeDto) => {
+        // get column if exists
+        const columnGuid = columnEdges.find(
+          (e) => e.source === node.id,
+        )?.target;
 
-      // find parent node
-      const parentId = archetype.edges.find(
-        (e) => e.target === node.id,
-      )?.source;
+        // find parent node
+        const parentId = archetype.edges.find(
+          (e) => e.target === node.id,
+        )?.source;
 
-      const currentGuid = nextGuid(); // decrease neg guid
+        const parentIdQualifiedName = `${projectId}@${archetype.archetypeId}@${parentId}`;
 
-      const qualifiedName = `${projectId}@${archetype.archetypeId}@${node.id}`;
+        const currentGuid = nextGuid(); // decrease neg guid
 
-      // update lookup for parent-child relationship
-      // use qualifiedName if already existing node or negative guid if not
-      parentLookup[node.id] =
-        isUpdate && existingNodes[qualifiedName] ? qualifiedName : currentGuid;
+        const qualifiedName = `${projectId}@${archetype.archetypeId}@${node.id}`;
 
-      return {
-        // add GUID if new entity
-        ...(isUpdate && existingNodes[qualifiedName]
-          ? {}
-          : { guid: currentGuid }),
-        typeName: AtlasArchetypeTypeName.Node,
-        status: 'ACTIVE',
-        attributes: {
-          label: node.data.label,
-          // NOTE: needed for analysis SDK JSONSchema
-          name: node.data.label,
-          owner: owner,
-          level: node.data.level,
-          qualifiedName,
-          position: {
-            x: node.position.x,
-            y: node.position.y,
+        // update lookup for parent-child relationship
+        // use qualifiedName if already existing node or negative guid if not
+        parentLookup[node.id] =
+          isUpdate && existingNodes[qualifiedName]
+            ? qualifiedName
+            : currentGuid;
+
+        if (isUpdate && existingNodes[qualifiedName])
+          guidAssignments.push(currentGuid);
+        return {
+          // add GUID if new entity
+          ...(isUpdate && existingNodes[qualifiedName]
+            ? {}
+            : { guid: currentGuid }),
+          typeName: AtlasArchetypeTypeName.Node,
+          status: 'ACTIVE',
+          attributes: {
+            label: node.data.label,
+            // NOTE: needed for analysis SDK JSONSchema
+            name: node.data.label,
+            owner: owner,
+            level: node.data.level,
+            qualifiedName,
+            position: {
+              x: node.position.x,
+              y: node.position.y,
+            },
           },
-        },
-        ...(isUpdate // classifications don't update with POST???
-          ? {}
-          : {
-              classifications: this.mergeClassifications(
-                columnGuid ? true : false, // isLeaf node
-                node.id,
-                node.type,
-                archetype.permissions || [],
-              ),
-            }),
-        relationshipAttributes: {
-          template: {
-            typeName: AtlasArchetypeTypeName.Template,
-            ...(templateGuid
+          ...(isUpdate // classifications don't update with POST???
+            ? {}
+            : {
+                classifications: this.mergeClassifications(
+                  columnGuid ? true : false, // isLeaf node
+                  node.id,
+                  node.type,
+                  archetype.permissions || [],
+                ),
+              }),
+          relationshipAttributes: {
+            template: {
+              typeName: AtlasArchetypeTypeName.Template,
+              ...(templateGuid
+                ? {
+                    guid: templateGuid,
+                  }
+                : {
+                    uniqueAttributes: {
+                      qualifiedName: `${projectId}@${archetype.archetypeId}`,
+                    },
+                  }),
+            },
+            ...(parentId
               ? {
-                  guid: templateGuid,
-                }
-              : {
-                  uniqueAttributes: {
-                    qualifiedName: `${projectId}@${archetype.archetypeId}`,
+                  parent_node: {
+                    typeName: AtlasArchetypeTypeName.Node,
+                    ...(isUpdate && existingNodes[parentIdQualifiedName]
+                      ? {
+                          uniqueAttributes: {
+                            qualifiedName: parentLookup[parentId],
+                          },
+                        }
+                      : { guid: parentLookup[parentId] }),
                   },
-                }),
+                }
+              : {}),
+            ...(columnGuid
+              ? { column: { guid: columnGuid, typeName: 'rdbms_column' } }
+              : {}),
           },
-          ...(parentId
-            ? {
-                parent_node: {
-                  typeName: AtlasArchetypeTypeName.Node,
-                  ...(isUpdate && existingNodes[qualifiedName]
-                    ? {
-                        uniqueAttributes: {
-                          qualifiedName: parentLookup[parentId],
-                        },
-                      }
-                    : { guid: parentLookup[parentId] }),
-                },
-              }
-            : {}),
-          ...(columnGuid
-            ? { column: { guid: columnGuid, typeName: 'rdbms_column' } }
-            : {}),
-        },
-      };
-    });
+        };
+      }),
+      guidAssignments,
+    };
   }
 
   private mergeClassifications(

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -111,7 +111,7 @@ export class AtlasProcessor {
         // 3. create archetype_node entities
         const { columns, nodes } = this.separateColumnsNodes(archetype);
         const entities: AtlasSubmitArchetypeEntityDto[] =
-          this.archetypeTemplateToAtlasEntitities(
+          this.archetypeTemplateToAtlasEntities(
             projectId,
             archetype,
             nodes,
@@ -207,7 +207,7 @@ export class AtlasProcessor {
       entities.push(
         archetypeTemplateBody,
         ...(nodes.length
-          ? this.archetypeTemplateToAtlasEntitities(
+          ? this.archetypeTemplateToAtlasEntities(
               projectId,
               archetype,
               nodes,
@@ -491,7 +491,7 @@ export class AtlasProcessor {
     });
   }
 
-  private archetypeTemplateToAtlasEntitities(
+  private archetypeTemplateToAtlasEntities(
     projectId: string,
     archetype: ArchetypeDto,
     nodes: ArchetypeNodeDto[],

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -155,7 +155,18 @@ export class AtlasProcessor {
         ? this.separateColumnsNodes(archetype)
         : { columns: [], nodes: [] };
 
-      // check relationships aka nodes
+      // get all the node ids
+      const nodeIds = new Set(nodes.map((n) => n.id));
+      // lookup for existing entities
+      const existingNodes: Record<
+        string,
+        {
+          guid: string;
+          classifications: AtlasArchetypeEntityDto['classifications'];
+        }
+      > = {};
+
+      // check for relationships (e.g. archetype_nodes) using archetype_template qualifiedName
       const entityRes = await this.atlas.get<AtlasArchetypeEntityResponseDto>(
         `/entity/uniqueAttribute/type/${AtlasArchetypeTypeName.Template}`,
         {
@@ -165,53 +176,67 @@ export class AtlasProcessor {
         },
       );
 
-      // get all the node ids
-      const nodeIds = new Set(nodes.map((n) => n.id));
-
-      // lookup for already existing nodes
-      const existingNodes: Record<string, string> = Object.fromEntries(
-        (entityRes.entity.relationshipAttributes?.nodes ?? [])
-          .filter(
-            (node) =>
-              node.entityStatus !== 'DELETED' &&
-              nodeIds.has(node.qualifiedName.split('@')[2]),
+      // check if there is any existing linked entities
+      if (Object.keys(entityRes?.referredEntities).length) {
+        for (const key in entityRes?.referredEntities) {
+          const entity = entityRes?.referredEntities[key];
+          const qualifiedName = entity.attributes?.qualifiedName;
+          if (
+            entity.typeName !== AtlasArchetypeTypeName.Node || //
+            entity.status !== 'ACTIVE' ||
+            !nodeIds.has(qualifiedName.split('@').at(-1))
           )
-          .map((node) => [node.qualifiedName, node.guid]),
-      );
+            continue; // skip anything not a Node, not ACTIVE, or not in nodeIds (updated set of archetype_nodes)
 
+          existingNodes[qualifiedName] = {
+            guid: entity.guid,
+            classifications: entity.classifications ?? [],
+          };
+        }
+      }
       // update existing nodes classifications with permissions
-      // TODO: test if also need to update the node_type (e.g. leaf, root, branch)
       // TODO: improve so not flooding the API with requests
       // TODO: improve error handling
-      if (archetype.permissions) {
-        Object.entries(existingNodes).forEach(([qualifiedName, guid]) => {
-          const nodeId = qualifiedName.split('@')[2];
-          const permissions = this.getPermissionClassification(
-            nodeId,
-            archetype.permissions,
-          );
-          if (!permissions.length) return;
+      if (archetype.permissions?.length) {
+        Object.entries(existingNodes).forEach(
+          ([qualifiedName, { guid, classifications }]) => {
+            const nodeId = qualifiedName.split('@').at(-1);
+            const permissions = this.getPermissionClassification(
+              nodeId,
+              archetype.permissions,
+            );
+            if (!permissions.length) return;
 
-          this.atlas
-            .put<AtlasArchetypeEntityResponseDto>(
-              `/entity/guid/${guid}/classifications`,
-              permissions,
-            )
-            .catch((err) =>
+            try {
+              // check if classification already exists for the entity
+              if (this.hasAnalysisPermClassification(guid, classifications)) {
+                this.atlas.put<AtlasArchetypeEntityResponseDto>(
+                  `/entity/guid/${guid}/classifications`,
+                  permissions,
+                );
+              } else {
+                // create classification for existing entity
+                this.atlas.post<AtlasArchetypeEntityResponseDto>(
+                  `/entity/guid/${guid}/classifications`,
+                  permissions,
+                );
+              }
+            } catch (err) {
               this.logger.error(
                 `Failed to set classifications for ${guid}: ${err?.message}`,
-              ),
-            );
-        });
+              );
+            }
+          },
+        );
       }
 
-      // Add archetype_template entity
+      // create archetype_template entity body
       const archetypeTemplateBody: AtlasSubmitArchetypeEntityDto = {
         typeName: AtlasArchetypeTypeName.Template,
         attributes: {
           name: archetype.name,
           projectId: projectId,
-          // using nanoid created in the beginning
+          // using the nanoid i.e. archetypeId as reference
           qualifiedName: `${projectId}@${archetype.archetypeId}`,
           status: archetype.status,
         },
@@ -222,7 +247,7 @@ export class AtlasProcessor {
               projectId,
             },
           },
-          // NOTE: this deletes nodes that have been removed
+          // NOTE: this deletes archetype_nodes that have been removed with the archetype update
           ...(Object.keys(existingNodes).length
             ? {
                 nodes: Object.entries(existingNodes).map(([qualifiedName]) => ({
@@ -247,7 +272,7 @@ export class AtlasProcessor {
           )
         : { entities: [], guidAssignments: [] };
 
-      // add new nodes that are assigned (neg guids)
+      // add any new nodes to archetype_template (neg GUIDs)
       if (guidAssignments.length) {
         const newNodeRefs = guidAssignments.map((guid) => ({
           guid,
@@ -325,7 +350,13 @@ export class AtlasProcessor {
     archetype: ArchetypeDto,
     nodes: ArchetypeNodeDto[],
     columns: ArchetypeNodeDto[],
-    existingNodes: Record<string, string> = {},
+    existingNodes: Record<
+      string,
+      {
+        guid: string;
+        classifications: AtlasArchetypeEntityDto['classifications'];
+      }
+    > = {},
     isUpdate: boolean = false,
     owner?: string,
     templateGuid?: string,
@@ -531,5 +562,17 @@ export class AtlasProcessor {
       [[], []],
     );
     return { columns, nodes };
+  }
+  private hasAnalysisPermClassification(
+    guid: string,
+    classifications: AtlasArchetypeEntityDto['classifications'] | undefined,
+  ): boolean {
+    if (!guid || !classifications?.length) return false;
+    return classifications.some(
+      (c) =>
+        c.typeName === 'archetype_node_analysis_permissions' &&
+        c.entityGuid === guid &&
+        c.entityStatus !== 'DELETED',
+    );
   }
 }

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -132,7 +132,6 @@ export class AtlasProcessor {
         `Handling 'process-add-archetype' for projectId ${projectId} DONE!`,
         `Created archetype ${archetype.archetypeId} with status ${archetype.status}`,
       );
-
       return archetype.archetypeId;
     } catch (error) {
       this.logger.error(
@@ -572,7 +571,7 @@ export class AtlasProcessor {
       (c) =>
         c.typeName === 'archetype_node_analysis_permissions' &&
         c.entityGuid === guid &&
-        c.entityStatus !== 'DELETED',
+        c.entityStatus === 'ACTIVE',
     );
   }
 }

--- a/src/queue/queue.service.ts
+++ b/src/queue/queue.service.ts
@@ -56,13 +56,19 @@ export class QueueService {
     );
   }
 
-  async updateArchetypeJob(projectId, archetypeId, archetype: ArchetypeDto) {
+  async updateArchetypeJob(
+    owner: string,
+    projectId: string,
+    archetypeId: string,
+    archetype: ArchetypeDto,
+  ) {
     this.logger.log(
       `Submitting 'process-update-archetype' to queue for archetypeId ${archetypeId}`,
     );
     return await this.atlasQueue.add(
       'process-update-archetype',
       {
+        owner,
         projectId,
         archetype,
       },
@@ -83,21 +89,6 @@ export class QueueService {
       {
         projectId,
         archetypeId,
-      },
-      {
-        attempts: 5,
-        backoff: 10000,
-      },
-    );
-  }
-
-  // TODO: remove redundant method
-  async addPermissionsJob(permissions: string, projectId: string) {
-    return await this.atlasQueue.add(
-      'process-add-permissions',
-      {
-        permissions,
-        projectId,
       },
       {
         attempts: 5,

--- a/src/queue/queue.service.ts
+++ b/src/queue/queue.service.ts
@@ -67,7 +67,7 @@ export class QueueService {
         archetype,
       },
       {
-        // TODO: add jobid?
+        // NOTE: add jobid?
         attempts: 5,
         backoff: 10000,
       },

--- a/src/queue/queue.service.ts
+++ b/src/queue/queue.service.ts
@@ -34,7 +34,11 @@ export class QueueService {
     );
   }
 
-  async addArchetypeJob(owner: string, archetype: ArchetypeDto) {
+  async addArchetypeJob(
+    owner: string,
+    projectId: string,
+    archetype: ArchetypeDto,
+  ) {
     this.logger.log(
       `Submitting 'process-add-archetype' to queue for projectId ${archetype.projectId}`,
     );
@@ -42,7 +46,7 @@ export class QueueService {
       'process-add-archetype',
       {
         owner,
-        projectId: archetype.projectId,
+        projectId: projectId,
         archetype,
       },
       {
@@ -52,14 +56,14 @@ export class QueueService {
     );
   }
 
-  async updateArchetypeJob(archetype: ArchetypeDto) {
+  async updateArchetypeJob(projectId, archetypeId, archetype: ArchetypeDto) {
     this.logger.log(
-      `Submitting 'process-update-archetype' to queue for archetypeId ${archetype.archetypeId}`,
+      `Submitting 'process-update-archetype' to queue for archetypeId ${archetypeId}`,
     );
     return await this.atlasQueue.add(
       'process-update-archetype',
       {
-        projectId: archetype.projectId,
+        projectId,
         archetype,
       },
       {


### PR DESCRIPTION
**Changes**:
- fix `auth.module` exclude variables - NestJS warnings cleared
- added proper Swagger (API docs) annotations to `archetype.controller` + `archetype.dto`'s - see http://localhost/api/v1/hub/docs#/Archetype. @chuleeshen, we should do the same for all other containers to have a proper API docs for the platform
- added classification permissions updates for existing nodes - more testing and error handling needed (will do another issue for it)
- fixed update archetype so it will compare the existing nodes in Atlas (i.e. Relationships of `archetype_template`) and the incoming updated Archetype structure and delete and update them accordingly
- added relationships for `archetype_template` for new created GUIDs (negative GUIDs) made as part of the UPDATE, so they don't get deleted straight away with the POST `/entities/bulk` request

**Notes**:
Discovered couple of bugs in the frontend with delete and update archetypes related see https://github.com/Epsilon-Data/frontend/issues/77 and https://github.com/Epsilon-Data/frontend/issues/78