### PR TITLE
73 tests for project service

### DIFF
--- a/prisma/migrations/20251113100740_modify_project_statuses/migration.sql
+++ b/prisma/migrations/20251113100740_modify_project_statuses/migration.sql
@@ -1,0 +1,40 @@
+/*
+  Warnings:
+
+  - The values [ACTIVE,LINKED] on the enum `ProjectStatus` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+
+-- AlterEnum add new statuses
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+BEGIN;
+ALTER TYPE "ProjectStatus" ADD VALUE 'PENDING';
+ALTER TYPE "ProjectStatus" ADD VALUE 'READY';
+COMMIT;
+
+-- Update existing data
+UPDATE "Project" SET "status" = 'READY' WHERE "status" = 'ACTIVE';
+
+-- AlterEnum
+BEGIN;
+CREATE TYPE "ProjectStatus_new" AS ENUM ('PENDING', 'CRAWLING', 'ERROR', 'READY', 'MAPPED');
+ALTER TABLE "public"."Project" ALTER COLUMN "status" DROP DEFAULT;
+ALTER TABLE "Project" ALTER COLUMN "status" TYPE "ProjectStatus_new" USING ("status"::text::"ProjectStatus_new");
+ALTER TYPE "ProjectStatus" RENAME TO "ProjectStatus_old";
+ALTER TYPE "ProjectStatus_new" RENAME TO "ProjectStatus";
+DROP TYPE "public"."ProjectStatus_old";
+ALTER TABLE "Project" ALTER COLUMN "status" SET DEFAULT 'PENDING';
+COMMIT;
+
+-- DropForeignKey
+ALTER TABLE "Connection" DROP CONSTRAINT "fk_connection_project_id";
+
+-- AlterTable
+ALTER TABLE "Project" ALTER COLUMN "status" SET DEFAULT 'PENDING';
+
+-- AddForeignKey
+ALTER TABLE "Connection" ADD CONSTRAINT "fk_connection_project_id" FOREIGN KEY ("projectId") REFERENCES "Project"("projectId") ON DELETE CASCADE ON UPDATE NO ACTION;

--- a/prisma/migrations/20251113115105_connection_make_request_optional/migration.sql
+++ b/prisma/migrations/20251113115105_connection_make_request_optional/migration.sql
@@ -1,0 +1,13 @@
+/*
+  Warnings:
+
+  - The primary key for the `Connection` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - A unique constraint covering the columns `[requestId]` on the table `Connection` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "Connection" DROP CONSTRAINT "Connection_pkey",
+ALTER COLUMN "requestId" DROP NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Connection_requestId_key" ON "Connection"("requestId");

--- a/prisma/migrations/20251113121036_connection_add_id/migration.sql
+++ b/prisma/migrations/20251113121036_connection_add_id/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - The required column `id` was added to the `Connection` table with a prisma-level default value. This is not possible if the table is not empty. Please add this column as optional, then populate it before making it required.
+
+*/
+-- AlterTable
+-- add id  column as nullable
+ALTER TABLE "Connection" ADD COLUMN "id" UUID;
+
+-- backfill existing rows with a UUID
+UPDATE "Connection" SET "id" = gen_random_uuid() WHERE "id" IS NULL;
+
+
+-- make id into key
+ALTER TABLE "Connection" ALTER COLUMN "id" SET NOT NULL;
+ALTER TABLE "Connection" ADD CONSTRAINT "connection_pkey" PRIMARY KEY ("id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,12 +28,13 @@ model Comment {
 }
 
 model Connection {
-  requestId     String  @id @db.Uuid
-  projectId     String  @unique @db.Uuid
-  orgAdminEmail String? @db.Text
-  tempDbDetails Json?   @db.Json
-  request       Request @relation(fields: [requestId], references: [requestId], onDelete: NoAction, onUpdate: NoAction, map: "fk_connection_request_id")
-  project       Project @relation(fields: [projectId], references: [projectId], onDelete: Cascade, onUpdate: NoAction, map: "fk_connection_project_id")
+  id            String   @id(map: "connection_pkey") @default(uuid()) @db.Uuid
+  requestId     String?  @unique @db.Uuid
+  projectId     String   @unique @db.Uuid
+  orgAdminEmail String?  @db.Text
+  tempDbDetails Json?    @db.Json
+  request       Request? @relation(fields: [requestId], references: [requestId], onDelete: NoAction, onUpdate: NoAction, map: "fk_connection_request_id")
+  project       Project  @relation(fields: [projectId], references: [projectId], onDelete: Cascade, onUpdate: NoAction, map: "fk_connection_project_id")
 }
 
 model Analysis {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,7 +33,7 @@ model Connection {
   orgAdminEmail String? @db.Text
   tempDbDetails Json?   @db.Json
   request       Request @relation(fields: [requestId], references: [requestId], onDelete: NoAction, onUpdate: NoAction, map: "fk_connection_request_id")
-  project       Project @relation(fields: [projectId], references: [projectId], onDelete: NoAction, onUpdate: NoAction, map: "fk_connection_project_id")
+  project       Project @relation(fields: [projectId], references: [projectId], onDelete: Cascade, onUpdate: NoAction, map: "fk_connection_project_id")
 }
 
 model Analysis {
@@ -74,7 +74,7 @@ model Project {
   dbKeywords      String[]
   createdDate     DateTime      @default(now()) @db.Date
   visualizations  Json?         @db.Json
-  status          ProjectStatus @default(CRAWLING)
+  status          ProjectStatus @default(PENDING)
   connection      Connection?
   analysis        Analysis[]
 
@@ -123,11 +123,11 @@ enum NotificationStatus {
 }
 
 enum ProjectStatus {
+  PENDING
   CRAWLING
-  ACTIVE
   ERROR
+  READY
   MAPPED
-  LINKED
 }
 
 enum RequestStatus {

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -1,9 +1,10 @@
 import { Controller, Get, Param, UseGuards } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { KeycloakAdminService } from './keycloak/keycloak.admin.service';
 import { ScopesGuard } from 'src/common/guards/scopes.guard';
 
 @ApiTags('Keycloak Admin')
+@ApiBearerAuth()
 @Controller('admin')
 export class AdminController {
   constructor(private readonly keycloakService: KeycloakAdminService) {}

--- a/src/analysis/analysis.controller.ts
+++ b/src/analysis/analysis.controller.ts
@@ -7,7 +7,7 @@ import {
   Post,
   Req,
 } from '@nestjs/common';
-import { ApiOperation } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
 import { KeycloakAdminService } from 'src/admin/keycloak/keycloak.admin.service';
 import { KeycloakService } from 'src/auth/keycloak/keycloak.service';
 import { ProjectService } from 'src/project/project.service';
@@ -16,6 +16,7 @@ import { ArchetypeService } from 'src/archetype/archetype.service';
 import type { Request } from 'express';
 
 @Controller('analysis')
+@ApiBearerAuth()
 export class AnalysisController {
   constructor(
     private readonly archetypeService: ArchetypeService,

--- a/src/analysis_request/analysis_request.controller.ts
+++ b/src/analysis_request/analysis_request.controller.ts
@@ -13,11 +13,12 @@ import {
 import { AnalysisRequestService } from './analysis_request.service';
 import { ScopesGuard } from 'src/common/guards/scopes.guard';
 import { AnalysisDto } from './dto';
-import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { CurrentUser } from 'src/common/decorators/user.decorator';
 import type { CurrentUserInfo } from 'src/common/decorators/user.decorator';
 
 @ApiTags('Analysis Request')
+@ApiBearerAuth()
 @Controller('analysis-request')
 export class AnalysisRequestController {
   constructor(private analysisRequestService: AnalysisRequestService) {}

--- a/src/analysis_request/dto/analysis_request.dto.ts
+++ b/src/analysis_request/dto/analysis_request.dto.ts
@@ -1,4 +1,5 @@
-import { Transform } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
 import {
   IsDefined,
   IsNotEmpty,
@@ -6,7 +7,9 @@ import {
   IsUUID,
   IsDate,
   IsOptional,
+  ValidateNested,
 } from 'class-validator';
+import { RequestDto } from 'src/connection_request/dto';
 
 import { transformDateString } from 'src/utils/class.util';
 
@@ -79,4 +82,24 @@ export class AnalysisDto {
   @IsString()
   @IsNotEmpty()
   projectEthicsId: string;
+}
+
+export class AnalysisRequestResponseDto {
+  @ApiProperty({
+    type: () => RequestDto,
+    nullable: true,
+    description: 'Request object',
+  })
+  @IsDefined()
+  @ValidateNested()
+  @Type(() => RequestDto)
+  request: RequestDto;
+
+  @ApiProperty({
+    description: 'Project name',
+    example: 'Health Project',
+  })
+  @IsDefined()
+  @IsString()
+  projectName: string;
 }

--- a/src/archetype/archetype.service.spec.ts
+++ b/src/archetype/archetype.service.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Test, TestingModule } from '@nestjs/testing';
 import { ArchetypeService } from './archetype.service';
@@ -530,7 +531,10 @@ describe('ArchetypeService', () => {
       const projectId = '638c6f81-00c8-47f4-82ec-6b94240e757d';
       const archetypeId = 'Xa7BAIWZCA8u';
       const token = 'test-token';
-      const attributes = { name: 'New Name', status: 'PUBLISHED' };
+      const attributes = {
+        name: 'New Name',
+        status: ArchetypeStatus.PUBLISHED,
+      };
 
       atlas.put.mockResolvedValueOnce({});
 
@@ -564,7 +568,7 @@ describe('ArchetypeService', () => {
     it('logs and rethrows when Atlas PUT fails', async () => {
       const projectId = 'p';
       const archetypeId = 'a';
-      const attributes = { status: 'DRAFT' };
+      const attributes = { status: ArchetypeStatus.DRAFT };
       const err = new Error('Atlas PUT failed');
       atlas.put.mockRejectedValueOnce(err);
 

--- a/src/atlas/atlas.service.spec.ts
+++ b/src/atlas/atlas.service.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -32,6 +32,19 @@ import { KeycloakService } from './keycloak/keycloak.service';
 export class AuthModule implements NestModule {
   constructor(private configService: ConfigService) {}
   configure(consumer: MiddlewareConsumer) {
+    const excludes = [
+      { path: 'health', method: RequestMethod.GET },
+      { path: 'analysis/*path', method: RequestMethod.ALL },
+    ];
+
+    // only add docs if dev
+    if (this.configService.get<boolean>('isDev')) {
+      excludes.push(
+        { path: 'docs', method: RequestMethod.GET },
+        { path: 'docs/*path', method: RequestMethod.GET },
+      );
+    }
+
     consumer
       .apply(
         // TODO: investigate this
@@ -43,12 +56,7 @@ export class AuthModule implements NestModule {
           audience: this.configService.get<string>('auth.audience'),
         }),
       )
-      .exclude(
-        { path: 'health', method: RequestMethod.GET },
-        { path: 'docs', method: RequestMethod.GET },
-        { path: 'docs/*path', method: RequestMethod.GET }, // TODO: only in dev
-        { path: 'analysis/*path', method: RequestMethod.ALL },
-      )
+      .exclude(...excludes)
       .forRoutes('*path');
   }
 

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -46,7 +46,7 @@ export class AuthModule implements NestModule {
       .exclude(
         { path: 'health', method: RequestMethod.GET },
         { path: 'docs', method: RequestMethod.GET },
-        { path: 'docs/*path', method: RequestMethod.GET },
+        { path: 'docs/*path', method: RequestMethod.GET }, // TODO: only in dev
         { path: 'analysis/*path', method: RequestMethod.ALL },
       )
       .forRoutes('*path');

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -1,9 +1,10 @@
 import { Body, Controller, Post } from '@nestjs/common';
 import { ChatService } from './chat.service';
 import { CommentDto } from './dto';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 
 @ApiTags('Chat')
+@ApiBearerAuth()
 @Controller('chat')
 export class ChatController {
   constructor(private readonly chatService: ChatService) {}

--- a/src/common/dto/error.dto.ts
+++ b/src/common/dto/error.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsString, IsArray, ValidateIf } from 'class-validator';
+
+export class ErrorResponseDto {
+  @ApiProperty({ example: 404 })
+  @IsNumber()
+  statusCode!: number;
+
+  @ApiProperty({
+    example: 'Resource not found',
+    oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+  })
+  // When message is a string
+  @ValidateIf((o: ErrorResponseDto) => typeof o.message === 'string')
+  @IsString()
+  // When message is an array of strings
+  @ValidateIf((o: ErrorResponseDto) => Array.isArray(o.message))
+  @IsArray()
+  @IsString({ each: true })
+  message!: string | string[];
+
+  @ApiProperty({ example: 'Not Found' })
+  @IsString()
+  error!: string;
+}

--- a/src/common/dto/index.ts
+++ b/src/common/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './error.dto';

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -3,7 +3,7 @@ const { env } = process;
 const trustedWebOrigins = () =>
   (
     env.EPSILON_AUTH_TRUSTED_WEB_ORIGIN ||
-    'http://localhost:3000,http://localhost:3334'
+    'http://localhost:3000,http://localhost:3334,http://localhost:4173/'
   )
     .split(',')
     .map((origin) => origin.trim());

--- a/src/connection_request/connection_request.controller.ts
+++ b/src/connection_request/connection_request.controller.ts
@@ -11,6 +11,7 @@ import {
 import { ConnectionRequestService } from './connection_request.service';
 import { DatabaseInfoDto } from './dto';
 import {
+  ApiBearerAuth,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
@@ -26,6 +27,7 @@ import type { CurrentUserInfo } from 'src/common/decorators/user.decorator';
 // import { ScopesGuard } from 'src/common/guards/scopes.guard';
 
 @ApiTags('Connection Request')
+@ApiBearerAuth()
 // @Resource('project')
 @Controller('connection-request')
 export class ConnectionRequestController {

--- a/src/connection_request/dto/connection_request.dto.ts
+++ b/src/connection_request/dto/connection_request.dto.ts
@@ -1,17 +1,17 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString, IsUUID } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 
 export class DatabaseInfoDto {
   @ApiProperty({
-    description: 'Logical database name (database)',
-    example: 'analytics_dw',
+    description: 'User assigned database name',
+    example: 'Health database',
   })
   @IsString()
   name: string;
 
   @ApiProperty({
-    description: 'Database engine/type',
-    example: 'postgres', // e.g. postgres | mysql | mssql | oracle | sqlite
+    description: 'Database engine/ file type',
+    example: 'postgres', // e.g. postgres | mysql | mssql | oracle | sqlite | CSV
   })
   @IsString()
   type: string;
@@ -58,13 +58,4 @@ export class DatabaseInfoDto {
   @IsOptional()
   @IsString()
   password?: string;
-
-  @ApiPropertyOptional({
-    description: 'Associated project identifier',
-    format: 'uuid',
-    example: '638c6f81-00c8-47f4-82ec-6b94240e757d',
-  })
-  @IsOptional()
-  @IsUUID()
-  projectId?: string;
 }

--- a/src/connection_request/dto/connection_request.dto.ts
+++ b/src/connection_request/dto/connection_request.dto.ts
@@ -1,9 +1,12 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { $Enums } from '@prisma/client';
+import { $Enums, Prisma } from '@prisma/client';
 import { Type } from 'class-transformer';
 import {
+  IsArray,
   IsDate,
   IsEnum,
+  IsJSON,
+  IsObject,
   IsOptional,
   IsString,
   IsUUID,
@@ -43,7 +46,6 @@ export class DatabaseInfoDto {
 
   @ApiPropertyOptional({
     description: 'Full connection URL (if provided, may supersede host/port)',
-    type: String,
     format: 'uri',
     example: 'postgres://user:pass@db.internal.company.local:5432/analytics_dw',
   })
@@ -69,15 +71,7 @@ export class DatabaseInfoDto {
   password?: string;
 }
 
-export class RequestDto {
-  @ApiProperty({
-    type: Date,
-    description: 'The date the request was created',
-  })
-  @IsDate()
-  @Type(() => Date)
-  createdDate: Date;
-
+export class ConnectionDto {
   @ApiPropertyOptional({
     description: 'Incoming request identifier',
     format: 'uuid',
@@ -87,6 +81,99 @@ export class RequestDto {
   @IsUUID()
   requestId?: string;
 
+  @ApiPropertyOptional({
+    description:
+      'Email of the organisation admin assigned to the project or owner',
+    example: 'admin@university.edu',
+  })
+  @IsOptional()
+  @IsString()
+  orgAdminEmail?: string;
+
+  @ApiPropertyOptional({
+    description: 'Temporary database connection details',
+    type: DatabaseInfoDto,
+  })
+  @IsOptional()
+  @IsObject()
+  @ValidateNested()
+  @Type(() => DatabaseInfoDto)
+  tempDbDetails?: DatabaseInfoDto;
+
+  @ApiPropertyOptional({
+    description: 'Miscellaneous extra information provided by the user',
+    example: 'Extra information and comments',
+  })
+  @IsOptional()
+  @IsString()
+  additionalInfo?: string;
+}
+
+export class ConnectionRequestDto {
+  @ApiPropertyOptional({
+    description: 'Connection request',
+    type: () => [RequestDto],
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => RequestDto)
+  request?: RequestDto | null;
+
+  @ApiPropertyOptional({
+    description: 'Incoming request identifier',
+    format: 'uuid',
+    example: '8b7e2f36-9217-4ea0-8d6e-b621fb6e5230',
+    nullable: true,
+  })
+  @IsUUID()
+  requestId!: string | null;
+
+  @ApiPropertyOptional({
+    description:
+      'Email of the organisation admin assigned to the project or owner',
+    example: 'admin@university.edu',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  orgAdminEmail?: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Temporary database connection details',
+    type: Object,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsJSON()
+  tempDbDetails?: Prisma.JsonValue | null;
+}
+export class RequestDto {
+  @ApiProperty({
+    description: 'Incoming request identifier',
+    format: 'uuid',
+    example: '8b7e2f36-9217-4ea0-8d6e-b621fb6e5230',
+  })
+  @IsUUID()
+  requestId!: string;
+
+  @ApiProperty({
+    type: Date,
+    description: 'The date the request was created',
+  })
+  @IsDate()
+  @Type(() => Date)
+  createdDate: Date;
+
+  @ApiPropertyOptional({
+    type: Date,
+    description: 'The date the request was last modified',
+  })
+  @IsOptional()
+  @IsDate()
+  @Type(() => Date)
+  lastModified?: Date;
+
   @ApiProperty({
     enum: $Enums.RequestStatus,
     description: 'The status of the request',
@@ -94,18 +181,76 @@ export class RequestDto {
   })
   @IsEnum($Enums.RequestStatus)
   status: $Enums.RequestStatus;
+
+  @ApiPropertyOptional({
+    description: 'Incoming request identifier',
+    format: 'uuid',
+    example: '8b7e2f36-9217-4ea0-8d6e-b621fb6e5230',
+  })
+  @IsOptional()
+  @IsUUID()
+  requestorId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Request comments',
+    type: () => [RequestCommentDto],
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => RequestCommentDto)
+  comments?: RequestCommentDto[];
+}
+
+export class RequestCommentDto {
+  @ApiProperty({
+    description: 'Incoming request identifier',
+    format: 'uuid',
+    example: '8b7e2f36-9217-4ea0-8d6e-b621fb6e5230',
+  })
+  @IsUUID()
+  requestId!: string;
+
+  @ApiProperty({
+    description: 'Comment identifier',
+    format: 'uuid',
+    example: '8b7e2f36-9217-4ea0-8d6e-b621fb6e5230',
+  })
+  @IsUUID()
+  commentId!: string;
+
+  @ApiProperty({
+    description: 'Author identifier (userId)',
+    format: 'uuid',
+    example: '8b7e2f36-9217-4ea0-8d6e-b621fb6e2230',
+  })
+  @IsUUID()
+  authorId!: string;
+
+  @ApiProperty({
+    type: Date,
+    description: 'The date the comment was created',
+  })
+  @IsDate()
+  @Type(() => Date)
+  createdDate: Date;
+
+  @ApiProperty({
+    description: 'Comment content',
+    example: 'This is a comment.',
+  })
+  @IsString()
+  content!: string;
 }
 
 export class RequestProjectInfoDto {
   @ApiProperty({
-    type: String,
     description: 'The name of the project',
   })
   @IsString()
   name!: string;
 
   @ApiProperty({
-    type: String,
     description: 'The ID of the project',
   })
   @IsString()
@@ -121,7 +266,7 @@ export class ConnectionRequestResponseDto {
   @IsOptional()
   @ValidateNested()
   @Type(() => RequestDto)
-  request: RequestDto | null;
+  request?: RequestDto | null;
 
   @ApiProperty({
     type: () => RequestProjectInfoDto,

--- a/src/connection_request/dto/connection_request.dto.ts
+++ b/src/connection_request/dto/connection_request.dto.ts
@@ -242,8 +242,7 @@ export class RequestCommentDto {
   @IsString()
   content!: string;
 }
-
-export class RequestProjectInfoDto {
+export class ConnectionRequestProjectInfoDto {
   @ApiProperty({
     description: 'The name of the project',
   })
@@ -269,10 +268,10 @@ export class ConnectionRequestResponseDto {
   request?: RequestDto | null;
 
   @ApiProperty({
-    type: () => RequestProjectInfoDto,
+    type: () => ConnectionRequestProjectInfoDto,
     description: 'Project details',
   })
   @ValidateNested()
-  @Type(() => RequestProjectInfoDto)
-  project: RequestProjectInfoDto;
+  @Type(() => ConnectionRequestProjectInfoDto)
+  project: ConnectionRequestProjectInfoDto;
 }

--- a/src/connection_request/dto/connection_request.dto.ts
+++ b/src/connection_request/dto/connection_request.dto.ts
@@ -1,5 +1,14 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString } from 'class-validator';
+import { $Enums } from '@prisma/client';
+import { Type } from 'class-transformer';
+import {
+  IsDate,
+  IsEnum,
+  IsOptional,
+  IsString,
+  IsUUID,
+  ValidateNested,
+} from 'class-validator';
 
 export class DatabaseInfoDto {
   @ApiProperty({
@@ -58,4 +67,67 @@ export class DatabaseInfoDto {
   @IsOptional()
   @IsString()
   password?: string;
+}
+
+export class RequestDto {
+  @ApiProperty({
+    type: Date,
+    description: 'The date the request was created',
+  })
+  @IsDate()
+  @Type(() => Date)
+  createdDate: Date;
+
+  @ApiPropertyOptional({
+    description: 'Incoming request identifier',
+    format: 'uuid',
+    example: '8b7e2f36-9217-4ea0-8d6e-b621fb6e5230',
+  })
+  @IsOptional()
+  @IsUUID()
+  requestId?: string;
+
+  @ApiProperty({
+    enum: $Enums.RequestStatus,
+    description: 'The status of the request',
+    example: $Enums.RequestStatus.PENDING,
+  })
+  @IsEnum($Enums.RequestStatus)
+  status: $Enums.RequestStatus;
+}
+
+export class RequestProjectInfoDto {
+  @ApiProperty({
+    type: String,
+    description: 'The name of the project',
+  })
+  @IsString()
+  name!: string;
+
+  @ApiProperty({
+    type: String,
+    description: 'The ID of the project',
+  })
+  @IsString()
+  projectId!: string;
+}
+
+export class ConnectionRequestResponseDto {
+  @ApiPropertyOptional({
+    type: () => RequestDto,
+    nullable: true,
+    description: 'Request object, null if no request exists',
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => RequestDto)
+  request: RequestDto | null;
+
+  @ApiProperty({
+    type: () => RequestProjectInfoDto,
+    description: 'Project details',
+  })
+  @ValidateNested()
+  @Type(() => RequestProjectInfoDto)
+  project: RequestProjectInfoDto;
 }

--- a/src/database/database.controller.ts
+++ b/src/database/database.controller.ts
@@ -12,6 +12,7 @@ import { DatabaseService } from './database.service';
 
 import {
   ApiAcceptedResponse,
+  ApiBearerAuth,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
@@ -30,6 +31,7 @@ import {
 } from './dto';
 
 @ApiTags('Database')
+@ApiBearerAuth()
 @Controller('database')
 @Resource('project')
 export class DatabaseController {

--- a/src/docker/docker.service.spec.ts
+++ b/src/docker/docker.service.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Test, TestingModule } from '@nestjs/testing';
 import { DockerService } from './docker.service';
 import { PrismaService } from 'src/prisma/prisma.service';

--- a/src/docker/docker.service.ts
+++ b/src/docker/docker.service.ts
@@ -88,10 +88,10 @@ export class DockerService {
         this.logger.log(
           `Container ${instanceName} run successfully for request ${requestId}.`,
         );
-        // set project status to active (e.g. ready for mapping)
+        // set project status to READY (e.g. ready for mapping)
         await this.prisma.project.update({
           where: { projectId },
-          data: { status: 'ACTIVE' },
+          data: { status: 'READY' },
         });
       } finally {
         //  5. Run cleanup for the container instance

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
+import 'reflect-metadata';
 import { HttpAdapterHost, NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-import { ValidationPipe } from '@nestjs/common';
+import { BadRequestException, ValidationPipe } from '@nestjs/common';
 import { AuthExceptionFilter } from './common/filters/auth.filter';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 
@@ -18,7 +19,17 @@ async function bootstrap() {
 
   app.useGlobalFilters(new AuthExceptionFilter());
 
-  app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true }));
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+      disableErrorMessages: false,
+      exceptionFactory: (errors) => {
+        return new BadRequestException(errors);
+      },
+    }),
+  );
 
   const config = new DocumentBuilder()
     .setTitle('Epsilon API')
@@ -27,12 +38,14 @@ async function bootstrap() {
     .addBearerAuth()
     .build();
 
-  const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup(
-    `${configService.get<string>('apiBaseUrl')}/docs`,
-    app,
-    document,
-  );
+  if (configService.get<boolean>('isDev')) {
+    const document = SwaggerModule.createDocument(app, config);
+    SwaggerModule.setup(
+      `${configService.get<string>('apiBaseUrl')}/docs`,
+      app,
+      document,
+    );
+  }
 
   // add prisma client exception filter
   const { httpAdapter } = app.get(HttpAdapterHost);

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ async function bootstrap() {
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,
-      forbidNonWhitelisted: true,
+      forbidNonWhitelisted: false, // TODO: should we not allow?
       transform: true,
       disableErrorMessages: false,
       exceptionFactory: (errors) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { HttpAdapterHost, NestFactory } from '@nestjs/core';
+import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { BadRequestException, ValidationPipe } from '@nestjs/common';
 import { AuthExceptionFilter } from './common/filters/auth.filter';
@@ -47,9 +47,7 @@ async function bootstrap() {
     );
   }
 
-  // add prisma client exception filter
-  const { httpAdapter } = app.get(HttpAdapterHost);
-  app.useGlobalFilters(new PrismaClientExceptionFilter(httpAdapter));
+  app.useGlobalFilters(new PrismaClientExceptionFilter());
 
   // start api service
   await app.listen(configService.get<number>('apiPort')!);

--- a/src/notification/notification.controller.ts
+++ b/src/notification/notification.controller.ts
@@ -1,12 +1,13 @@
 import { Body, Controller, Get, Post } from '@nestjs/common';
 import { NotificationService } from './notification.service';
 import { NotificationDto } from './dto';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 
 import { CurrentUser } from 'src/common/decorators/user.decorator';
 import type { CurrentUserInfo } from 'src/common/decorators/user.decorator';
 
 @ApiTags('Notification')
+@ApiBearerAuth()
 @Controller('notification')
 export class NotificationController {
   constructor(private notificationService: NotificationService) {}

--- a/src/prisma/prisma-client-exception/prisma-client-exception.filter.ts
+++ b/src/prisma/prisma-client-exception/prisma-client-exception.filter.ts
@@ -1,28 +1,85 @@
-import { ArgumentsHost, Catch, HttpStatus } from '@nestjs/common';
-import { BaseExceptionFilter } from '@nestjs/core';
+import {
+  ArgumentsHost,
+  BadRequestException,
+  Catch,
+  ConflictException,
+  ExceptionFilter,
+  HttpException,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { Response } from 'express';
 
-@Catch(Prisma.PrismaClientKnownRequestError)
-export class PrismaClientExceptionFilter extends BaseExceptionFilter {
-  catch(exception: Prisma.PrismaClientKnownRequestError, host: ArgumentsHost) {
+@Catch(
+  Prisma.PrismaClientKnownRequestError,
+  Prisma.PrismaClientValidationError,
+  Prisma.PrismaClientUnknownRequestError,
+)
+export class PrismaClientExceptionFilter implements ExceptionFilter {
+  catch(
+    exception:
+      | Prisma.PrismaClientKnownRequestError
+      | Prisma.PrismaClientValidationError
+      | Prisma.PrismaClientUnknownRequestError,
+    host: ArgumentsHost,
+  ) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
-    const message = exception.message.replace(/\n/g, '');
 
-    switch (exception.code) {
-      case 'P2002': {
-        const status = HttpStatus.CONFLICT;
-        response.status(status).json({
-          statusCode: status,
-          message: message,
-        });
-        break;
-      }
-      default:
-        // default 500 error code
-        super.catch(exception, host);
-        break;
+    let mapped: HttpException;
+
+    // 1️⃣ Handle validation errors (schema / query misuse)
+    if (exception instanceof Prisma.PrismaClientValidationError) {
+      // You can parse the message if you want something prettier
+      mapped = new BadRequestException(
+        'Invalid request data for database operation',
+      );
     }
+    // 2️⃣ Handle known request errors via code
+    else if (exception instanceof Prisma.PrismaClientKnownRequestError) {
+      switch (exception.code) {
+        case 'P2025': {
+          // Record not found
+          const msg =
+            (exception.meta?.cause as string | undefined) ??
+            'Resource not found';
+          mapped = new NotFoundException(msg);
+          break;
+        }
+
+        case 'P2002': {
+          // Unique constraint violation
+          const target =
+            (exception.meta?.target as string[])?.join(', ') ?? 'unique field';
+          mapped = new ConflictException(
+            `Unique constraint failed on: ${target}`,
+          );
+          break;
+        }
+
+        case 'P2003': {
+          // Foreign key constraint
+          const field = exception.meta?.field_name as string | undefined;
+          mapped = new ConflictException(
+            `Foreign key constraint failed on: ${field ?? 'relation'}`,
+          );
+          break;
+        }
+
+        default: {
+          mapped = new InternalServerErrorException(exception.message);
+          break;
+        }
+      }
+    } else {
+      // Fallback (shouldn't normally hit with this @Catch)
+      mapped = new InternalServerErrorException('Unexpected database error');
+    }
+
+    const status = mapped.getStatus();
+    const body = mapped.getResponse();
+
+    response.status(status).json(body);
   }
 }

--- a/src/project/dto/project.dto.ts
+++ b/src/project/dto/project.dto.ts
@@ -260,6 +260,35 @@ export class SettingsDto {
   visualizations?: VisualDto[];
 }
 
+export class SettingsResponseDto {
+  @ApiProperty({
+    description: 'Unique project identifier (UUID)',
+    format: 'uuid',
+    example: '6d3cffa2-43b5-48a2-ba73-50931ddf07b2',
+  })
+  @IsDefined()
+  @IsUUID()
+  projectId!: string;
+
+  @ApiProperty({
+    description: 'Unique project identifier (UUID)',
+    format: 'uri',
+    example: 'https://image.com/6d3cffa2-43b5-48a2-ba73-50931ddf07b2/cover.jpg',
+  })
+  @IsOptional()
+  @IsUrl()
+  cover?: string;
+
+  @ApiProperty({
+    description: 'List of members involved in the project',
+    type: Object,
+    nullable: true,
+  })
+  @IsDefined()
+  @IsJSON()
+  visualizations: Prisma.JsonValue | null;
+}
+
 class VisualDto {
   @IsDefined()
   @IsString()
@@ -414,7 +443,7 @@ export class ProjectDetailsResponseDto {
   @Transform(({ value }) => parseInteger(value))
   participantsNum!: number;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Keywords used to identify relevant database columns',
     isArray: true,
     example: ['heart_rate', 'age', 'bmi'],

--- a/src/project/dto/project.dto.ts
+++ b/src/project/dto/project.dto.ts
@@ -17,6 +17,7 @@ import { parseInteger, transformDateString } from 'src/utils/class.util';
 
 import { $Enums } from '@prisma/client';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { DatabaseInfoDto } from 'src/connection_request/dto';
 
 export class ProjectListDto {
   @ApiProperty({
@@ -83,48 +84,6 @@ export class ProjectListDto {
   status!: $Enums.ProjectStatus;
 }
 
-export class DatabaseDto {
-  @ApiProperty({
-    description: 'Human-readable database name',
-    example: 'Research DB',
-  })
-  @IsString()
-  @IsNotEmpty()
-  name!: string;
-
-  @ApiProperty({
-    description: 'Type of the datasource (e.g. database engine or file type)',
-    example: 'postgres',
-  })
-  @IsString()
-  @IsNotEmpty()
-  type!: string;
-
-  @ApiPropertyOptional({
-    description: 'Connection URL to access the database',
-    example: 'pg://user:pass@localhost:5432/mydb',
-  })
-  @IsOptional()
-  @IsString()
-  url?: string;
-
-  @ApiPropertyOptional({
-    description: 'Database username',
-    example: 'db_user',
-  })
-  @IsOptional()
-  @IsString()
-  username?: string;
-
-  @ApiPropertyOptional({
-    description: 'Database password',
-    example: '**********',
-  })
-  @IsOptional()
-  @IsString()
-  password?: string;
-}
-
 export class ConnectionDto {
   @ApiProperty({
     description: 'Incoming request identifier',
@@ -136,7 +95,8 @@ export class ConnectionDto {
   requestId: string;
 
   @ApiPropertyOptional({
-    description: 'Email of the organisation admin assigned to the project',
+    description:
+      'Email of the organisation admin assigned to the project or owner',
     example: 'admin@university.edu',
   })
   @IsOptional()
@@ -145,17 +105,17 @@ export class ConnectionDto {
 
   @ApiPropertyOptional({
     description: 'Temporary database connection details',
-    type: DatabaseDto,
+    type: DatabaseInfoDto,
   })
   @IsOptional()
   @IsObject()
   @ValidateNested()
-  @Type(() => DatabaseDto)
-  tempDbDetails?: DatabaseDto;
+  @Type(() => DatabaseInfoDto)
+  tempDbDetails?: DatabaseInfoDto;
 
   @ApiPropertyOptional({
     description: 'Miscellaneous extra information provided by the user',
-    example: 'DB accessible only after VPN activation',
+    example: 'Extra information and comments',
   })
   @IsOptional()
   @IsString()
@@ -163,73 +123,140 @@ export class ConnectionDto {
 }
 
 export class ProjectDto {
+  @ApiPropertyOptional({
+    description: 'Unique project identifier (UUID)',
+    format: 'uuid',
+    example: '6d3cffa2-43b5-48a2-ba73-50931ddf07b2',
+  })
   @IsOptional()
   @IsUUID()
-  projectId: string;
+  projectId?: string;
 
+  @ApiProperty({
+    description: 'Owner user ID (UUID)',
+    format: 'uuid',
+    example: 'user_845aedf2-44aa-49c5-92e8-8c824f2ae123',
+  })
   @IsDefined()
   @IsUUID()
   @IsNotEmpty()
   ownerId: string;
 
+  @ApiPropertyOptional({
+    description: 'Custom project identifier or slug',
+    example: 'brain-study-2025',
+  })
   @IsOptional()
   @IsString()
   customId?: string;
 
+  @ApiProperty({
+    description: 'Human-readable name of the project',
+    example: 'Brain Imaging Correlation Study',
+  })
   @IsDefined()
   @IsString()
   @IsNotEmpty()
   name: string;
 
+  @ApiProperty({
+    description: 'Project lead researcher',
+    example: 'Prof. Lead Researcher',
+  })
   @IsDefined()
   @IsString()
   @IsNotEmpty()
   lead: string;
 
+  @ApiProperty({
+    description: 'Institution where the project is based',
+    example: 'University of Edinburgh',
+  })
   @IsDefined()
   @IsString()
   @IsNotEmpty()
   university: string;
 
+  @ApiProperty({
+    description: 'Faculty or department running the project',
+    example: 'School of Informatics',
+  })
   @IsDefined()
   @IsString()
   @IsNotEmpty()
   faculty: string;
 
+  @ApiProperty({
+    description: 'Ethics approval ID provided by the institution',
+    example: 'ETH-2025-0912-A',
+  })
   @IsDefined()
   @IsString()
   @IsNotEmpty()
   ethicsId: string;
 
+  @ApiProperty({
+    description: 'Full project description',
+    example: 'Investigating correlations in large-scale MRI datasets...',
+  })
   @IsDefined()
   @IsString()
   description: string;
 
+  @ApiProperty({
+    description: 'Project start date',
+    type: String,
+    format: 'date-time',
+    example: '2025-04-01T00:00:00.000Z',
+  })
   @IsDefined()
   @IsDate()
   @Transform(({ value }) => transformDateString(value))
   startDate: Date;
 
+  @ApiProperty({
+    description: 'Project end date',
+    type: String,
+    format: 'date-time',
+    example: '2026-12-31T00:00:00.000Z',
+  })
   @IsDefined()
   @IsDate()
   @Transform(({ value }) => transformDateString(value))
   endDate: Date;
 
+  @ApiProperty({
+    description: 'List of members involved in the project',
+    example: "[{'email': 'user1@email.com' 'role': 'collaborator'}]",
+  })
   @IsDefined()
   @IsString()
   @IsNotEmpty()
   members: string;
 
+  @ApiProperty({
+    description: 'Number of project participants',
+    example: 148,
+  })
   @IsDefined()
   @IsNumber()
   @IsNotEmpty()
   @Transform(({ value }) => parseInteger(value))
   participantsNum: number;
 
+  @ApiProperty({
+    description: 'Keywords used to identify relevant database columns',
+    isArray: true,
+    example: ['heart_rate', 'age', 'bmi'],
+  })
   @IsDefined()
   @IsString({ each: true })
   dbKeywords: string[];
 
+  @ApiProperty({
+    description: 'Connection metadata & crawling request info',
+    type: ConnectionDto,
+  })
   @IsDefined()
   @IsNotEmptyObject()
   @IsObject()

--- a/src/project/dto/project.dto.ts
+++ b/src/project/dto/project.dto.ts
@@ -12,12 +12,19 @@ import {
   ValidateNested,
   IsUrl,
   IsEnum,
+  IsJSON,
+  IsArray,
 } from 'class-validator';
 import { parseInteger, transformDateString } from 'src/utils/class.util';
 
-import { $Enums } from '@prisma/client';
+import { $Enums, Prisma } from '@prisma/client';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { DatabaseInfoDto } from 'src/connection_request/dto';
+import {
+  ConnectionDto,
+  ConnectionRequestDto,
+  ConnectionRequestResponseDto,
+} from 'src/connection_request/dto';
+import { AnalysisRequestResponseDto } from 'src/analysis_request/dto';
 
 export class ProjectSummaryInfoDto {
   @ApiProperty({
@@ -83,44 +90,6 @@ export class ProjectSummaryInfoDto {
   })
   @IsEnum($Enums.ProjectStatus)
   status!: $Enums.ProjectStatus;
-}
-
-export class ConnectionDto {
-  @ApiProperty({
-    description: 'Incoming request identifier',
-    format: 'uuid',
-    example: '8b7e2f36-9217-4ea0-8d6e-b621fb6e5230',
-  })
-  @IsOptional()
-  @IsUUID()
-  requestId?: string;
-
-  @ApiPropertyOptional({
-    description:
-      'Email of the organisation admin assigned to the project or owner',
-    example: 'admin@university.edu',
-  })
-  @IsOptional()
-  @IsString()
-  orgAdminEmail?: string;
-
-  @ApiPropertyOptional({
-    description: 'Temporary database connection details',
-    type: DatabaseInfoDto,
-  })
-  @IsOptional()
-  @IsObject()
-  @ValidateNested()
-  @Type(() => DatabaseInfoDto)
-  tempDbDetails?: DatabaseInfoDto;
-
-  @ApiPropertyOptional({
-    description: 'Miscellaneous extra information provided by the user',
-    example: 'Extra information and comments',
-  })
-  @IsOptional()
-  @IsString()
-  additionalInfo?: string;
 }
 
 export class ProjectDto {
@@ -301,4 +270,176 @@ class VisualDto {
   @IsUrl()
   @IsNotEmpty()
   link: string;
+}
+
+export class ProjectDetailsResponseDto {
+  @ApiPropertyOptional({
+    type: () => ConnectionRequestDto,
+    nullable: true,
+    description: 'Request object, null if no request exists',
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ConnectionRequestDto)
+  connection?: ConnectionRequestDto | null;
+
+  @ApiPropertyOptional({
+    description: 'Unique project identifier (UUID)',
+    format: 'uuid',
+    example: '6d3cffa2-43b5-48a2-ba73-50931ddf07b2',
+  })
+  @IsOptional()
+  @IsUUID()
+  projectId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Current project lifecycle status',
+    enum: $Enums.ProjectStatus,
+    example: $Enums.ProjectStatus.READY,
+  })
+  @IsEnum($Enums.ProjectStatus)
+  @IsOptional()
+  status?: $Enums.ProjectStatus;
+
+  @ApiPropertyOptional({
+    description: 'Custom project identifier',
+    example: 'customid123',
+  })
+  @IsOptional()
+  @IsString()
+  customId?: string;
+
+  @ApiProperty({
+    description: 'Owner user ID (UUID)',
+    format: 'uuid',
+    example: 'user_845aedf2-44aa-49c5-92e8-8c824f2ae123',
+  })
+  @IsDefined()
+  @IsUUID()
+  @IsNotEmpty()
+  ownerId!: string;
+
+  @ApiProperty({
+    description: 'Human-readable name of the project',
+    example: 'Health Research Study',
+  })
+  @IsDefined()
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @ApiProperty({
+    description: 'Project lead researcher',
+    example: 'Prof. Lead Researcher',
+  })
+  @IsDefined()
+  @IsString()
+  @IsNotEmpty()
+  lead!: string;
+
+  @ApiProperty({
+    description: 'Institution where the project is based',
+    example: 'University of Edinburgh',
+  })
+  @IsDefined()
+  @IsString()
+  @IsNotEmpty()
+  university!: string;
+
+  @ApiProperty({
+    description: 'Faculty or department running the project',
+    example: 'School of Informatics',
+  })
+  @IsDefined()
+  @IsString()
+  @IsNotEmpty()
+  faculty!: string;
+
+  @ApiProperty({
+    description: 'Ethics approval ID provided by the institution',
+    example: 'ETH-2025-0912-A',
+  })
+  @IsDefined()
+  @IsString()
+  @IsNotEmpty()
+  ethicsId!: string;
+
+  @ApiProperty({
+    description: 'Full project description',
+    example: 'Investigating correlations in large-scale MRI datasets...',
+  })
+  @IsDefined()
+  @IsString()
+  description!: string;
+
+  @ApiProperty({
+    description: 'Project start date',
+    type: String,
+    format: 'date-time',
+    example: '2025-04-01T00:00:00.000Z',
+  })
+  @IsDefined()
+  @IsDate()
+  @Transform(({ value }) => transformDateString(value))
+  startDate!: Date;
+
+  @ApiProperty({
+    description: 'Project end date',
+    type: String,
+    format: 'date-time',
+    example: '2026-12-31T00:00:00.000Z',
+  })
+  @IsDefined()
+  @IsDate()
+  @Transform(({ value }) => transformDateString(value))
+  endDate!: Date;
+
+  @ApiPropertyOptional({
+    description: 'List of members involved in the project',
+    example: "[{'email': 'user1@email.com' 'role': 'collaborator'}]",
+    type: Object,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsJSON()
+  tempDbDetails?: Prisma.JsonValue | null;
+
+  @ApiProperty({
+    description: 'Number of project participants',
+    example: 148,
+  })
+  @IsDefined()
+  @IsNumber()
+  @IsNotEmpty()
+  @Transform(({ value }) => parseInteger(value))
+  participantsNum!: number;
+
+  @ApiProperty({
+    description: 'Keywords used to identify relevant database columns',
+    isArray: true,
+    example: ['heart_rate', 'age', 'bmi'],
+  })
+  @IsDefined()
+  @IsString({ each: true })
+  dbKeywords: string[];
+}
+
+export class ProjectRequestsResponse {
+  @ApiProperty({
+    description: 'Connection requests for the project',
+    type: () => [ConnectionRequestResponseDto],
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ConnectionRequestResponseDto)
+  connection!: ConnectionRequestResponseDto[];
+
+  @ApiProperty({
+    description: 'Analysis requests for the project',
+    type: () => [AnalysisRequestResponseDto],
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => AnalysisRequestResponseDto)
+  analysis: AnalysisRequestResponseDto[];
 }

--- a/src/project/dto/project.dto.ts
+++ b/src/project/dto/project.dto.ts
@@ -16,7 +16,7 @@ import {
 import { parseInteger, transformDateString } from 'src/utils/class.util';
 
 import { $Enums } from '@prisma/client';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class ProjectListDto {
   @ApiProperty({
@@ -77,51 +77,86 @@ export class ProjectListDto {
   @ApiProperty({
     description: 'Current project lifecycle status',
     enum: $Enums.ProjectStatus,
-    example: $Enums.ProjectStatus.ACTIVE,
+    example: $Enums.ProjectStatus.READY,
   })
   @IsEnum($Enums.ProjectStatus)
   status!: $Enums.ProjectStatus;
 }
 
-class DatabaseDto {
-  @IsOptional()
+export class DatabaseDto {
+  @ApiProperty({
+    description: 'Human-readable database name',
+    example: 'Research DB',
+  })
   @IsString()
   @IsNotEmpty()
-  name: string;
+  name!: string;
 
-  @IsOptional()
+  @ApiProperty({
+    description: 'Type of the datasource (e.g. database engine or file type)',
+    example: 'postgres',
+  })
   @IsString()
   @IsNotEmpty()
-  type: string;
+  type!: string;
 
+  @ApiPropertyOptional({
+    description: 'Connection URL to access the database',
+    example: 'pg://user:pass@localhost:5432/mydb',
+  })
   @IsOptional()
   @IsString()
-  url: string;
+  url?: string;
 
+  @ApiPropertyOptional({
+    description: 'Database username',
+    example: 'db_user',
+  })
   @IsOptional()
   @IsString()
-  username: string;
+  username?: string;
 
+  @ApiPropertyOptional({
+    description: 'Database password',
+    example: '**********',
+  })
   @IsOptional()
   @IsString()
-  password: string;
+  password?: string;
 }
 
-class ConnectionDto {
+export class ConnectionDto {
+  @ApiProperty({
+    description: 'Incoming request identifier',
+    format: 'uuid',
+    example: '8b7e2f36-9217-4ea0-8d6e-b621fb6e5230',
+  })
   @IsOptional()
   @IsUUID()
   requestId: string;
 
+  @ApiPropertyOptional({
+    description: 'Email of the organisation admin assigned to the project',
+    example: 'admin@university.edu',
+  })
   @IsOptional()
   @IsString()
   orgAdminEmail?: string;
 
+  @ApiPropertyOptional({
+    description: 'Temporary database connection details',
+    type: DatabaseDto,
+  })
   @IsOptional()
   @IsObject()
   @ValidateNested()
   @Type(() => DatabaseDto)
   tempDbDetails?: DatabaseDto;
 
+  @ApiPropertyOptional({
+    description: 'Miscellaneous extra information provided by the user',
+    example: 'DB accessible only after VPN activation',
+  })
   @IsOptional()
   @IsString()
   additionalInfo?: string;

--- a/src/project/dto/project.dto.ts
+++ b/src/project/dto/project.dto.ts
@@ -18,7 +18,7 @@ import {
 import { parseInteger, transformDateString } from 'src/utils/class.util';
 
 import { $Enums, Prisma } from '@prisma/client';
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional, PartialType } from '@nestjs/swagger';
 import {
   ConnectionDto,
   ConnectionRequestDto,
@@ -92,42 +92,15 @@ export class ProjectSummaryInfoDto {
   status!: $Enums.ProjectStatus;
 }
 
-export class ProjectDto {
-  @ApiPropertyOptional({
-    description: 'Unique project identifier (UUID)',
-    format: 'uuid',
-    example: '6d3cffa2-43b5-48a2-ba73-50931ddf07b2',
-  })
-  @IsOptional()
-  @IsUUID()
-  projectId?: string;
-
-  @ApiPropertyOptional({
-    description: 'Current project lifecycle status',
-    enum: $Enums.ProjectStatus,
-    example: $Enums.ProjectStatus.READY,
-  })
-  @IsEnum($Enums.ProjectStatus)
-  @IsOptional()
-  status?: $Enums.ProjectStatus;
-
+export class CreateProjectDto {
   @ApiPropertyOptional({
     description: 'Custom project identifier',
     example: 'customid123',
   })
   @IsOptional()
+  @IsNotEmpty()
   @IsString()
   customId?: string;
-
-  @ApiProperty({
-    description: 'Owner user ID (UUID)',
-    format: 'uuid',
-    example: 'user_845aedf2-44aa-49c5-92e8-8c824f2ae123',
-  })
-  @IsDefined()
-  @IsUUID()
-  @IsNotEmpty()
-  ownerId!: string;
 
   @ApiProperty({
     description: 'Human-readable name of the project',
@@ -180,6 +153,7 @@ export class ProjectDto {
   })
   @IsDefined()
   @IsString()
+  @IsNotEmpty()
   description!: string;
 
   @ApiProperty({
@@ -207,7 +181,7 @@ export class ProjectDto {
   // FIXME: This should be JSON or string[]
   @ApiPropertyOptional({
     description: 'List of members involved in the project',
-    example: "[{'email': 'user1@email.com' 'role': 'collaborator'}]",
+    example: "[{'email': 'user1@email.com', 'role': 'collaborator'}]",
   })
   @IsOptional()
   @IsString()
@@ -230,34 +204,101 @@ export class ProjectDto {
   })
   @IsDefined()
   @IsString({ each: true })
-  dbKeywords: string[];
+  dbKeywords!: string[];
 
   @ApiProperty({
     description: 'Connection metadata & crawling request info',
     type: ConnectionDto,
   })
   @IsDefined()
-  @IsNotEmptyObject()
   @IsObject()
+  @IsNotEmptyObject()
   @ValidateNested()
   @Type(() => ConnectionDto)
   connection!: ConnectionDto;
 }
 
-export class SettingsDto {
+export class UpdateProjectDto extends PartialType(CreateProjectDto) {
+  @ApiProperty({
+    description: 'Unique project identifier (UUID)',
+    format: 'uuid',
+    example: '6d3cffa2-43b5-48a2-ba73-50931ddf07b2',
+  })
   @IsDefined()
   @IsUUID()
-  @IsNotEmpty()
-  projectId: string;
+  projectId!: string;
 
+  @ApiPropertyOptional({
+    description: 'Current project lifecycle status',
+    enum: $Enums.ProjectStatus,
+    example: $Enums.ProjectStatus.PENDING,
+  })
+  @IsEnum($Enums.ProjectStatus)
+  @IsOptional()
+  status?: $Enums.ProjectStatus;
+}
+
+export class SettingsDto {
+  @ApiProperty({
+    description: 'Unique project identifier (UUID)',
+    format: 'uuid',
+    example: '6d3cffa2-43b5-48a2-ba73-50931ddf07b2',
+  })
+  @IsDefined()
+  @IsNotEmpty()
+  @IsUUID()
+  projectId!: string;
+
+  @ApiPropertyOptional({
+    description: 'Cover image file stored as binary data (Buffer)',
+    type: 'string',
+    format: 'binary',
+    nullable: true,
+    example: null,
+  })
   @IsOptional()
   cover?: Buffer;
 
+  @ApiPropertyOptional({
+    description: 'Array of visuals containing title + external link',
+    type: () => [VisualDto],
+    nullable: true,
+    example: [
+      {
+        title: 'Health conditions',
+        link: 'https://app.example.com/visuals/health-overview',
+      },
+      {
+        title: 'Demographics Breakdown',
+        link: 'https://app.example.com/demographics/breakdown',
+      },
+    ],
+  })
   @IsOptional()
-  @IsObject()
+  @IsObject({ each: true })
   @ValidateNested({ each: true })
   @Type(() => VisualDto)
   visualizations?: VisualDto[];
+}
+export class VisualDto {
+  @ApiProperty({
+    description: 'Title describing the visualization or external resource',
+    example: 'Patients demographics breakdown',
+  })
+  @IsDefined()
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @ApiProperty({
+    description: 'External link pointing to the visualization resource',
+    format: 'uri',
+    example: 'https://app.example.com/demographics/breakdown',
+  })
+  @IsDefined()
+  @IsUrl()
+  @IsNotEmpty()
+  link!: string;
 }
 
 export class SettingsResponseDto {
@@ -287,18 +328,6 @@ export class SettingsResponseDto {
   @IsDefined()
   @IsJSON()
   visualizations: Prisma.JsonValue | null;
-}
-
-class VisualDto {
-  @IsDefined()
-  @IsString()
-  @IsNotEmpty()
-  title: string;
-
-  @IsDefined()
-  @IsUrl()
-  @IsNotEmpty()
-  link: string;
 }
 
 export class ProjectDetailsResponseDto {

--- a/src/project/dto/project.dto.ts
+++ b/src/project/dto/project.dto.ts
@@ -19,12 +19,14 @@ import { $Enums } from '@prisma/client';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { DatabaseInfoDto } from 'src/connection_request/dto';
 
-export class ProjectListDto {
+export class ProjectSummaryInfoDto {
   @ApiProperty({
-    description: 'Unique project identifier (UUID or slug)',
-    example: 'proj_123abc456',
+    description: 'Unique project identifier (UUID)',
+    format: 'uuid',
+    example: '6d3cffa2-43b5-48a2-ba73-50931ddf07b2',
   })
-  @IsString()
+  @IsDefined()
+  @IsUUID()
   projectId!: string;
 
   @ApiProperty({
@@ -36,10 +38,20 @@ export class ProjectListDto {
 
   @ApiProperty({
     description: 'Project name',
-    example: 'Heart Rate Variability Study',
+    example: 'Example Health Study',
   })
   @IsString()
   name!: string;
+
+  @ApiProperty({
+    description: 'Timestamp of last modification',
+    example: '2025-11-12T09:30:00.000Z',
+    type: String,
+    format: 'date-time',
+  })
+  @Type(() => Date)
+  @IsDate()
+  lastModified!: Date;
 
   @ApiProperty({
     description: 'University associated with this project',
@@ -56,24 +68,13 @@ export class ProjectListDto {
   faculty!: string;
 
   @ApiProperty({
-    description: 'Timestamp of last modification',
-    example: '2025-11-12T09:30:00.000Z',
-    type: String,
-    format: 'date-time',
+    description: 'Project lead researcher',
+    example: 'Prof. Lead Researcher',
   })
-  @Type(() => Date)
-  @IsDate()
-  lastModified!: Date;
-
-  @ApiProperty({
-    description: 'Timestamp when the project was created',
-    example: '2025-10-01T14:45:00.000Z',
-    type: String,
-    format: 'date-time',
-  })
-  @Type(() => Date)
-  @IsDate()
-  createdDate!: Date;
+  @IsDefined()
+  @IsString()
+  @IsNotEmpty()
+  lead: string;
 
   @ApiProperty({
     description: 'Current project lifecycle status',
@@ -92,7 +93,7 @@ export class ConnectionDto {
   })
   @IsOptional()
   @IsUUID()
-  requestId: string;
+  requestId?: string;
 
   @ApiPropertyOptional({
     description:
@@ -132,6 +133,23 @@ export class ProjectDto {
   @IsUUID()
   projectId?: string;
 
+  @ApiPropertyOptional({
+    description: 'Current project lifecycle status',
+    enum: $Enums.ProjectStatus,
+    example: $Enums.ProjectStatus.READY,
+  })
+  @IsEnum($Enums.ProjectStatus)
+  @IsOptional()
+  status?: $Enums.ProjectStatus;
+
+  @ApiPropertyOptional({
+    description: 'Custom project identifier',
+    example: 'customid123',
+  })
+  @IsOptional()
+  @IsString()
+  customId?: string;
+
   @ApiProperty({
     description: 'Owner user ID (UUID)',
     format: 'uuid',
@@ -140,24 +158,16 @@ export class ProjectDto {
   @IsDefined()
   @IsUUID()
   @IsNotEmpty()
-  ownerId: string;
-
-  @ApiPropertyOptional({
-    description: 'Custom project identifier or slug',
-    example: 'brain-study-2025',
-  })
-  @IsOptional()
-  @IsString()
-  customId?: string;
+  ownerId!: string;
 
   @ApiProperty({
     description: 'Human-readable name of the project',
-    example: 'Brain Imaging Correlation Study',
+    example: 'Health Research Study',
   })
   @IsDefined()
   @IsString()
   @IsNotEmpty()
-  name: string;
+  name!: string;
 
   @ApiProperty({
     description: 'Project lead researcher',
@@ -166,7 +176,7 @@ export class ProjectDto {
   @IsDefined()
   @IsString()
   @IsNotEmpty()
-  lead: string;
+  lead!: string;
 
   @ApiProperty({
     description: 'Institution where the project is based',
@@ -175,7 +185,7 @@ export class ProjectDto {
   @IsDefined()
   @IsString()
   @IsNotEmpty()
-  university: string;
+  university!: string;
 
   @ApiProperty({
     description: 'Faculty or department running the project',
@@ -184,7 +194,7 @@ export class ProjectDto {
   @IsDefined()
   @IsString()
   @IsNotEmpty()
-  faculty: string;
+  faculty!: string;
 
   @ApiProperty({
     description: 'Ethics approval ID provided by the institution',
@@ -193,7 +203,7 @@ export class ProjectDto {
   @IsDefined()
   @IsString()
   @IsNotEmpty()
-  ethicsId: string;
+  ethicsId!: string;
 
   @ApiProperty({
     description: 'Full project description',
@@ -201,7 +211,7 @@ export class ProjectDto {
   })
   @IsDefined()
   @IsString()
-  description: string;
+  description!: string;
 
   @ApiProperty({
     description: 'Project start date',
@@ -212,7 +222,7 @@ export class ProjectDto {
   @IsDefined()
   @IsDate()
   @Transform(({ value }) => transformDateString(value))
-  startDate: Date;
+  startDate!: Date;
 
   @ApiProperty({
     description: 'Project end date',
@@ -223,16 +233,16 @@ export class ProjectDto {
   @IsDefined()
   @IsDate()
   @Transform(({ value }) => transformDateString(value))
-  endDate: Date;
+  endDate!: Date;
 
-  @ApiProperty({
+  // FIXME: This should be JSON or string[]
+  @ApiPropertyOptional({
     description: 'List of members involved in the project',
     example: "[{'email': 'user1@email.com' 'role': 'collaborator'}]",
   })
-  @IsDefined()
+  @IsOptional()
   @IsString()
-  @IsNotEmpty()
-  members: string;
+  members?: string;
 
   @ApiProperty({
     description: 'Number of project participants',
@@ -242,7 +252,7 @@ export class ProjectDto {
   @IsNumber()
   @IsNotEmpty()
   @Transform(({ value }) => parseInteger(value))
-  participantsNum: number;
+  participantsNum!: number;
 
   @ApiProperty({
     description: 'Keywords used to identify relevant database columns',
@@ -262,7 +272,7 @@ export class ProjectDto {
   @IsObject()
   @ValidateNested()
   @Type(() => ConnectionDto)
-  connection: ConnectionDto;
+  connection!: ConnectionDto;
 }
 
 export class SettingsDto {

--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -19,10 +19,12 @@ import {
 import { ProjectService } from './project.service';
 import {
   ProjectDetailsResponseDto,
-  ProjectDto,
+  CreateProjectDto,
   ProjectRequestsResponse,
   ProjectSummaryInfoDto,
   SettingsDto,
+  SettingsResponseDto,
+  UpdateProjectDto,
 } from './dto';
 import {
   ApiBearerAuth,
@@ -60,7 +62,7 @@ export class ProjectController {
   })
   async createProject(
     @CurrentUser() user: CurrentUserInfo,
-    @Body() dto: ProjectDto,
+    @Body() dto: CreateProjectDto,
   ) {
     // TODO: we need to make sure that we actually use usernames because these will be needed for atlas authorization as emails will change which break ownership lookups and Ranger policies
     return await this.projectService.createProject(user, dto);
@@ -147,7 +149,7 @@ export class ProjectController {
   })
   updateProject(
     @Param('projectId', ParseUUIDPipe) projectId: string,
-    @Body() dto: ProjectDto,
+    @Body() dto: UpdateProjectDto,
   ) {
     return this.projectService.updateProject(projectId, dto);
   }
@@ -170,6 +172,7 @@ export class ProjectController {
   @ApiOperation({ summary: 'Get project settings' })
   @ApiOkResponse({
     description: 'Project settings are returned',
+    type: SettingsResponseDto,
   })
   async getProjectSettings(
     @Param('projectId', ParseUUIDPipe) projectId: string,
@@ -177,6 +180,23 @@ export class ProjectController {
     return await this.projectService.getProjectSettings(projectId);
   }
 
+  // TODO: need to see if this is needed
+  @UseGuards(ResourceGuard)
+  @Scopes('view, edit')
+  @Post(':projectId/settings')
+  @ApiOperation({ summary: 'Add project settings' })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiNoContentResponse({
+    description: 'Project settings are added',
+  })
+  async addProjectSettings(
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+    @Body() dto: SettingsDto,
+  ) {
+    return await this.projectService.updateProjectSettings(projectId, dto);
+  }
+
+  // TODO: need to see if this is needed
   @UseGuards(ResourceGuard)
   @Scopes('view, edit')
   @Put(':projectId/settings')
@@ -192,6 +212,7 @@ export class ProjectController {
     return await this.projectService.updateProjectSettings(projectId, dto);
   }
 
+  // TODO: this needs refactoring, is it used?
   @UseGuards(ResourceGuard)
   @Scopes('view, edit')
   @Post(':projectId/upload-cover')
@@ -207,14 +228,4 @@ export class ProjectController {
     const result = this.projectService.uploadProjectCover(projectId, file);
     return result;
   }
-
-  // @Get(':projectId/summary')
-  // async projectSummary(@Param('projectId', ParseUUIDPipe) projectId: string) {
-  //   return await this.projectService.projectSummary(projectId);
-  // }
-
-  // @Get(':requestId')
-  // details(@Param('requestId', ParseUUIDPipe) requestId: string) {
-  //   return this.connectionRequestService.details(requestId);
-  // }
 }

--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -15,7 +15,6 @@ import {
   UseGuards,
   HttpCode,
   HttpStatus,
-  // UseGuards,
 } from '@nestjs/common';
 import { ProjectService } from './project.service';
 import { ProjectDto, ProjectListDto, SettingsDto } from './dto';
@@ -47,6 +46,16 @@ export class ProjectController {
     private keycloakConnect: KeycloakService,
   ) {}
 
+  @Post()
+  @ApiOperation({ summary: 'Create project' })
+  @ApiOkResponse({
+    description: 'Created project data',
+  })
+  createProject(@CurrentUser() user: CurrentUserInfo, @Body() dto: ProjectDto) {
+    // TODO: we need to make sure that we actually use usernames because these will be needed for atlas authorization as emails will change which break ownership lookups and Ranger policies
+    return this.projectService.createProject(user, dto);
+  }
+
   @Get('')
   @ApiOperation({ summary: 'Get list of projects owned by logged in user' })
   @ApiOkResponse({
@@ -66,7 +75,7 @@ export class ProjectController {
     isArray: true,
   })
   async getUserSharedProjects(@Req() request: Request) {
-    // check for user resource permissions
+    // check for user resource permissions against keycloak
     // TODO: perhaps call this once and cache or make it into a helper/decorator
     const authzRequest = {
       response_mode: 'permissions',
@@ -101,16 +110,6 @@ export class ProjectController {
     @Param('projectId', ParseUUIDPipe) projectId: string,
   ) {
     return await this.projectService.getProjectRequests(projectId, user.email);
-  }
-
-  @Post()
-  @ApiOperation({ summary: 'Create project' })
-  @ApiOkResponse({
-    description: 'Created project data is returned',
-  })
-  createProject(@CurrentUser() user: CurrentUserInfo, @Body() dto: ProjectDto) {
-    // TODO: we need to make sure that we actually use usernames because these will be needed for atlas authorization as emails will change which break ownership lookups and Ranger policies
-    return this.projectService.createProject(user.username, dto);
   }
 
   @UseGuards(ResourceGuard)

--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -27,8 +27,11 @@ import {
   UpdateProjectDto,
 } from './dto';
 import {
+  ApiBadRequestResponse,
   ApiBearerAuth,
+  ApiConflictResponse,
   ApiNoContentResponse,
+  ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
@@ -43,6 +46,7 @@ import type { Request } from 'express';
 import { Resource } from 'src/common/decorators/resource.decorator';
 import { Scopes } from 'src/common/decorators/scopes.decorator';
 import { ResourceGuard } from 'src/common/guards/resource.guard';
+import { ErrorResponseDto } from 'src/common/dto';
 
 @ApiTags('Project')
 @ApiBearerAuth()
@@ -60,6 +64,9 @@ export class ProjectController {
   @ApiNoContentResponse({
     description: 'Project created successfully',
   })
+  @ApiNotFoundResponse({ type: ErrorResponseDto })
+  @ApiBadRequestResponse({ type: ErrorResponseDto })
+  @ApiConflictResponse({ type: ErrorResponseDto })
   async createProject(
     @CurrentUser() user: CurrentUserInfo,
     @Body() dto: CreateProjectDto,
@@ -75,6 +82,8 @@ export class ProjectController {
     type: ProjectSummaryInfoDto,
     isArray: true,
   })
+  @ApiBadRequestResponse({ type: ErrorResponseDto })
+  @ApiConflictResponse({ type: ErrorResponseDto })
   async getUserOwnedProjects(@CurrentUser() user: CurrentUserInfo) {
     return await this.projectService.getUserOwnedProjects(user.id);
   }
@@ -86,6 +95,7 @@ export class ProjectController {
     type: ProjectSummaryInfoDto,
     isArray: true,
   })
+  @ApiBadRequestResponse({ type: ErrorResponseDto })
   async getUserSharedProjects(@Req() request: Request) {
     // check for user resource permissions against keycloak
     // TODO: perhaps call this once and cache or make it into a helper/decorator
@@ -106,6 +116,7 @@ export class ProjectController {
     type: ProjectSummaryInfoDto,
     isArray: true,
   })
+  @ApiBadRequestResponse({ type: ErrorResponseDto })
   async getAllProjects() {
     return await this.projectService.getAllProjects();
   }
@@ -118,6 +129,7 @@ export class ProjectController {
     description: 'List of analysis and connection requests for the projects',
     type: ProjectRequestsResponse,
   })
+  @ApiBadRequestResponse({ type: ErrorResponseDto })
   async getProjectRequests(
     @CurrentUser() user: CurrentUserInfo,
     @Param('projectId', ParseUUIDPipe) projectId: string,
@@ -133,6 +145,8 @@ export class ProjectController {
     description: 'Project details are returned',
     type: ProjectDetailsResponseDto,
   })
+  @ApiNotFoundResponse({ type: ErrorResponseDto })
+  @ApiBadRequestResponse({ type: ErrorResponseDto })
   async getProjectDetails(
     @Param('projectId', ParseUUIDPipe) projectId: string,
   ) {
@@ -162,6 +176,9 @@ export class ProjectController {
   @ApiNoContentResponse({
     description: 'Project deleted',
   })
+  @ApiNotFoundResponse({ type: ErrorResponseDto })
+  @ApiBadRequestResponse({ type: ErrorResponseDto })
+  @ApiConflictResponse({ type: ErrorResponseDto })
   deleteProject(@Param('projectId', ParseUUIDPipe) projectId: string) {
     return this.projectService.deleteProject(projectId);
   }
@@ -174,6 +191,8 @@ export class ProjectController {
     description: 'Project settings are returned',
     type: SettingsResponseDto,
   })
+  @ApiNotFoundResponse({ type: ErrorResponseDto })
+  @ApiBadRequestResponse({ type: ErrorResponseDto })
   async getProjectSettings(
     @Param('projectId', ParseUUIDPipe) projectId: string,
   ) {
@@ -189,6 +208,9 @@ export class ProjectController {
   @ApiNoContentResponse({
     description: 'Project settings are added',
   })
+  @ApiNotFoundResponse({ type: ErrorResponseDto })
+  @ApiBadRequestResponse({ type: ErrorResponseDto })
+  @ApiConflictResponse({ type: ErrorResponseDto })
   async addProjectSettings(
     @Param('projectId', ParseUUIDPipe) projectId: string,
     @Body() dto: SettingsDto,
@@ -205,6 +227,9 @@ export class ProjectController {
   @ApiNoContentResponse({
     description: 'Project settings are updated',
   })
+  @ApiNotFoundResponse({ type: ErrorResponseDto })
+  @ApiBadRequestResponse({ type: ErrorResponseDto })
+  @ApiConflictResponse({ type: ErrorResponseDto })
   async updateProjectSettings(
     @Param('projectId', ParseUUIDPipe) projectId: string,
     @Body() dto: SettingsDto,
@@ -220,6 +245,9 @@ export class ProjectController {
   @ApiNoContentResponse({
     description: 'Project cover image is returned',
   })
+  @ApiNotFoundResponse({ type: ErrorResponseDto })
+  @ApiBadRequestResponse({ type: ErrorResponseDto })
+  @ApiConflictResponse({ type: ErrorResponseDto })
   async uploadProjectCover(
     @UploadedFile(new ParseFilePipe())
     file: Express.Multer.File,

--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -17,7 +17,7 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { ProjectService } from './project.service';
-import { ProjectDto, ProjectListDto, SettingsDto } from './dto';
+import { ProjectDto, ProjectSummaryInfoDto, SettingsDto } from './dto';
 import {
   ApiBearerAuth,
   ApiNoContentResponse,
@@ -48,19 +48,23 @@ export class ProjectController {
 
   @Post()
   @ApiOperation({ summary: 'Create project' })
-  @ApiOkResponse({
-    description: 'Created project data',
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiNoContentResponse({
+    description: 'Project created successfully',
   })
-  createProject(@CurrentUser() user: CurrentUserInfo, @Body() dto: ProjectDto) {
+  async createProject(
+    @CurrentUser() user: CurrentUserInfo,
+    @Body() dto: ProjectDto,
+  ) {
     // TODO: we need to make sure that we actually use usernames because these will be needed for atlas authorization as emails will change which break ownership lookups and Ranger policies
-    return this.projectService.createProject(user, dto);
+    return await this.projectService.createProject(user, dto);
   }
 
   @Get('')
   @ApiOperation({ summary: 'Get list of projects owned by logged in user' })
   @ApiOkResponse({
     description: 'List of user owner projects are returned',
-    type: ProjectListDto,
+    type: ProjectSummaryInfoDto,
     isArray: true,
   })
   async getUserOwnedProjects(@CurrentUser() user: CurrentUserInfo) {
@@ -71,7 +75,7 @@ export class ProjectController {
   @ApiOperation({ summary: 'Get list of projects user is collaborator on' })
   @ApiOkResponse({
     description: 'List of collaborator projects are returned',
-    type: ProjectListDto,
+    type: ProjectSummaryInfoDto,
     isArray: true,
   })
   async getUserSharedProjects(@Req() request: Request) {
@@ -91,7 +95,7 @@ export class ProjectController {
   @ApiOperation({ summary: 'Get list of all projects' })
   @ApiOkResponse({
     description: 'List of all projects',
-    type: ProjectListDto,
+    type: ProjectSummaryInfoDto,
     isArray: true,
   })
   async getAllProjects() {

--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -17,7 +17,13 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { ProjectService } from './project.service';
-import { ProjectDto, ProjectSummaryInfoDto, SettingsDto } from './dto';
+import {
+  ProjectDetailsResponseDto,
+  ProjectDto,
+  ProjectRequestsResponse,
+  ProjectSummaryInfoDto,
+  SettingsDto,
+} from './dto';
 import {
   ApiBearerAuth,
   ApiNoContentResponse,
@@ -108,6 +114,7 @@ export class ProjectController {
   @ApiOperation({ summary: 'Get list of incoming requests' })
   @ApiOkResponse({
     description: 'List of analysis and connection requests for the projects',
+    type: ProjectRequestsResponse,
   })
   async getProjectRequests(
     @CurrentUser() user: CurrentUserInfo,
@@ -122,6 +129,7 @@ export class ProjectController {
   @ApiOperation({ summary: 'Get project details' })
   @ApiOkResponse({
     description: 'Project details are returned',
+    type: ProjectDetailsResponseDto,
   })
   async getProjectDetails(
     @Param('projectId', ParseUUIDPipe) projectId: string,

--- a/src/project/project.service.spec.ts
+++ b/src/project/project.service.spec.ts
@@ -8,6 +8,7 @@ import { FileStorageService } from 'src/file_storage/file_storage.service';
 import { KeycloakAdminService } from 'src/admin/keycloak/keycloak.admin.service';
 import { RequestStatus } from '@prisma/client';
 import { SettingsDto } from './dto';
+import { NotFoundException } from '@nestjs/common/exceptions';
 
 // mock nanoid + uuid to make tests deterministic
 jest.mock('nanoid', () => ({
@@ -24,7 +25,7 @@ describe('ProjectService', () => {
   const prismaMock = {
     project: {
       findMany: jest.fn(),
-      findUnique: jest.fn(),
+      findUniqueOrThrow: jest.fn(),
       create: jest.fn(),
       update: jest.fn(),
       delete: jest.fn(),
@@ -395,7 +396,7 @@ describe('ProjectService', () => {
   });
 
   describe('getProjectDetails', () => {
-    it('should delegate to prisma.project.findUnique', async () => {
+    it('should delegate to prisma.project.findUniqueOrThrow', async () => {
       const projectId = 'proj-1';
       const project = {
         projectId,
@@ -406,11 +407,13 @@ describe('ProjectService', () => {
         },
       };
 
-      (prismaMock.project.findUnique as jest.Mock).mockResolvedValue(project);
+      (prismaMock.project.findUniqueOrThrow as jest.Mock).mockResolvedValue(
+        project,
+      );
 
       const result = await service.getProjectDetails(projectId);
 
-      expect(prismaMock.project.findUnique).toHaveBeenCalledWith({
+      expect(prismaMock.project.findUniqueOrThrow).toHaveBeenCalledWith({
         where: { projectId },
         include: {
           connection: {
@@ -510,7 +513,7 @@ describe('ProjectService', () => {
       const projectId = 'proj-1';
       const visualizations = [{ title: 'Dash', link: 'https://example.com' }];
 
-      (prismaMock.project.findUnique as jest.Mock).mockResolvedValue({
+      (prismaMock.project.findUniqueOrThrow as jest.Mock).mockResolvedValue({
         visualizations,
       });
 
@@ -520,7 +523,7 @@ describe('ProjectService', () => {
 
       const result = await service.getProjectSettings(projectId);
 
-      expect(prismaMock.project.findUnique).toHaveBeenCalledWith({
+      expect(prismaMock.project.findUniqueOrThrow).toHaveBeenCalledWith({
         where: { projectId },
         select: {
           visualizations: true,
@@ -541,11 +544,15 @@ describe('ProjectService', () => {
 
     it('should return null when project does not exist', async () => {
       const projectId = 'proj-1';
-      (prismaMock.project.findUnique as jest.Mock).mockResolvedValue(null);
+      (prismaMock.project.findUniqueOrThrow as jest.Mock).mockRejectedValue(
+        new NotFoundException('Resource not found'),
+      );
 
-      const result = await service.getProjectSettings(projectId);
+      await expect(
+        service.getProjectSettings(projectId),
+      ).rejects.toBeInstanceOf(NotFoundException);
 
-      expect(result).toBeNull();
+      // expect(result).toThrow();
       expect(fileStorageMock.getFileUrl).not.toHaveBeenCalled();
     });
   });

--- a/src/project/project.service.spec.ts
+++ b/src/project/project.service.spec.ts
@@ -1,0 +1,616 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProjectService } from './project.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { QueueService } from 'src/queue/queue.service';
+import { FileStorageService } from 'src/file_storage/file_storage.service';
+import { KeycloakAdminService } from 'src/admin/keycloak/keycloak.admin.service';
+import { RequestStatus } from '@prisma/client';
+import { SettingsDto } from './dto';
+
+// mock nanoid + uuid to make tests deterministic
+jest.mock('nanoid', () => ({
+  nanoid: jest.fn(() => 'mockedCustomId12'),
+}));
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'mocked-request-id'),
+}));
+
+describe('ProjectService', () => {
+  let service: ProjectService;
+
+  const prismaMock = {
+    project: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    connection: {
+      findMany: jest.fn(),
+    },
+    analysis: {
+      findMany: jest.fn(),
+    },
+    comment: {
+      create: jest.fn(),
+    },
+  } as unknown as PrismaService;
+
+  const queueMock = {
+    dataBrokerJob: jest.fn(),
+  } as unknown as QueueService;
+
+  const fileStorageMock = {
+    getFileUrl: jest.fn(),
+    deleteFile: jest.fn(),
+    putFile: jest.fn(),
+  } as unknown as FileStorageService;
+
+  const keycloakMock = {
+    newResource: jest.fn(),
+  } as unknown as KeycloakAdminService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProjectService,
+        { provide: PrismaService, useValue: prismaMock },
+        { provide: QueueService, useValue: queueMock },
+        { provide: FileStorageService, useValue: fileStorageMock },
+        { provide: KeycloakAdminService, useValue: keycloakMock },
+      ],
+    }).compile();
+
+    service = module.get<ProjectService>(ProjectService);
+  });
+
+  describe('getUserOwnedProjects', () => {
+    it('should return projects for given ownerId', async () => {
+      const userId = 'user-123';
+      const projects = [
+        {
+          projectId: 'p1',
+          customId: 'c1',
+          name: 'Project 1',
+          lastModified: new Date(),
+          status: 'MAPPED',
+          university: 'Uni',
+          lead: 'Lead',
+          faculty: 'Faculty',
+        },
+      ];
+      (prismaMock.project.findMany as jest.Mock).mockResolvedValue(projects);
+
+      const result = await service.getUserOwnedProjects(userId);
+
+      expect(prismaMock.project.findMany).toHaveBeenCalledWith({
+        where: { ownerId: userId },
+        select: {
+          projectId: true,
+          customId: true,
+          name: true,
+          lastModified: true,
+          status: true,
+          university: true,
+          lead: true,
+          faculty: true,
+        },
+      });
+      expect(result).toEqual(projects);
+    });
+  });
+
+  describe('getUserSharedProjects', () => {
+    it('should filter permissions and return matching projects', async () => {
+      const permissions = [
+        {
+          rsname: 'project:p1',
+          scopes: ['view'],
+          rsid: 'id1',
+        },
+        {
+          rsname: 'project:p2',
+          scopes: ['view', 'delete'], // should be excluded as it's owned by user
+          rsid: 'id2',
+        },
+        {
+          rsname: 'project:p3',
+          scopes: ['view'],
+          rsid: 'id3',
+        },
+      ];
+
+      const projects = [
+        {
+          projectId: 'p1',
+          customId: 'c1',
+          name: 'Project 1',
+          lastModified: new Date(),
+          status: 'MAPPED',
+          university: 'Uni',
+          faculty: 'Faculty',
+          lead: 'Lead',
+        },
+        {
+          projectId: 'p3',
+          customId: 'c3',
+          name: 'Project 3',
+          lastModified: new Date(),
+          status: 'MAPPED',
+          university: 'Uni',
+          faculty: 'Faculty',
+          lead: 'Lead',
+        },
+      ];
+
+      (prismaMock.project.findMany as jest.Mock).mockResolvedValue(projects);
+
+      const result = await service.getUserSharedProjects(permissions);
+
+      expect(prismaMock.project.findMany).toHaveBeenCalledWith({
+        where: {
+          projectId: {
+            in: ['p1', 'p3'],
+          },
+        },
+        select: {
+          projectId: true,
+          customId: true,
+          name: true,
+          lastModified: true,
+          lead: true,
+          status: true,
+          university: true,
+          faculty: true,
+        },
+      });
+      expect(result).toEqual(projects);
+    });
+  });
+
+  describe('getAllProjects', () => {
+    it('should return all mapped projects', async () => {
+      const projects = [
+        {
+          projectId: 'p1',
+          customId: 'c1',
+          name: 'Project 1',
+          lastModified: new Date(),
+          createdDate: new Date(),
+          university: 'Uni',
+          faculty: 'Faculty',
+        },
+      ];
+
+      (prismaMock.project.findMany as jest.Mock).mockResolvedValue(projects);
+
+      const result = await service.getAllProjects();
+
+      expect(prismaMock.project.findMany).toHaveBeenCalledWith({
+        where: {
+          status: {
+            in: ['MAPPED'],
+          },
+        },
+        select: {
+          projectId: true,
+          customId: true,
+          name: true,
+          lastModified: true,
+          createdDate: true,
+          university: true,
+          faculty: true,
+        },
+      });
+      expect(result).toEqual(projects);
+    });
+  });
+
+  describe('getProjectRequests', () => {
+    it('should return connection and analysis requests', async () => {
+      const projectId = 'proj-1';
+      const email = 'admin@example.com';
+
+      const connectionRequests = [
+        {
+          request: {
+            requestId: 'req-1',
+            status: RequestStatus.PENDING,
+            createdDate: new Date(),
+          },
+          project: {
+            projectId: 'proj-1',
+            name: 'Project 1',
+          },
+        },
+      ];
+
+      const analysisRequests = [
+        {
+          request: {
+            requestId: 'req-2',
+            status: RequestStatus.APPROVED,
+            createdDate: new Date(),
+          },
+          projectName: 'Project 1',
+        },
+      ];
+
+      (prismaMock.connection.findMany as jest.Mock).mockResolvedValue(
+        connectionRequests,
+      );
+      (prismaMock.analysis.findMany as jest.Mock).mockResolvedValue(
+        analysisRequests,
+      );
+
+      const result = await service.getProjectRequests(projectId, email);
+
+      expect(prismaMock.connection.findMany).toHaveBeenCalledWith({
+        where: {
+          orgAdminEmail: email,
+        },
+        select: {
+          request: {
+            select: {
+              requestId: true,
+              status: true,
+              createdDate: true,
+            },
+          },
+          project: {
+            select: {
+              projectId: true,
+              name: true,
+            },
+          },
+        },
+      });
+
+      expect(prismaMock.analysis.findMany).toHaveBeenCalledWith({
+        where: {
+          projectId: projectId,
+        },
+        select: {
+          request: {
+            select: {
+              requestId: true,
+              status: true,
+              createdDate: true,
+            },
+          },
+          projectName: true,
+        },
+      });
+
+      expect(result).toEqual({
+        connection: connectionRequests,
+        analysis: analysisRequests,
+      });
+    });
+  });
+
+  describe('createProject', () => {
+    // user mock
+    const user = {
+      email: 'owner@example.com',
+      username: 'owner-user',
+      id: 'user1',
+    };
+
+    it('should create project, create keycloak resource and comment when orgAdminEmail defined', async () => {
+      // create dto mock
+      const dto = {
+        name: 'My Project',
+        lead: 'Lead Name',
+        university: 'Uni',
+        faculty: 'Faculty',
+        ethicsId: 'ETH-123',
+        description: 'Desc',
+        startDate: new Date(),
+        endDate: new Date(),
+        participantsNum: 10,
+        members: JSON.stringify([
+          { email: 'member1@example.com', role: 'collaborator' },
+        ]),
+        dbKeywords: ['keyword1', 'keyword2'],
+        connection: {
+          orgAdminEmail: 'admin@example.com',
+          additionalInfo: 'Please approve quickly',
+        },
+      };
+      (prismaMock.project.create as jest.Mock).mockResolvedValue({
+        projectId: 'proj-1',
+        ownerId: user.id,
+        connection: {
+          request: {
+            requestId: 'mocked-request-id',
+          },
+        },
+      });
+
+      await service.createProject(user, dto);
+
+      expect(prismaMock.project.create).toHaveBeenCalled();
+      expect(keycloakMock.newResource).toHaveBeenCalledWith('proj-1', 'user1', [
+        'member1@example.com',
+      ]);
+      expect(prismaMock.comment.create).toHaveBeenCalledWith({
+        data: {
+          requestId: 'mocked-request-id',
+          authorId: user.id,
+          content: dto.connection.additionalInfo,
+        },
+      });
+      expect(queueMock.dataBrokerJob).not.toHaveBeenCalled();
+    });
+
+    it('should trigger dataBrokerJob when no orgAdminEmail and tempDbDetails.url present', async () => {
+      // create dto mock
+      const dto = {
+        name: 'My Project',
+        lead: 'Lead Name',
+        university: 'Uni',
+        faculty: 'Faculty',
+        ethicsId: 'ETH-123',
+        description: 'Desc',
+        startDate: new Date(),
+        endDate: new Date(),
+        participantsNum: 10,
+        members: JSON.stringify([
+          { email: 'member1@example.com', role: 'collaborator' },
+        ]),
+        dbKeywords: ['keyword1', 'keyword2'],
+        connection: {
+          tempDbDetails: {
+            url: 'postgres://...',
+            type: 'postgres',
+            name: 'User added Database Name',
+          },
+        },
+      };
+      (prismaMock.project.create as jest.Mock).mockResolvedValue({
+        projectId: 'proj-1',
+        ownerId: user.id,
+        connection: {
+          request: null,
+        },
+      });
+
+      await service.createProject(user, dto);
+
+      expect(queueMock.dataBrokerJob).toHaveBeenCalledWith(
+        'owner-user',
+        'proj-1',
+        'mocked-request-id',
+        dto.connection.tempDbDetails,
+      );
+      expect(keycloakMock.newResource).toHaveBeenCalled();
+    });
+  });
+
+  describe('getProjectDetails', () => {
+    it('should delegate to prisma.project.findUnique', async () => {
+      const projectId = 'proj-1';
+      const project = {
+        projectId,
+        connection: {
+          request: {
+            comments: [],
+          },
+        },
+      };
+
+      (prismaMock.project.findUnique as jest.Mock).mockResolvedValue(project);
+
+      const result = await service.getProjectDetails(projectId);
+
+      expect(prismaMock.project.findUnique).toHaveBeenCalledWith({
+        where: { projectId },
+        include: {
+          connection: {
+            include: {
+              request: {
+                include: {
+                  comments: true,
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(result).toEqual(project);
+    });
+  });
+
+  describe('updateProject', () => {
+    it('should call prisma.project.update with correct payload', async () => {
+      // mocks
+      const projectId = 'proj-1';
+      const dto = {
+        projectId,
+        name: 'Updated name',
+        lead: 'Updated lead',
+        university: 'Updated Uni',
+        faculty: 'Updated Faculty',
+        ethicsId: 'ETH-999',
+        description: 'Updated description',
+        startDate: new Date('2025-01-01'),
+        endDate: new Date('2025-12-31'),
+        participantsNum: 100,
+        dbKeywords: ['updated'],
+        connection: {
+          tempDbDetails: {
+            url: 'postgres://updated',
+            type: 'postgres',
+            name: 'Database update',
+          },
+        },
+      };
+
+      (prismaMock.project.update as jest.Mock).mockResolvedValue({});
+
+      await service.updateProject(projectId, dto);
+
+      expect(prismaMock.project.update).toHaveBeenCalledWith({
+        where: { projectId },
+        data: {
+          name: dto.name,
+          lead: dto.lead,
+          university: dto.university,
+          faculty: dto.faculty,
+          ethicsId: dto.ethicsId,
+          description: dto.description,
+          startDate: dto.startDate,
+          endDate: dto.endDate,
+          lastModified: expect.any(Date),
+          participantsNum: dto.participantsNum,
+          dbKeywords: dto.dbKeywords,
+          connection: {
+            update: {
+              tempDbDetails: JSON.stringify(dto.connection.tempDbDetails),
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe('deleteProject', () => {
+    it('should delete project and include connection and analysis', async () => {
+      const projectId = 'proj-1';
+      const deleted = {
+        projectId,
+        connection: [],
+        analysis: [],
+      };
+
+      (prismaMock.project.delete as jest.Mock).mockResolvedValue(deleted);
+
+      const result = await service.deleteProject(projectId);
+
+      expect(prismaMock.project.delete).toHaveBeenCalledWith({
+        where: { projectId },
+        include: {
+          connection: true,
+          analysis: true,
+        },
+      });
+      expect(result).toEqual(deleted);
+    });
+  });
+
+  describe('getProjectSettings', () => {
+    it('should return settings with cover URL when project exists', async () => {
+      const projectId = 'proj-1';
+      const visualizations = [{ title: 'Dash', link: 'https://example.com' }];
+
+      (prismaMock.project.findUnique as jest.Mock).mockResolvedValue({
+        visualizations,
+      });
+
+      (fileStorageMock.getFileUrl as jest.Mock).mockResolvedValue(
+        'https://cdn.example.com/cover.jpg',
+      );
+
+      const result = await service.getProjectSettings(projectId);
+
+      expect(prismaMock.project.findUnique).toHaveBeenCalledWith({
+        where: { projectId },
+        select: {
+          visualizations: true,
+        },
+      });
+
+      expect(fileStorageMock.getFileUrl).toHaveBeenCalledWith(
+        'cover',
+        `${projectId}/cover.jpg`,
+      );
+
+      expect(result).toEqual({
+        projectId,
+        visualizations,
+        cover: 'https://cdn.example.com/cover.jpg',
+      });
+    });
+
+    it('should return null when project does not exist', async () => {
+      const projectId = 'proj-1';
+      (prismaMock.project.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const result = await service.getProjectSettings(projectId);
+
+      expect(result).toBeNull();
+      expect(fileStorageMock.getFileUrl).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateProjectSettings', () => {
+    it('should update visualizations and delete old cover', async () => {
+      const projectId = 'proj-1';
+
+      const dto: SettingsDto = {
+        projectId,
+        cover: undefined,
+        visualizations: [
+          {
+            title: 'New Dash',
+            link: 'https://example.com/new',
+          },
+        ],
+      };
+
+      (prismaMock.project.update as jest.Mock).mockResolvedValue({});
+
+      const result = await service.updateProjectSettings(projectId, dto);
+
+      expect(prismaMock.project.update).toHaveBeenCalledWith({
+        where: { projectId },
+        data: {
+          visualizations: JSON.stringify(dto.visualizations),
+        },
+      });
+
+      expect(fileStorageMock.deleteFile).toHaveBeenCalledWith(
+        'cover',
+        `${projectId}`,
+      );
+
+      expect(result).toBe(projectId);
+    });
+  });
+
+  describe('uploadProjectCover', () => {
+    it('should update lastModified and upload cover file', async () => {
+      const projectId = 'proj-1';
+
+      const file = {
+        buffer: Buffer.from('filedata'),
+      } as Express.Multer.File;
+
+      (prismaMock.project.update as jest.Mock).mockResolvedValue({});
+
+      const result = await service.uploadProjectCover(projectId, file);
+
+      expect(prismaMock.project.update).toHaveBeenCalledWith({
+        where: { projectId },
+        data: {
+          lastModified: expect.any(Date),
+        },
+      });
+
+      expect(fileStorageMock.putFile).toHaveBeenCalledWith(
+        'cover',
+        `${projectId}/cover.jpg`,
+        file,
+      );
+
+      expect(result).toBe(file.buffer);
+    });
+  });
+});

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -1,12 +1,13 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import {
+  CreateProjectDto,
   ProjectDetailsResponseDto,
-  ProjectDto,
   ProjectRequestsResponse,
   ProjectSummaryInfoDto,
   SettingsDto,
   SettingsResponseDto,
+  UpdateProjectDto,
 } from './dto';
 import { FileStorageService } from 'src/file_storage/file_storage.service';
 import { KeycloakAdminService } from 'src/admin/keycloak/keycloak.admin.service';
@@ -148,20 +149,17 @@ export class ProjectService {
     return requestList;
   }
 
-  async createProject(user: CurrentUserInfo, dto: ProjectDto) {
+  async createProject(user: CurrentUserInfo, dto: CreateProjectDto) {
     // TODO:  Why not have this as object?
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const memberData: unknown[] = JSON.parse(dto.members ?? '[]');
-    const customId = nanoid(12);
-    const packageName = dto.name
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '_')
-      .replace(/^_+|_+$/g, '');
+    const { packageId, customId } = this.createIds(dto.name, dto.customId);
+    const ownerId = user.id; //using current logged in user details rather than post
 
     const request = {
-      ownerId: dto.ownerId,
-      customId: customId,
-      packageId: `${packageName}_${customId.slice(0, 6)}`,
+      ownerId,
+      customId,
+      packageId,
       name: dto.name,
       lead: dto.lead,
       university: dto.university,
@@ -194,7 +192,7 @@ export class ProjectService {
               request: {
                 create: {
                   requestId,
-                  requestorId: dto.ownerId,
+                  requestorId: ownerId,
                 },
               },
             }),
@@ -226,7 +224,7 @@ export class ProjectService {
         await this.prisma.comment.create({
           data: {
             requestId,
-            authorId: dto.ownerId,
+            authorId: ownerId,
             content: dto.connection.additionalInfo,
           },
         });
@@ -267,27 +265,53 @@ export class ProjectService {
     });
   }
 
-  async updateProject(projectId: string, dto: ProjectDto) {
-    const dbData = JSON.stringify(dto.connection.tempDbDetails);
-    // const memberData = JSON.parse(dto.members);
+  async updateProject(projectId: string, dto: UpdateProjectDto) {
+    // should not update on invalid projectId
+    if (projectId !== dto.projectId) return;
+    // TODO:  Why not have this as object?
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const memberData: unknown[] = JSON.parse(dto.members ?? '[]');
+    const data = {
+      // NOTE: can you change name as that changes package???
+      name: dto.name,
+      lead: dto.lead,
+      status: dto.status,
+      // NOTE: can you change customId as that also changes package??
+      university: dto.university,
+      faculty: dto.faculty,
+      ethicsId: dto.ethicsId,
+      description: dto.description,
+      startDate: dto.startDate,
+      endDate: dto.endDate,
+      lastModified: new Date(),
+      participantsNum: dto.participantsNum,
+      ...(memberData.length && {
+        members: dto.members,
+      }),
+      dbKeywords: dto.dbKeywords,
+    };
+
+    // remove undefined fields
+    Object.keys(data).forEach(
+      (key) => data[key] === undefined && delete data[key],
+    );
+
+    // Check if connection details are updated
+    const connection =
+      dto.connection?.tempDbDetails !== undefined
+        ? {
+            connection: {
+              update: {
+                tempDbDetails: JSON.stringify(dto.connection.tempDbDetails),
+              },
+            },
+          }
+        : {};
     await this.prisma.project.update({
       where: { projectId: projectId },
       data: {
-        name: dto.name,
-        lead: dto.lead,
-        university: dto.university,
-        faculty: dto.faculty,
-        ethicsId: dto.ethicsId,
-        description: dto.description,
-        startDate: dto.startDate,
-        endDate: dto.endDate,
-        participantsNum: dto.participantsNum,
-        dbKeywords: dto.dbKeywords,
-        connection: {
-          update: {
-            tempDbDetails: dbData,
-          },
-        },
+        ...data,
+        ...connection,
       },
     });
   }
@@ -355,8 +379,19 @@ export class ProjectService {
         lastModified: new Date(),
       },
     });
-
+    // FIXME: not sure if forcing jpg is good, it should use the ext it has been uploaded
     await this.fileStorage.putFile('cover', `${projectId}/cover.jpg`, file);
     return file.buffer;
+  }
+
+  // TODO: review this generation
+  private createIds(name: string, id?: string) {
+    const customId = id ?? nanoid(12);
+    const packageName = name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '');
+    const packageId = `${packageName}_${customId.slice(0, 6)}`;
+    return { packageId, customId };
   }
 }

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -6,6 +6,7 @@ import {
   ProjectRequestsResponse,
   ProjectSummaryInfoDto,
   SettingsDto,
+  SettingsResponseDto,
 } from './dto';
 import { FileStorageService } from 'src/file_storage/file_storage.service';
 import { KeycloakAdminService } from 'src/admin/keycloak/keycloak.admin.service';
@@ -303,7 +304,9 @@ export class ProjectService {
     });
   }
 
-  async getProjectSettings(projectId: string) {
+  async getProjectSettings(
+    projectId: string,
+  ): Promise<SettingsResponseDto | null> {
     const project = await this.prisma.project.findUnique({
       where: {
         projectId: projectId,
@@ -322,7 +325,7 @@ export class ProjectService {
       return {
         projectId: projectId,
         visualizations: project.visualizations,
-        cover: cover || null,
+        cover: cover ?? null,
       };
     }
     return null;

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -7,6 +7,7 @@ import { nanoid } from 'nanoid';
 import { QueueService } from 'src/queue/queue.service';
 
 import { KeycloakPermissionDto } from 'src/auth/keycloak/dto';
+import { CurrentUserInfo } from 'src/common/decorators/user.decorator';
 @Injectable()
 export class ProjectService {
   private readonly logger = new Logger(ProjectService.name);
@@ -135,7 +136,7 @@ export class ProjectService {
     return requestList;
   }
 
-  async createProject(owner: string, dto: ProjectDto) {
+  async createProject(user: CurrentUserInfo, dto: ProjectDto) {
     // TODO:  Why not have this as object?
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const memberData = JSON.parse(dto.members);
@@ -163,7 +164,7 @@ export class ProjectService {
       dbKeywords: dto.dbKeywords,
       connection: {
         create: {
-          orgAdminEmail: dto.connection.orgAdminEmail,
+          orgAdminEmail: dto.connection.orgAdminEmail ?? user.email,
           tempDbDetails: JSON.stringify(dto.connection.tempDbDetails),
           request: {
             create: {
@@ -217,7 +218,7 @@ export class ProjectService {
         },
       });
       await this.queue.dataBrokerJob(
-        owner,
+        user.username,
         project.projectId,
         project.connection.requestId,
         dto.connection.tempDbDetails,

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -253,7 +253,7 @@ export class ProjectService {
   async getProjectDetails(
     projectId: string,
   ): Promise<ProjectDetailsResponseDto | null> {
-    return await this.prisma.project.findUnique({
+    return await this.prisma.project.findUniqueOrThrow({
       where: {
         projectId: projectId,
       },
@@ -313,7 +313,7 @@ export class ProjectService {
             },
           }
         : {};
-    await this.prisma.project.update({
+    return await this.prisma.project.update({
       where: { projectId: projectId },
       data: {
         ...data,
@@ -334,10 +334,8 @@ export class ProjectService {
     });
   }
 
-  async getProjectSettings(
-    projectId: string,
-  ): Promise<SettingsResponseDto | null> {
-    const project = await this.prisma.project.findUnique({
+  async getProjectSettings(projectId: string): Promise<SettingsResponseDto> {
+    const project = await this.prisma.project.findUniqueOrThrow({
       where: {
         projectId: projectId,
       },
@@ -345,20 +343,16 @@ export class ProjectService {
         visualizations: true,
       },
     });
+    const bucket = 'cover';
+    const key = `${projectId}/cover.jpg`;
 
-    if (project) {
-      const bucket = 'cover';
-      const key = `${projectId}/cover.jpg`;
+    const cover = await this.fileStorage.getFileUrl(bucket, key);
 
-      const cover = await this.fileStorage.getFileUrl(bucket, key);
-
-      return {
-        projectId: projectId,
-        visualizations: project.visualizations,
-        cover: cover ?? null,
-      };
-    }
-    return null;
+    return {
+      projectId: projectId,
+      visualizations: project.visualizations,
+      cover: cover ?? null,
+    };
   }
 
   async updateProjectSettings(projectId: string, dto: SettingsDto) {

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -1,6 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
-import { ProjectDto, ProjectSummaryInfoDto, SettingsDto } from './dto';
+import {
+  ProjectDetailsResponseDto,
+  ProjectDto,
+  ProjectRequestsResponse,
+  ProjectSummaryInfoDto,
+  SettingsDto,
+} from './dto';
 import { FileStorageService } from 'src/file_storage/file_storage.service';
 import { KeycloakAdminService } from 'src/admin/keycloak/keycloak.admin.service';
 import { nanoid } from 'nanoid';
@@ -90,7 +96,10 @@ export class ProjectService {
     });
   }
 
-  async getProjectRequests(projectId: string, email: string) {
+  async getProjectRequests(
+    projectId: string,
+    email: string,
+  ): Promise<ProjectRequestsResponse> {
     const requestList: {
       connection: ConnectionRequestResponseDto[];
       analysis: AnalysisRequestResponseDto[];
@@ -236,8 +245,10 @@ export class ProjectService {
     return;
   }
 
-  async getProjectDetails(projectId: string) {
-    const project = await this.prisma.project.findFirst({
+  async getProjectDetails(
+    projectId: string,
+  ): Promise<ProjectDetailsResponseDto | null> {
+    return await this.prisma.project.findUnique({
       where: {
         projectId: projectId,
       },
@@ -253,8 +264,6 @@ export class ProjectService {
         },
       },
     });
-    //TODO: get archetype when project status is MAPPED
-    return project;
   }
 
   async updateProject(projectId: string, dto: ProjectDto) {
@@ -316,7 +325,7 @@ export class ProjectService {
         cover: cover || null,
       };
     }
-    return {};
+    return null;
   }
 
   async updateProjectSettings(projectId: string, dto: SettingsDto) {

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -8,6 +8,8 @@ import { QueueService } from 'src/queue/queue.service';
 
 import { KeycloakPermissionDto } from 'src/auth/keycloak/dto';
 import { CurrentUserInfo } from 'src/common/decorators/user.decorator';
+import { v4 as uuidv4 } from 'uuid';
+
 @Injectable()
 export class ProjectService {
   private readonly logger = new Logger(ProjectService.name);
@@ -22,11 +24,6 @@ export class ProjectService {
     const projects = await this.prisma.project.findMany({
       where: {
         ownerId: userId,
-        connection: {
-          request: {
-            requestorId: userId,
-          },
-        },
       },
       select: {
         projectId: true,
@@ -162,26 +159,34 @@ export class ProjectService {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       members: memberData,
       dbKeywords: dto.dbKeywords,
-      connection: {
-        create: {
-          orgAdminEmail: dto.connection.orgAdminEmail ?? user.email,
-          tempDbDetails: JSON.stringify(dto.connection.tempDbDetails),
-          request: {
-            create: {
-              requestorId: dto.ownerId,
-            },
+    };
+
+    // check if database credential request is needed
+    const createRequest = dto.connection.orgAdminEmail ? true : false;
+    const requestId = uuidv4();
+    const project = await this.prisma.project.create({
+      data: {
+        ...request,
+        connection: {
+          create: {
+            // if no orgAdminEmail provider make owner admin
+            orgAdminEmail: dto.connection.orgAdminEmail ?? user.email,
+            tempDbDetails:
+              JSON.stringify(dto.connection.tempDbDetails) ?? undefined,
+            ...(createRequest && {
+              request: {
+                create: {
+                  requestId,
+                  requestorId: dto.ownerId,
+                },
+              },
+            }),
           },
         },
       },
-    };
-
-    const project = await this.prisma.project.create({
-      data: request,
       include: {
         connection: {
-          include: {
-            request: true,
-          },
+          include: { request: true },
         },
       },
     });
@@ -198,42 +203,28 @@ export class ProjectService {
       memberEmails,
     );
 
-    if (dto.connection.additionalInfo && project.connection) {
-      await this.prisma.comment.create({
-        data: {
-          requestId: project.connection.request.requestId,
-          authorId: dto.ownerId,
-          content: dto.connection.additionalInfo,
-        },
-      });
+    if (createRequest) {
+      // create comment if additionalInfo is provided to request
+      if (dto.connection.additionalInfo) {
+        await this.prisma.comment.create({
+          data: {
+            requestId,
+            authorId: dto.ownerId,
+            content: dto.connection.additionalInfo,
+          },
+        });
+      }
+    } else {
+      // database credentials should exist so run database crawling
+      if (dto.connection.tempDbDetails?.url) {
+        await this.queue.dataBrokerJob(
+          user.username,
+          project.projectId,
+          requestId,
+          dto.connection.tempDbDetails,
+        );
+      }
     }
-
-    if (dto.connection.tempDbDetails?.url && project.connection) {
-      await this.prisma.request.update({
-        where: {
-          requestId: project.connection.requestId,
-        },
-        data: {
-          status: 'APPROVED',
-        },
-      });
-      await this.queue.dataBrokerJob(
-        user.username,
-        project.projectId,
-        project.connection.requestId,
-        dto.connection.tempDbDetails,
-      );
-    } else if (project.connection) {
-      await this.prisma.request.update({
-        where: {
-          requestId: project.connection.requestId,
-        },
-        data: {
-          status: 'PENDING',
-        },
-      });
-    }
-
     return project;
   }
 

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -232,6 +232,12 @@ export class ProjectService {
     } else {
       // database credentials should exist so run database crawling
       if (dto.connection.tempDbDetails?.url) {
+        await this.prisma.project.update({
+          where: { projectId: project.projectId },
+          data: {
+            status: 'CRAWLING',
+          },
+        });
         await this.queue.dataBrokerJob(
           user.username,
           project.projectId,

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
-import { ProjectDto, ProjectListDto, SettingsDto } from './dto';
+import { ProjectDto, ProjectSummaryInfoDto, SettingsDto } from './dto';
 import { FileStorageService } from 'src/file_storage/file_storage.service';
 import { KeycloakAdminService } from 'src/admin/keycloak/keycloak.admin.service';
 import { nanoid } from 'nanoid';
@@ -9,6 +9,8 @@ import { QueueService } from 'src/queue/queue.service';
 import { KeycloakPermissionDto } from 'src/auth/keycloak/dto';
 import { CurrentUserInfo } from 'src/common/decorators/user.decorator';
 import { v4 as uuidv4 } from 'uuid';
+import { ConnectionRequestResponseDto } from 'src/connection_request/dto';
+import { AnalysisRequestResponseDto } from 'src/analysis_request/dto';
 
 @Injectable()
 export class ProjectService {
@@ -20,7 +22,7 @@ export class ProjectService {
     private readonly keycloak: KeycloakAdminService,
   ) {}
 
-  async getUserOwnedProjects(userId: string): Promise<ProjectListDto[]> {
+  async getUserOwnedProjects(userId: string): Promise<ProjectSummaryInfoDto[]> {
     const projects = await this.prisma.project.findMany({
       where: {
         ownerId: userId,
@@ -30,9 +32,9 @@ export class ProjectService {
         customId: true,
         name: true,
         lastModified: true,
-        createdDate: true,
         status: true,
         university: true,
+        lead: true,
         faculty: true,
       },
     });
@@ -41,7 +43,7 @@ export class ProjectService {
 
   async getUserSharedProjects(
     permissions: KeycloakPermissionDto[],
-  ): Promise<ProjectListDto[]> {
+  ): Promise<ProjectSummaryInfoDto[]> {
     const uuids = permissions
       .filter(
         (item) =>
@@ -59,7 +61,7 @@ export class ProjectService {
         customId: true,
         name: true,
         lastModified: true,
-        createdDate: true,
+        lead: true,
         status: true,
         university: true,
         faculty: true,
@@ -89,7 +91,10 @@ export class ProjectService {
   }
 
   async getProjectRequests(projectId: string, email: string) {
-    const requestList: { connection: unknown[]; analysis: unknown[] } = {
+    const requestList: {
+      connection: ConnectionRequestResponseDto[];
+      analysis: AnalysisRequestResponseDto[];
+    } = {
       connection: [],
       analysis: [],
     };
@@ -136,7 +141,7 @@ export class ProjectService {
   async createProject(user: CurrentUserInfo, dto: ProjectDto) {
     // TODO:  Why not have this as object?
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const memberData = JSON.parse(dto.members);
+    const memberData: unknown[] = JSON.parse(dto.members ?? '[]');
     const customId = nanoid(12);
     const packageName = dto.name
       .toLowerCase()
@@ -156,8 +161,10 @@ export class ProjectService {
       startDate: dto.startDate,
       endDate: dto.endDate,
       participantsNum: dto.participantsNum,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      members: memberData,
+
+      ...(memberData.length && {
+        members: dto.members,
+      }),
       dbKeywords: dto.dbKeywords,
     };
 
@@ -191,7 +198,7 @@ export class ProjectService {
       },
     });
 
-    const memberEmails = (memberData as unknown[]).map(
+    const memberEmails = memberData.map(
       (member: Record<string, string>) => member.email,
     );
 
@@ -225,7 +232,8 @@ export class ProjectService {
         );
       }
     }
-    return project;
+    // just return, no content
+    return;
   }
 
   async getProjectDetails(projectId: string) {

--- a/src/queue/atlas.processor.spec.ts
+++ b/src/queue/atlas.processor.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import request from 'supertest';


### PR DESCRIPTION
**BREAKING CHANGES:**
- `npx prisma migrate dev` needs to be run as new migrations added
- frontend PR https://github.com/Epsilon-Data/frontend/pull/95 needs to go in the same time


**Changes:**
- added migrations for new project statuses  (see BREAKING CHANGES)
- changed connection - project relationships in the database (1-1 relationship)
- made request optional for connection as only needed if not db creds are known
- cleaned up project creation and update functions
- added dto's for API (swagger) docs and made the API exhaustive for Project
- added `project.service` tests for existing methods

**Future:**
- we need to add "public" methods that return project information for Browse Hub (project exploration) - will make a new issue for this as you are starting to work on that bit of the frontend now @chuleeshen 
- @chuleeshen, I wasn't sure of some of the settings endpoints, are they used or not. Probably will get back to them when starting to do the Project Settings tasks - https://github.com/Epsilon-Data/frontend/issues/19