### PR TITLE
Coordinator API endpoints

### DIFF
--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -19,7 +19,6 @@ import { AdminConfigService } from 'src/config/admin-config.service';
 @Module({
   imports: [ConfigModule],
   controllers: [AdminController],
-  exports: [],
   providers: [AdminConfigService],
 })
 export class AdminModule {

--- a/src/admin/keycloak/keycloak-admin.service.ts
+++ b/src/admin/keycloak/keycloak-admin.service.ts
@@ -38,6 +38,7 @@ import {
   KeycloakConflictError,
   KeycloakUnavailableError,
 } from './keycloak-admin.errors';
+import { ClientLoginDto } from 'src/coordinator/dto';
 
 export type UserQueryParams = {
   readonly email?: string;
@@ -543,18 +544,16 @@ export class KeycloakAdminService implements OnModuleInit {
   }
 
   // used by coordinator
-  async getAccessTokenClient(
-    clientId: string,
-    clientSecret: string,
-  ): Promise<{
+  async getAccessTokenClient(login: ClientLoginDto): Promise<{
     access_token: string;
     expires_in?: number;
   }> {
     await this.auth({
       grantType: 'client_credentials',
       clientId:
-        clientId ?? this.configService.get<string>('coordinator.clientId'),
-      clientSecret,
+        login.clientId ??
+        this.configService.get<string>('coordinator.clientId'),
+      clientSecret: login.clientSecret,
     });
 
     const token = await this.kcAdminClient.getAccessToken();

--- a/src/admin/keycloak/keycloak-admin.service.ts
+++ b/src/admin/keycloak/keycloak-admin.service.ts
@@ -542,6 +542,25 @@ export class KeycloakAdminService implements OnModuleInit {
     return { access_token: token || '' };
   }
 
+  // used by coordinator
+  async getAccessTokenClient(
+    clientId: string,
+    clientSecret: string,
+  ): Promise<{
+    access_token: string;
+    expires_in?: number;
+  }> {
+    await this.auth({
+      grantType: 'client_credentials',
+      clientId:
+        clientId ?? this.configService.get<string>('coordinator.clientId'),
+      clientSecret,
+    });
+
+    const token = await this.kcAdminClient.getAccessToken();
+    return { access_token: token || '' };
+  }
+
   //FIXME: not working properly
   async deleteResource(id: string) {
     this.logger.debug('Deleting resource', id);

--- a/src/analysis-request/analysis-request.module.ts
+++ b/src/analysis-request/analysis-request.module.ts
@@ -5,5 +5,6 @@ import { AnalysisRequestController } from './analysis-request.controller';
 @Module({
   providers: [AnalysisRequestService],
   controllers: [AnalysisRequestController],
+  exports: [AnalysisRequestService],
 })
 export class AnalysisRequestModule {}

--- a/src/analysis/analysis.module.ts
+++ b/src/analysis/analysis.module.ts
@@ -1,14 +1,11 @@
-import { forwardRef, Module } from '@nestjs/common';
-import { AnalysisService } from './analysis.service';
+import { Module } from '@nestjs/common';
 import { AnalysisController } from './analysis.controller';
 import { AdminModule } from 'src/admin/admin.module';
-import { ArchetypeService } from 'src/archetype/archetype.service';
-import { DatabaseModule } from 'src/database/database.module';
-import { AnalysisRequestService } from 'src/analysis-request/analysis-request.service';
+import { ArchetypeModule } from 'src/archetype/archetype.module';
+import { AnalysisRequestModule } from 'src/analysis-request/analysis-request.module';
 
 @Module({
-  imports: [AdminModule, forwardRef(() => DatabaseModule)],
+  imports: [AdminModule, ArchetypeModule, AnalysisRequestModule],
   controllers: [AnalysisController],
-  providers: [AnalysisService, ArchetypeService, AnalysisRequestService],
 })
 export class AnalysisModule {}

--- a/src/analysis/analysis.service.ts
+++ b/src/analysis/analysis.service.ts
@@ -1,6 +1,0 @@
-import { Injectable } from '@nestjs/common';
-
-@Injectable()
-export class AnalysisService {
-  constructor() {}
-}

--- a/src/analysis/dto/analysis.dto.ts
+++ b/src/analysis/dto/analysis.dto.ts
@@ -77,6 +77,15 @@ export class DatasetDto {
 
 export class AnalysisArchetypeResponseDto {
   @ApiProperty({
+    description: 'Id of the Archetype',
+    example: '3kHBQLNwl9qc',
+  })
+  @IsDefined()
+  @IsString()
+  @IsNotEmpty()
+  $id!: string;
+
+  @ApiProperty({
     description: 'JSON Schema meta-identifier (draft URI)',
     example: 'https://json-schema.org/draft/2020-12/schema',
   })

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -20,6 +20,7 @@ import configuration from './config/configuration';
 import { AdminConfigService } from './config/admin-config.service';
 import { AuthConfigService } from './config/auth-config.service';
 import { AnalysisModule } from './analysis/analysis.module';
+import { CoordinatorModule } from './coordinator/coordinator.module';
 
 @Module({
   imports: [
@@ -45,6 +46,7 @@ import { AnalysisModule } from './analysis/analysis.module';
     DatabaseModule,
     AtlasModule,
     DockerModule,
+    CoordinatorModule,
   ],
   controllers: [AppController],
   providers: [AdminConfigService, AuthConfigService],

--- a/src/archetype/archetype.service.spec.ts
+++ b/src/archetype/archetype.service.spec.ts
@@ -955,6 +955,7 @@ describe('ArchetypeService', () => {
       const token = 'test-token';
       const archetypeId = 'Xa7BAIWZCA8u';
       const templateGuid = '329fedeb-c6ac-4b37-996c-f658c2cdeafd';
+      const templateQN = `${projectId}@${archetypeId}`;
       const templateName = 'My Archetype Title';
 
       // mock for getting GUID and name of PUBLISHED template
@@ -983,7 +984,9 @@ describe('ArchetypeService', () => {
         entity: {
           guid: templateGuid,
           typeName: AtlasArchetypeTypeName.Template,
+
           attributes: {
+            qualifiedName: templateQN,
             name: templateName,
             status: 'PUBLISHED',
           },
@@ -1085,6 +1088,7 @@ describe('ArchetypeService', () => {
       atlas.get.mockResolvedValueOnce(columnEntity);
 
       const schema = (await service.getAnalysisArchetype(projectId, token)) as {
+        $id: string;
         $schema: 'https://json-schema.org/draft/2020-12/schema#';
         title: string;
         type: 'object';
@@ -1135,6 +1139,7 @@ describe('ArchetypeService', () => {
         token,
       );
 
+      expect(schema.$id).toBe(archetypeId);
       // Schema basics
       expect(schema.$schema).toBe(
         'https://json-schema.org/draft/2020-12/schema#',

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -357,14 +357,6 @@ export class ArchetypeService {
       token,
     );
     if (res.approximateCount) {
-      const properties: Record<string, object> = {};
-      const schema = {
-        $schema: 'https://json-schema.org/draft/2020-12/schema#',
-        title: res.attributes?.values[0][0],
-        type: 'object',
-        properties,
-      };
-
       const templateGuid = res.attributes?.values[0][1];
       const templateEntity =
         await this.atlas.get<AtlasArchetypeEntityResponseDto>(
@@ -372,7 +364,17 @@ export class ArchetypeService {
           undefined,
           token,
         );
-
+      const properties: Record<string, object> = {};
+      const archetypeId = templateEntity.entity.attributes.qualifiedName
+        .split('@')
+        .at(-1);
+      const schema = {
+        $id: archetypeId,
+        $schema: 'https://json-schema.org/draft/2020-12/schema#',
+        title: res.attributes?.values[0][0],
+        type: 'object',
+        properties,
+      };
       // TODO: handle errors
       for (const key in templateEntity?.referredEntities) {
         const node = templateEntity.referredEntities[key];
@@ -634,10 +636,14 @@ export class ArchetypeService {
     return ALLOWED_TRANSITIONS[current]?.includes(next) ?? false;
   }
 
-  private initJsonObject() {
-    const type = 'object';
-    const properties: Record<string, object> = {};
-    return { type, properties };
+  private initJsonObject(): {
+    type: 'object';
+    properties: Record<string, unknown>;
+  } {
+    return {
+      type: 'object',
+      properties: {},
+    };
   }
 
   private atlasTypeToJSONType(dataType: string): string {
@@ -665,7 +671,7 @@ export class ArchetypeService {
   }
 
   private isEntityAllowedByPermissions(entity: AtlasArchetypeEntityDto) {
-    // Level-0 → always allowed
+    // Level-0 always allowed
     if (entity.attributes?.level === 0) return true;
 
     let isActiveBranchNode = false;
@@ -690,7 +696,7 @@ export class ArchetypeService {
     // TODO: check this logic
     if (isActiveBranchNode) return true;
 
-    // No permission classifications → allow only for ACTIVE branch nodes
+    // No permission classifications, allow only for ACTIVE branch nodes
     if (perms.length === 0) {
       return isActiveBranchNode;
     }
@@ -718,22 +724,22 @@ export class ArchetypeService {
       (c) => c.attributes?.access_level === ArchetypePermission.NONE,
     );
 
-    // explicit NONE on this node → always deny
+    // explicit NONE on this node -  always deny
     if (hasExplicitDeny) {
       return false;
     }
 
-    // explicit non-NONE permission → allow even if inherited is NONE
+    // explicit non-NONE permission - allow even if inherited is NONE
     if (hasExplicitGrant) {
       return true;
     }
 
-    // no explicit perms, but inherited NONE exists → deny
+    // no explicit perms, but inherited NONE exists - deny
     if (hasInheritedDeny) {
       return false;
     }
 
-    // permissions exist, none are NONE → allow
+    // permissions exist, none are NONE -  allow
     return true;
   }
 }

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -367,7 +367,7 @@ export class ArchetypeService {
       const properties: Record<string, object> = {};
       const archetypeId = templateEntity.entity.attributes.qualifiedName
         .split('@')
-        .at(-1);
+        .at(-1) as string;
       const schema = {
         $id: archetypeId,
         $schema: 'https://json-schema.org/draft/2020-12/schema#',

--- a/src/auth/auth.middleware.ts
+++ b/src/auth/auth.middleware.ts
@@ -16,9 +16,12 @@ export class AuthMiddleware implements NestMiddleware {
   use(request: Request, response: Response, next: NextFunction) {
     const allowTokenAuth =
       request.method === 'GET' &&
-      request.originalUrl.startsWith(
+      (request.originalUrl.startsWith(
         `${this.configService.get<string>('apiBaseUrl')}/analysis`,
-      )
+      ) ||
+        request.originalUrl.startsWith(
+          `${this.configService.get<string>('apiBaseUrl')}/coordinator`,
+        ))
         ? true
         : false;
     return addToken(

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -27,16 +27,16 @@ import { AuthConfigService } from 'src/config/auth-config.service';
 @Global()
 @Module({
   imports: [ConfigModule],
-  controllers: [],
-  exports: [KeycloakService],
   providers: [AuthConfigService, KeycloakService],
+  exports: [KeycloakService],
 })
 export class AuthModule implements NestModule {
   constructor(private configService: ConfigService) {}
   configure(consumer: MiddlewareConsumer) {
     const excludes = [
       { path: 'health', method: RequestMethod.GET },
-      { path: 'analysis/auth', method: RequestMethod.ALL }, // analysis sdk auth path
+      { path: 'analysis/auth', method: RequestMethod.POST }, // analysis sdk auth path
+      { path: 'coordinator/auth', method: RequestMethod.POST }, // coordinator client auth path
     ];
 
     // only add docs if dev

--- a/src/common/filters/auth-exception.filter.ts
+++ b/src/common/filters/auth-exception.filter.ts
@@ -52,7 +52,7 @@ export class AuthExceptionFilter implements ExceptionFilter {
     }
 
     if (isKeycloakNetworkError(exception)) {
-      // Map Keycloak error → HTTP response
+      // Map Keycloak error -  HTTP response
       const status =
         exception.response?.status && exception.response.status >= 400
           ? exception.response.status

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -39,6 +39,9 @@ export default () => ({
     clientSecret:
       env.EPSILON_SDK_CLIENT_SECRET || '6nHzYqIlwcQDqDc2TuJtilucZxAH3O6N',
   },
+  coordinator: {
+    clientId: env.EPSILON_COORDINATOR_CLINET_ID || 'coordinator-client',
+  },
   atlas: {
     // default values for local dev
     uri: env.ATLAS_URI || 'http://localhost:21000',

--- a/src/coordinator/coordinator.controller.ts
+++ b/src/coordinator/coordinator.controller.ts
@@ -1,0 +1,114 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiInternalServerErrorResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+  getSchemaPath,
+} from '@nestjs/swagger';
+import { Public } from 'src/common/decorators/public.decorator';
+import { KeycloakAdminService } from 'src/admin/keycloak/keycloak-admin.service';
+import { Resource } from 'src/common/decorators/resource.decorator';
+import { DatabaseService } from 'src/database/database.service';
+import { AuthTokenResponseDto } from 'src/analysis/dto';
+import { GenericErrorResponseDto } from 'src/common/dto';
+import { ClientLoginDto } from './dto';
+import { ScopesGuard } from 'src/common/guards/scopes.guard';
+import { DatasetDetailsResponseDto } from 'src/database/dto';
+
+@ApiTags('Coordinator')
+@ApiBearerAuth()
+@Controller('coordinator')
+@Resource('project')
+export class CoordinatorController {
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly keycloakService: KeycloakAdminService,
+  ) {}
+
+  @Public()
+  @Post('auth')
+  @ApiOperation({
+    summary:
+      'Get access token for internal coordinator client (Public endpoint)',
+  })
+  @HttpCode(HttpStatus.OK)
+  @ApiOkResponse({
+    description: 'List of user owned projects are returned',
+    type: AuthTokenResponseDto,
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Invalid credentials',
+    content: {
+      'application/json': {
+        schema: { $ref: getSchemaPath(GenericErrorResponseDto) },
+        example: {
+          statusCode: 401,
+          message: 'Invalid user credentials',
+          error: 'AuthorisationServiceError',
+        },
+      },
+    },
+  })
+  async getAccessToken(@Body() login: ClientLoginDto) {
+    return await this.keycloakService.getAccessTokenClient(login);
+  }
+
+  @Get(':projectId/:archetypeId')
+  @UseGuards(new ScopesGuard('epsilon.coordinator'))
+  @ApiOperation({ summary: 'Get project archetype dataset details' })
+  @ApiOkResponse({
+    description: 'Project published archetype dataset details returned',
+    type: DatasetDetailsResponseDto,
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid request to metadata service',
+    type: GenericErrorResponseDto,
+    schema: { $ref: getSchemaPath(GenericErrorResponseDto) },
+    example: {
+      statusCode: 400,
+      message: 'Invalid request to metadata service',
+      error: 'MetadataServiceError',
+    },
+  })
+  @ApiNotFoundResponse({
+    description: 'Archetype or underlying Atlas entity not found',
+    type: GenericErrorResponseDto,
+    schema: { $ref: getSchemaPath(GenericErrorResponseDto) },
+    example: {
+      statusCode: 404,
+      message: 'Requested resource could not be found',
+      error: 'MetadataServiceError',
+    },
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Upstream Atlas / metadata service error',
+    type: GenericErrorResponseDto,
+    schema: { $ref: getSchemaPath(GenericErrorResponseDto) },
+    example: {
+      statusCode: 500,
+      message: 'Metadata service is currently unavailable',
+      error: 'MetadataServiceError',
+    },
+  })
+  async getDatasetDetails(
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+    @Param('archetypeId') archetypeId: string,
+  ) {
+    return this.databaseService.getDatasetDetails(projectId, archetypeId);
+  }
+}

--- a/src/coordinator/coordinator.module.ts
+++ b/src/coordinator/coordinator.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CoordinatorController } from './coordinator.controller';
+import { DatabaseModule } from 'src/database/database.module';
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [CoordinatorController],
+})
+export class CoordinatorModule {}

--- a/src/coordinator/dto/coordinator.dto.ts
+++ b/src/coordinator/dto/coordinator.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDefined, IsNotEmpty, IsString } from 'class-validator';
+
+export class ClientLoginDto {
+  @ApiProperty({
+    description: 'Client id',
+    example: 'coordinator-client',
+  })
+  @IsString()
+  @IsDefined()
+  @IsNotEmpty()
+  clientId!: string;
+
+  @ApiProperty({
+    description: 'Client secret',
+    example: '*********',
+  })
+  @IsString()
+  @IsDefined()
+  @IsNotEmpty()
+  clientSecret!: string;
+}
+
+export class AuthTokenResponseDto {
+  @ApiProperty({
+    description: 'The JWT access token issued after successful authentication',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
+  access_token!: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Token lifetime in seconds (optional depending on identity provider)',
+    example: 3600,
+  })
+  expires_in?: number;
+}

--- a/src/coordinator/dto/index.ts
+++ b/src/coordinator/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './coordinator.dto';

--- a/src/database/database.controller.ts
+++ b/src/database/database.controller.ts
@@ -169,6 +169,11 @@ export class DatabaseController {
     },
   })
   async columns(@Param('projectId', ParseUUIDPipe) projectId: string) {
+    const result = await this.databaseSourceService.getDatasetDetails(
+      'b19e1e6c-f2eb-494d-8e7f-8cfa38469a99',
+      '3kHBQLNwl9qc',
+    );
+    console.log(JSON.stringify(result));
     return await this.databaseSourceService.columns(projectId);
   }
 

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -1,10 +1,10 @@
-import { forwardRef, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { DatabaseController } from './database.controller';
 import { DatabaseService } from './database.service';
 import { ArchetypeModule } from 'src/archetype/archetype.module';
 
 @Module({
-  imports: [forwardRef(() => ArchetypeModule)],
+  imports: [ArchetypeModule],
   controllers: [DatabaseController],
   providers: [DatabaseService],
   exports: [DatabaseService],

--- a/src/database/database.service.spec.ts
+++ b/src/database/database.service.spec.ts
@@ -1,8 +1,14 @@
+/* eslint-disable @typescript-eslint/unbound-method */
 import { Test, TestingModule } from '@nestjs/testing';
 import { DatabaseService } from './database.service';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { AtlasService } from 'src/atlas/atlas.service';
-import { AtlasQueryType } from 'src/atlas/dto';
+import { AtlasArchetypeTypeName, AtlasQueryType } from 'src/atlas/dto';
+import {
+  DatasetDataObjectDto,
+  DatasetDetailsResponseDto,
+  DatasetTableReferenceDto,
+} from './dto';
 
 describe('DatabaseService', () => {
   let moduleRef: TestingModule;
@@ -278,6 +284,205 @@ describe('DatabaseService', () => {
           table: `${schemaName}.table_b`,
         },
       ]);
+    });
+  });
+
+  describe('getDatasetDetails', () => {
+    it('should build dataObjects and tableReferences for an active node with column and foreign key', async () => {
+      const projectId = 'proj-1';
+      const archetypeId = 'arch-1';
+      const token = 'test-token';
+
+      // get template entity with one node
+      const nodeGuid = 'node-guid';
+      const columnGuid = 'col-guid';
+      const templateEntity = {
+        entity: {},
+        referredEntities: {
+          [nodeGuid]: {
+            status: 'ACTIVE',
+            typeName: AtlasArchetypeTypeName.Node,
+            attributes: {
+              label: 'Heart rate',
+            },
+            relationshipAttributes: {
+              column: {
+                guid: columnGuid,
+                relationshipStatus: 'ACTIVE',
+              },
+            },
+          },
+        },
+      };
+
+      // get column entity with table relationship
+      const tableGuid = 'table-guid';
+      const columnEntity = {
+        entity: {
+          attributes: {
+            name: 'heart_rate_value',
+          },
+          displayText: 'heart_rate_value_fallback',
+          relationshipAttributes: {
+            table: {
+              guid: tableGuid,
+              typeName: 'rdbms_table',
+              relationshipStatus: 'ACTIVE',
+              displayText: 'measurements',
+            },
+          },
+        },
+        referredEntities: {},
+      };
+
+      // get table entity with db and one foreign key
+      const tableEntity = {
+        entity: {
+          relationshipAttributes: {
+            db: {
+              relationshipStatus: 'ACTIVE',
+              displayText: 'research_db',
+            },
+          },
+        },
+        referredEntities: {
+          fk1: {
+            status: 'ACTIVE',
+            typeName: 'rdbms_foreign_key',
+            relationshipAttributes: {
+              references_table: {
+                relationshipStatus: 'ACTIVE',
+                displayText: 'participants',
+              },
+              key_columns: [
+                {
+                  relationshipStatus: 'ACTIVE',
+                  typeName: 'rdbms_column',
+                  displayText: 'participant_id',
+                },
+              ],
+              references_columns: [
+                {
+                  relationshipStatus: 'ACTIVE',
+                  typeName: 'rdbms_column',
+                  displayText: 'id',
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      // Wire atlas.get calls in order
+      atlasService.get
+        .mockResolvedValueOnce(templateEntity) // first: template
+        .mockResolvedValueOnce(columnEntity) // second: column
+        .mockResolvedValueOnce(tableEntity); // third: table
+
+      const result = await service.getDatasetDetails(
+        projectId,
+        archetypeId,
+        token,
+      );
+
+      // Expect 3 calls
+      expect(atlasService.get).toHaveBeenCalledTimes(3);
+
+      // template call
+      expect(atlasService.get).toHaveBeenNthCalledWith(
+        1,
+        `/entity/uniqueAttribute/type/${AtlasArchetypeTypeName.Template}`,
+        {
+          'attr:qualifiedName': `${projectId}@${archetypeId}`,
+          ignoreRelationships: false,
+          minExtInfo: false,
+        },
+        token,
+      );
+
+      // column entity call
+      expect(atlasService.get).toHaveBeenNthCalledWith(
+        2,
+        `/entity/guid/${columnGuid}`,
+        undefined,
+        token,
+      );
+
+      // table entity call
+      expect(atlasService.get).toHaveBeenNthCalledWith(
+        3,
+        `/entity/guid/${tableGuid}`,
+        undefined,
+        token,
+      );
+
+      // Check result shape
+      const expectedDataObjectKey = 'heart_rate'; // "Heart rate" - "heart_rate"
+
+      expect(
+        result.dataObjects[expectedDataObjectKey],
+      ).toEqual<DatasetDataObjectDto>({
+        label: 'Heart rate',
+        table: 'measurements',
+        column: 'heart_rate_value',
+      });
+
+      expect(
+        result.tableReferences['measurements'],
+      ).toEqual<DatasetTableReferenceDto>({
+        db: 'research_db',
+        foreignKeys: [
+          {
+            referenceTable: 'participants',
+            keyColumns: ['participant_id'],
+            refColumns: ['id'],
+          },
+        ],
+      });
+
+      // Ensure no extra keys
+      expect(Object.keys(result.dataObjects)).toEqual([expectedDataObjectKey]);
+      expect(Object.keys(result.tableReferences)).toEqual(['measurements']);
+    });
+
+    it('should skip nodes when column relationship is not ACTIVE', async () => {
+      const projectId = 'proj-1';
+      const archetypeId = 'arch-1';
+      const token = 'test-token';
+
+      const templateEntity = {
+        entity: {},
+        referredEntities: {
+          node1: {
+            status: 'ACTIVE',
+            typeName: AtlasArchetypeTypeName.Node,
+            attributes: {
+              label: 'Heart rate',
+            },
+            relationshipAttributes: {
+              column: {
+                guid: 'col-guid',
+                relationshipStatus: 'DELETED', // not ACTIVE - should skip
+              },
+            },
+          },
+        },
+      };
+
+      atlasService.get.mockResolvedValueOnce(templateEntity);
+
+      const result = await service.getDatasetDetails(
+        projectId,
+        archetypeId,
+        token,
+      );
+
+      // Only template call, no column/table lookups
+      expect(atlasService.get).toHaveBeenCalledTimes(1);
+      expect(result).toEqual<DatasetDetailsResponseDto>({
+        tableReferences: {},
+        dataObjects: {},
+      });
     });
   });
 });

--- a/src/database/database.service.ts
+++ b/src/database/database.service.ts
@@ -2,6 +2,8 @@ import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { AtlasService } from 'src/atlas/atlas.service';
 import {
+  AtlasArchetypeEntityResponseDto,
+  AtlasArchetypeTypeName,
   AtlasBulkEntityResponseDto,
   AtlasEntityDto,
   AtlasEntityHeaderDto,
@@ -188,6 +190,54 @@ export class DatabaseService {
     });
 
     return output;
+  }
+
+  async getDatasetDetails(
+    projectId: string,
+    archetypeId: string,
+    token?: string,
+  ) {
+    const qualifiedName = `${projectId}@${archetypeId}`;
+    const result: Record<string, object> = {};
+    const templateEntity =
+      await this.atlas.get<AtlasArchetypeEntityResponseDto>(
+        `/entity/uniqueAttribute/type/${AtlasArchetypeTypeName.Template}`,
+        {
+          'attr:qualifiedName': qualifiedName,
+          ignoreRelationships: false, // default false
+          minExtInfo: false, // default false
+        },
+        token,
+      );
+    for (const key in templateEntity?.referredEntities) {
+      const node = templateEntity.referredEntities[key];
+
+      if (
+        node.status !== 'ACTIVE' &&
+        node.typeName !== AtlasArchetypeTypeName.Node
+      )
+        continue;
+      const objectName = node.attributes
+        .label!.replace(/\s+/g, '_')
+        .toLowerCase();
+      const label = node.attributes?.label;
+      // check if node has a column
+      if (node.relationshipAttributes?.column) {
+        const column = node.relationshipAttributes?.column;
+        // skip if relationship inactive
+        if (column.relationshipStatus !== 'ACTIVE') continue;
+        const { entity } = await this.atlas.get<AtlasEntityResponseDto>(
+          `/entity/guid/${column.guid}`,
+          undefined,
+          token,
+        );
+        result[objectName] = {
+          label,
+          table: entity.attributes.table,
+        };
+      }
+    }
+    return result;
   }
 
   private async getInstanceInfo(projectId: string, token?: string) {

--- a/src/database/database.service.ts
+++ b/src/database/database.service.ts
@@ -8,12 +8,17 @@ import {
   AtlasEntityDto,
   AtlasEntityHeaderDto,
   AtlasEntityResponseDto,
+  AtlasRelatedEntityRefDto,
   AtlasSearchDslResponseDto,
 } from 'src/atlas/dto';
 import {
   ColumnInfoDto,
   DatabaseSummaryResponseDto,
   DatabaseTableDto,
+  DatasetDataObjectDto,
+  DatasetDetailsResponseDto,
+  DatasetForeignKeyDto,
+  DatasetTableReferenceDto,
 } from './dto';
 
 @Injectable()
@@ -196,9 +201,12 @@ export class DatabaseService {
     projectId: string,
     archetypeId: string,
     token?: string,
-  ) {
+  ): Promise<DatasetDetailsResponseDto> {
     const qualifiedName = `${projectId}@${archetypeId}`;
-    const result: Record<string, object> = {};
+    const result: DatasetDetailsResponseDto = {
+      tableReferences: {} as Record<string, DatasetTableReferenceDto>,
+      dataObjects: {} as Record<string, DatasetDataObjectDto>,
+    };
     const templateEntity =
       await this.atlas.get<AtlasArchetypeEntityResponseDto>(
         `/entity/uniqueAttribute/type/${AtlasArchetypeTypeName.Template}`,
@@ -217,24 +225,97 @@ export class DatabaseService {
         node.typeName !== AtlasArchetypeTypeName.Node
       )
         continue;
-      const objectName = node.attributes
-        .label!.replace(/\s+/g, '_')
-        .toLowerCase();
-      const label = node.attributes?.label;
       // check if node has a column
       if (node.relationshipAttributes?.column) {
-        const column = node.relationshipAttributes?.column;
         // skip if relationship inactive
+        const column = node.relationshipAttributes?.column;
         if (column.relationshipStatus !== 'ACTIVE') continue;
-        const { entity } = await this.atlas.get<AtlasEntityResponseDto>(
+        // get label and object name
+        const label = node.attributes?.label as string;
+        const objectName = label.replace(/\s+/g, '_').toLowerCase();
+
+        // get column info
+        const columnEntity = await this.atlas.get<AtlasEntityResponseDto>(
           `/entity/guid/${column.guid}`,
           undefined,
           token,
         );
-        result[objectName] = {
+
+        const table = columnEntity.entity.relationshipAttributes
+          ?.table as AtlasRelatedEntityRefDto;
+        if (table.relationshipStatus !== 'ACTIVE') continue; // shouldn't happen
+        const tableName = table.displayText;
+        // add data object reference
+        result.dataObjects[objectName] = {
           label,
-          table: entity.attributes.table,
+          table: tableName,
+          column:
+            (columnEntity.entity.attributes?.name as string) ??
+            columnEntity.entity.displayText,
         };
+
+        // check if table ref already existing
+        if (!result.tableReferences[tableName]) {
+          const tableEntity = await this.atlas.get<AtlasEntityResponseDto>(
+            `/entity/guid/${table.guid}`,
+            undefined,
+            token,
+          );
+          // get db name
+          const db = tableEntity.entity.relationshipAttributes
+            ?.db as AtlasRelatedEntityRefDto;
+          if (db.relationshipStatus !== 'ACTIVE') continue; // shouldn't happen
+
+          const foreignKeys: DatasetForeignKeyDto[] = [];
+          // iterate foreign keys
+          const referred = tableEntity.referredEntities ?? {};
+          for (const key in referred) {
+            const entity = referred[key];
+            // only look at foreign keys
+            if (
+              entity?.status !== 'ACTIVE' ||
+              entity?.typeName !== 'rdbms_foreign_key'
+            )
+              continue;
+            const refTable = entity.relationshipAttributes
+              ?.references_table as AtlasRelatedEntityRefDto;
+            if (refTable.relationshipStatus !== 'ACTIVE') continue; // shouldn't happen
+
+            const keyColumns = (
+              entity.relationshipAttributes
+                ?.key_columns as AtlasRelatedEntityRefDto[]
+            )
+              .filter(
+                (e) =>
+                  e.relationshipStatus === 'ACTIVE' &&
+                  e.typeName === 'rdbms_column',
+              )
+              .map((c) => c.displayText);
+
+            const refColumns = (
+              entity.relationshipAttributes
+                ?.references_columns as AtlasRelatedEntityRefDto[]
+            )
+              .filter(
+                (e) =>
+                  e.relationshipStatus === 'ACTIVE' &&
+                  e.typeName === 'rdbms_column',
+              )
+              .map((c) => c.displayText);
+
+            // add foreign key
+            foreignKeys.push({
+              referenceTable: refTable.displayText,
+              refColumns,
+              keyColumns,
+            });
+          }
+
+          result.tableReferences[tableName] = {
+            db: db.displayText,
+            foreignKeys,
+          };
+        }
       }
     }
     return result;

--- a/src/database/dto/database.dto.ts
+++ b/src/database/dto/database.dto.ts
@@ -179,3 +179,121 @@ export class TableColumnRefDto {
   @IsString()
   table!: string;
 }
+
+export class DatasetForeignKeyDto {
+  @ApiProperty({
+    description: 'Name of the referenced table',
+    example: 'public.participants',
+  })
+  @IsDefined()
+  @IsString()
+  referenceTable!: string;
+
+  @ApiProperty({
+    description:
+      'Columns in the current table participating in the foreign key',
+    example: ['participant_id'],
+  })
+  @IsDefined()
+  @IsArray()
+  @IsString({ each: true })
+  keyColumns!: string[];
+
+  @ApiProperty({
+    description:
+      'Columns in the referenced table that the foreign key points to',
+    example: ['id'],
+  })
+  @IsDefined()
+  @IsArray()
+  @IsString({ each: true })
+  refColumns!: string[];
+}
+
+export class DatasetTableReferenceDto {
+  @ApiProperty({
+    description: 'Database name in which the table resides',
+    example: 'public',
+  })
+  @IsDefined()
+  @IsString()
+  db!: string;
+
+  @ApiProperty({
+    description: 'Foreign keys defined on this table',
+    type: () => [DatasetForeignKeyDto],
+    example: [
+      {
+        referenceTable: 'participants',
+        keyColumns: ['participant_id'],
+        refColumns: ['id'],
+      },
+    ],
+  })
+  @IsDefined()
+  @IsArray()
+  foreignKeys!: DatasetForeignKeyDto[];
+}
+
+export class DatasetDataObjectDto {
+  @ApiProperty({
+    description: 'Label of the data element from the archetype node',
+    example: 'Heart rate',
+  })
+  @IsDefined()
+  @IsString()
+  label!: string;
+
+  @ApiProperty({
+    description: 'Table name this data object comes from',
+    example: 'measurements',
+  })
+  @IsDefined()
+  @IsString()
+  table!: string;
+
+  @ApiProperty({
+    description: 'Column name in the table that stores this data object',
+    example: 'heart_rate_value',
+  })
+  @IsDefined()
+  @IsString()
+  column!: string;
+}
+
+export class DatasetDetailsResponseDto {
+  @ApiProperty({
+    description:
+      'Map of table name - table metadata (database name and foreign keys)',
+    example: {
+      measurements: {
+        db: 'public',
+        foreignKeys: [
+          {
+            referenceTable: 'public.participants',
+            keyColumns: ['participant_id'],
+            refColumns: ['id'],
+          },
+        ],
+      },
+    },
+  })
+  @IsDefined()
+  @IsObject()
+  tableReferences!: Record<string, DatasetTableReferenceDto>;
+
+  @ApiProperty({
+    description:
+      'Map of data object name - data object details (label, table, column)',
+    example: {
+      heart_rate: {
+        label: 'Heart rate',
+        table: 'measurements',
+        column: 'heart_rate_value',
+      },
+    },
+  })
+  @IsDefined()
+  @IsObject()
+  dataObjects!: Record<string, DatasetDataObjectDto>;
+}


### PR DESCRIPTION
**Prerequisites:**
- Platform PR https://github.com/Epsilon-Data/platform/pull/54 that adds `coordinator-client`

**Changes:**
- added coordinator module
- added `/coordinator/auth` endpoint - using clientId and clientSecret
- added `$id` to Archetype JSONSchema response which refers to `archetypeId` - needed in coordinator
- added `/coordinator/:projectId/:archetypeId` endpoint - returns databaseDetails `dataObjects` (leaf as key, label, column, table) and `tableReferences` (table as key, db, foreign keys array)
> NOTE: look at swagger docs on http://localhost/api/v1/hub/docs#/Coordinator for the example responses of the api

Let me know if you want to do any changes to the structures here