### PR TITLE
feat!: refactor project endpoints

### DIFF
--- a/src/analysis/analysis.controller.ts
+++ b/src/analysis/analysis.controller.ts
@@ -44,8 +44,8 @@ export class AnalysisController {
       request,
     );
     if (permissions)
-      //TODO: may need a different query for the project to get info for SDK
-      return await this.projectService.getUserProjects(permissions);
+      //TODO: need a different query for the project to get info for SDK
+      return await this.projectService.getUserSharedProjects(permissions);
   }
 
   @Get('datasets/:projectId')

--- a/src/archetype/archetype.controller.ts
+++ b/src/archetype/archetype.controller.ts
@@ -76,7 +76,7 @@ export class ArchetypeController {
   }
 
   @UseGuards(ResourceGuard)
-  @Scopes('view', 'edit')
+  @Scopes('view, edit')
   @Post(':projectId')
   @HttpCode(HttpStatus.ACCEPTED)
   @ApiOperation({ summary: 'Create archetype for a project' })

--- a/src/archetype/archetype.service.spec.ts
+++ b/src/archetype/archetype.service.spec.ts
@@ -15,6 +15,7 @@ import {
 } from 'src/atlas/dto';
 import { ArchetypeNodeType, ArchetypePermission, ArchetypeStatus } from './dto';
 import { Logger } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
 
 describe('ArchetypeService', () => {
   let service: ArchetypeService;
@@ -36,6 +37,12 @@ describe('ArchetypeService', () => {
         {
           provide: AtlasService,
           useValue: { get: jest.fn(), post: jest.fn(), put: jest.fn() },
+        },
+        {
+          provide: PrismaService,
+          useValue: {
+            project: { update: jest.fn() },
+          },
         },
         { provide: QueueService, useValue: mockQueue },
       ],

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { AtlasService } from 'src/atlas/atlas.service';
 import { QueueService } from 'src/queue/queue.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { $Enums } from '@prisma/client';
 import {
   ArchetypeDto,
   ArchetypeEdgeDto,
@@ -8,6 +10,7 @@ import {
   ArchetypeNodeType,
   ArchetypePermission,
   ArchetypeStatus,
+  UpdateArchetypeAttributesDto,
 } from './dto';
 import {
   AtlasArchetypeEntityResponseDto,
@@ -24,6 +27,7 @@ export class ArchetypeService {
   constructor(
     private atlas: AtlasService,
     private readonly queue: QueueService,
+    private prisma: PrismaService,
   ) {}
 
   // Queries
@@ -365,7 +369,7 @@ export class ArchetypeService {
   async updateArchetypeDetails(
     projectId: string,
     archetypeId: string,
-    attributes: unknown,
+    attributes: UpdateArchetypeAttributesDto,
     token?: string,
   ) {
     try {
@@ -382,7 +386,16 @@ export class ArchetypeService {
         },
         token,
       );
-      return;
+      if (attributes.status && attributes.status === ArchetypeStatus.PUBLISHED)
+        await this.prisma.project.update({
+          where: { projectId: projectId },
+          data: {
+            lastModified: new Date(),
+            status: $Enums.ProjectStatus.MAPPED,
+          },
+        });
+
+      return; // NO CONTENT
     } catch (error) {
       this.logger.error(`Error updating archetype details`, error);
       throw error;

--- a/src/project/dto/project.dto.ts
+++ b/src/project/dto/project.dto.ts
@@ -11,8 +11,77 @@ import {
   IsObject,
   ValidateNested,
   IsUrl,
+  IsEnum,
 } from 'class-validator';
 import { parseInteger, transformDateString } from 'src/utils/class.util';
+
+import { $Enums } from '@prisma/client';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ProjectListDto {
+  @ApiProperty({
+    description: 'Unique project identifier (UUID or slug)',
+    example: 'proj_123abc456',
+  })
+  @IsString()
+  projectId!: string;
+
+  @ApiProperty({
+    description: 'Custom human-readable project identifier',
+    example: 'HRT-2025-001',
+  })
+  @IsString()
+  customId!: string;
+
+  @ApiProperty({
+    description: 'Project name',
+    example: 'Heart Rate Variability Study',
+  })
+  @IsString()
+  name!: string;
+
+  @ApiProperty({
+    description: 'University associated with this project',
+    example: 'University of Oxford',
+  })
+  @IsString()
+  university!: string;
+
+  @ApiProperty({
+    description: 'Faculty or department within the university',
+    example: 'Department of Biomedical Engineering',
+  })
+  @IsString()
+  faculty!: string;
+
+  @ApiProperty({
+    description: 'Timestamp of last modification',
+    example: '2025-11-12T09:30:00.000Z',
+    type: String,
+    format: 'date-time',
+  })
+  @Type(() => Date)
+  @IsDate()
+  lastModified!: Date;
+
+  @ApiProperty({
+    description: 'Timestamp when the project was created',
+    example: '2025-10-01T14:45:00.000Z',
+    type: String,
+    format: 'date-time',
+  })
+  @Type(() => Date)
+  @IsDate()
+  createdDate!: Date;
+
+  @ApiProperty({
+    description: 'Current project lifecycle status',
+    enum: $Enums.ProjectStatus,
+    example: $Enums.ProjectStatus.ACTIVE,
+  })
+  @IsEnum($Enums.ProjectStatus)
+  status!: $Enums.ProjectStatus;
+}
 
 class DatabaseDto {
   @IsOptional()

--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -12,11 +12,20 @@ import {
   UploadedFile,
   ParseFilePipe,
   Query,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
   // UseGuards,
 } from '@nestjs/common';
 import { ProjectService } from './project.service';
-import { ProjectDto, SettingsDto } from './dto';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ProjectDto, ProjectListDto, SettingsDto } from './dto';
+import {
+  ApiBearerAuth,
+  ApiNoContentResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { coverOptions } from 'src/utils/options.util';
 import { KeycloakService } from 'src/auth/keycloak/keycloak.service';
@@ -24,57 +33,69 @@ import { CurrentUser } from 'src/common/decorators/user.decorator';
 import type { CurrentUserInfo } from 'src/common/decorators/user.decorator';
 import type { Request } from 'express';
 
-// import { Resource } from 'src/common/decorators/resource.decorator';
-// import { Scopes } from 'src/common/decorators/scopes.decorator';
-// import { ResourceGuard } from 'src/common/guards/resource.guard';
+import { Resource } from 'src/common/decorators/resource.decorator';
+import { Scopes } from 'src/common/decorators/scopes.decorator';
+import { ResourceGuard } from 'src/common/guards/resource.guard';
 
 @ApiTags('Project')
+@ApiBearerAuth()
 @Controller('project')
+@Resource('project')
 export class ProjectController {
   constructor(
     private projectService: ProjectService,
     private keycloakConnect: KeycloakService,
   ) {}
 
-  @Get('own')
+  @Get('')
   @ApiOperation({ summary: 'Get list of projects owned by logged in user' })
+  @ApiOkResponse({
+    description: 'List of user owner projects are returned',
+    type: ProjectListDto,
+    isArray: true,
+  })
   async getUserOwnedProjects(@CurrentUser() user: CurrentUserInfo) {
     return await this.projectService.getUserOwnedProjects(user.id);
   }
 
-  @Get('share')
-  async getUserSharedProjects(@CurrentUser() user: CurrentUserInfo) {
-    return await this.projectService.getUserSharedProjects(user.email);
-  }
-
-  @Get('')
-  @ApiOperation({ summary: 'Get list of all projects for logged in user' })
-  async getUserProjects(@Req() request: Request) {
+  @Get('shared')
+  @ApiOperation({ summary: 'Get list of projects user is collaborator on' })
+  @ApiOkResponse({
+    description: 'List of collaborator projects are returned',
+    type: ProjectListDto,
+    isArray: true,
+  })
+  async getUserSharedProjects(@Req() request: Request) {
     // check for user resource permissions
-    // TODO: perhaps call this once and cache
+    // TODO: perhaps call this once and cache or make it into a helper/decorator
     const authzRequest = {
       response_mode: 'permissions',
     };
-
     const permissions = await this.keycloakConnect.getPermissions(
       authzRequest,
       request,
     );
-    return await this.projectService.getUserProjects(permissions);
+    return await this.projectService.getUserSharedProjects(permissions);
   }
 
   @Get('all')
   @ApiOperation({ summary: 'Get list of all projects' })
+  @ApiOkResponse({
+    description: 'List of all projects',
+    type: ProjectListDto,
+    isArray: true,
+  })
   async getAllProjects() {
     return await this.projectService.getAllProjects();
   }
 
-  // NOTE: example usage of resource guard
-  // @Resource('Project')
-  // @UseGuards(ResourceGuard)
-  // @Scopes('view,edit')
+  @UseGuards(ResourceGuard)
+  @Scopes('view')
   @Get(':projectId/requests')
   @ApiOperation({ summary: 'Get list of incoming requests' })
+  @ApiOkResponse({
+    description: 'List of analysis and connection requests for the projects',
+  })
   async getProjectRequests(
     @CurrentUser() user: CurrentUserInfo,
     @Param('projectId', ParseUUIDPipe) projectId: string,
@@ -84,21 +105,35 @@ export class ProjectController {
 
   @Post()
   @ApiOperation({ summary: 'Create project' })
+  @ApiOkResponse({
+    description: 'Created project data is returned',
+  })
   createProject(@CurrentUser() user: CurrentUserInfo, @Body() dto: ProjectDto) {
     // TODO: we need to make sure that we actually use usernames because these will be needed for atlas authorization as emails will change which break ownership lookups and Ranger policies
     return this.projectService.createProject(user.username, dto);
   }
 
+  @UseGuards(ResourceGuard)
+  @Scopes('view')
   @Get(':projectId')
   @ApiOperation({ summary: 'Get project details' })
+  @ApiOkResponse({
+    description: 'Project details are returned',
+  })
   async getProjectDetails(
     @Param('projectId', ParseUUIDPipe) projectId: string,
   ) {
     return await this.projectService.getProjectDetails(projectId);
   }
 
+  @UseGuards(ResourceGuard)
+  @Scopes('view, edit')
   @Put(':projectId')
   @ApiOperation({ summary: 'Edit project' })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiNoContentResponse({
+    description: 'Project details updated',
+  })
   updateProject(
     @Param('projectId', ParseUUIDPipe) projectId: string,
     @Body() dto: ProjectDto,
@@ -106,22 +141,39 @@ export class ProjectController {
     return this.projectService.updateProject(projectId, dto);
   }
 
+  @UseGuards(ResourceGuard)
+  @Scopes('view, edit, delete')
   @Delete(':projectId')
   @ApiOperation({ summary: 'Delete project' })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiNoContentResponse({
+    description: 'Project deleted',
+  })
   deleteProject(@Param('projectId', ParseUUIDPipe) projectId: string) {
     return this.projectService.deleteProject(projectId);
   }
 
+  @UseGuards(ResourceGuard)
+  @Scopes('view')
   @Get(':projectId/settings')
   @ApiOperation({ summary: 'Get project settings' })
+  @ApiOkResponse({
+    description: 'Project settings are returned',
+  })
   async getProjectSettings(
     @Param('projectId', ParseUUIDPipe) projectId: string,
   ) {
     return await this.projectService.getProjectSettings(projectId);
   }
 
+  @UseGuards(ResourceGuard)
+  @Scopes('view, edit')
   @Put(':projectId/settings')
   @ApiOperation({ summary: 'Update project settings' })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiNoContentResponse({
+    description: 'Project settings are updated',
+  })
   async updateProjectSettings(
     @Param('projectId', ParseUUIDPipe) projectId: string,
     @Body() dto: SettingsDto,
@@ -129,8 +181,13 @@ export class ProjectController {
     return await this.projectService.updateProjectSettings(projectId, dto);
   }
 
-  @Post('upload-cover')
+  @UseGuards(ResourceGuard)
+  @Scopes('view, edit')
+  @Post(':projectId/upload-cover')
   @UseInterceptors(FileInterceptor('file', coverOptions))
+  @ApiNoContentResponse({
+    description: 'Project cover image is returned',
+  })
   async uploadProjectCover(
     @UploadedFile(new ParseFilePipe())
     file: Express.Multer.File,

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
-import { ProjectDto, SettingsDto } from './dto';
+import { ProjectDto, ProjectListDto, SettingsDto } from './dto';
 import { FileStorageService } from 'src/file_storage/file_storage.service';
 import { KeycloakAdminService } from 'src/admin/keycloak/keycloak.admin.service';
 import { nanoid } from 'nanoid';
@@ -9,6 +9,7 @@ import { QueueService } from 'src/queue/queue.service';
 import { KeycloakPermissionDto } from 'src/auth/keycloak/dto';
 @Injectable()
 export class ProjectService {
+  private readonly logger = new Logger(ProjectService.name);
   constructor(
     private prisma: PrismaService,
     private queue: QueueService,
@@ -16,7 +17,7 @@ export class ProjectService {
     private readonly keycloak: KeycloakAdminService,
   ) {}
 
-  async getUserOwnedProjects(userId: string) {
+  async getUserOwnedProjects(userId: string): Promise<ProjectListDto[]> {
     const projects = await this.prisma.project.findMany({
       where: {
         ownerId: userId,
@@ -40,28 +41,15 @@ export class ProjectService {
     return projects;
   }
 
-  async getUserSharedProjects(userEmail: string) {
-    const projects = await this.prisma.$queryRaw<
-      Array<{
-        projectId: string;
-        customId: string;
-        name: string;
-        lastModified: Date;
-        createdDate: Date;
-        status: string;
-        university: string | null;
-        faculty: string | null;
-      }>
-    >`
-    SELECT "projectId","customId","name","lastModified","createdDate","status","university","faculty"
-    FROM "Project"
-    WHERE "members"::jsonb @> ${JSON.stringify([{ email: userEmail }])}::jsonb
-  `;
-    return projects;
-  }
-
-  async getUserProjects(permissions: KeycloakPermissionDto[]) {
-    const uuids = permissions.map((item) => item.rsname.split(':')[1]);
+  async getUserSharedProjects(
+    permissions: KeycloakPermissionDto[],
+  ): Promise<ProjectListDto[]> {
+    const uuids = permissions
+      .filter(
+        (item) =>
+          item.scopes.includes('view') && !item.scopes.includes('delete'),
+      )
+      .map((item) => item.rsname.split(':').at(1)!);
     const projects = await this.prisma.project.findMany({
       where: {
         projectId: {
@@ -87,7 +75,7 @@ export class ProjectService {
     return await this.prisma.project.findMany({
       where: {
         status: {
-          in: ['MAPPED', 'LINKED', 'ACTIVE'],
+          in: ['MAPPED'],
         },
       },
       select: {
@@ -96,7 +84,6 @@ export class ProjectService {
         name: true,
         lastModified: true,
         createdDate: true,
-        status: true,
         university: true,
         faculty: true,
       },
@@ -248,6 +235,7 @@ export class ProjectService {
 
     return project;
   }
+
   async getProjectDetails(projectId: string) {
     const project = await this.prisma.project.findFirst({
       where: {
@@ -328,7 +316,7 @@ export class ProjectService {
         cover: cover || null,
       };
     }
-    return null;
+    return {};
   }
 
   async updateProjectSettings(projectId: string, dto: SettingsDto) {
@@ -341,6 +329,7 @@ export class ProjectService {
       },
     });
 
+    // TODO: check this
     await this.fileStorage.deleteFile('cover', `${projectId}`);
     return projectId;
   }


### PR DESCRIPTION
BREAKING CHANGES for frontend. https://github.com/Epsilon-Data/frontend/pull/90 needs to dealt with first!

**Changes:**
- changed `/project` endpoints to return owned projects (GET `/project`) and shared/collaborator projects (GET `/project/shared`  - @chuleeshen, you need to make changes to the frontend api calls (https://github.com/Epsilon-Data/frontend/pull/90)
- added swagger documentation to existing project endpoints - needs a bit more work to get the proper DTOs into the swagger as well
- added auth guards to current project endpoints
- change `/project/all` to only return projects with `MAPPED` status - @chuleeshen, refer to my comment on your related PR about the statuses (https://github.com/Epsilon-Data/frontend/pull/90)
- added project status change to `MAPPED` when an archetype for a project is set to `PUBLISHED`

**Future:**
- @chuleeshen, I noticed that the BrowseHub is using the same API endpoints to get project info, we need to make new public (for logged in users) that return less information (no credentials etc.) to be shown. I will do that once you start with the BrowseHub explore tasks in https://github.com/Epsilon-Data/frontend/issues/22
- there are some questionable `/project` endpoint that add settings, we need to see if all of those are in use still, so some refactoring required
- proper dto's/types are needed for comprehensive swagger api docs 