### PR TITLE
Modified get analysis requests endpoint

### DIFF
--- a/prisma/migrations/20251117103359_add_request_status/migration.sql
+++ b/prisma/migrations/20251117103359_add_request_status/migration.sql
@@ -1,0 +1,10 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "RequestStatus" ADD VALUE 'REVISION';
+ALTER TYPE "RequestStatus" ADD VALUE 'REJECTED';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -132,5 +132,7 @@ enum ProjectStatus {
 
 enum RequestStatus {
   PENDING
+  REVISION
+  REJECTED
   APPROVED
 }

--- a/src/analysis_request/analysis_request.controller.ts
+++ b/src/analysis_request/analysis_request.controller.ts
@@ -32,7 +32,7 @@ export class AnalysisRequestController {
 
   @Get()
   @ApiOperation({
-    summary: 'Get list of analysis requests',
+    summary: 'Get list of analysis requests sent',
   })
   @UseGuards(new ScopesGuard('api.hub.read'))
   async getList(@CurrentUser() user: CurrentUserInfo) {

--- a/src/analysis_request/analysis_request.service.ts
+++ b/src/analysis_request/analysis_request.service.ts
@@ -28,17 +28,36 @@ export class AnalysisRequestService {
       },
       select: {
         requestId: true,
-        projectName: true,
+        project: {
+          select: {
+            projectId: true,
+            name: true,
+            university: true,
+          },
+        },
         request: {
           select: {
             status: true,
             createdDate: true,
+            lastModified: true,
           },
         },
       },
     });
 
-    return requestList;
+    const formatted = requestList.map((request) => {
+      return {
+        requestId: request.requestId,
+        projectId: request.project.projectId,
+        projectName: request.project.name,
+        projectUniversity: request.project.university,
+        status: request.request.status,
+        createdDate: request.request.createdDate,
+        lastModified: request.request.lastModified,
+      };
+    });
+
+    return formatted;
   }
 
   async createRequest(dto: AnalysisDto) {


### PR DESCRIPTION
Changes:
- Add request statuses for analysis requests (prisma migration)
- Return more details when getting the list of analysis requests for the logged-in user
