### PR TITLE
Automatic user creation and magic links

### DIFF
--- a/src/admin/keycloak/keycloak-admin.service.ts
+++ b/src/admin/keycloak/keycloak-admin.service.ts
@@ -321,6 +321,7 @@ export class KeycloakAdminService implements OnModuleInit {
     }
   }
   async createGroup(group: GroupRepresentation) {
+    this.logger.debug(`Creating ${group.name} group...`);
     try {
       return await this.kcAdminClient.groups.create({
         ...group,

--- a/src/analysis-request/analysis-request.service.spec.ts
+++ b/src/analysis-request/analysis-request.service.spec.ts
@@ -307,15 +307,13 @@ describe('AnalysisRequestService', () => {
       });
     });
 
-    it('should throw NotFoundException when no request is found for the project and user', async () => {
+    it('should return null request is found for the project and user', async () => {
       const userId = 'user-1';
       const projectId = 'proj-123';
 
       prisma.analysis.findFirst.mockResolvedValue(null);
 
-      await expect(
-        service.getByProject(userId, projectId),
-      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(await service.getByProject(userId, projectId)).toEqual(null);
 
       expect(prisma.analysis.findFirst).toHaveBeenCalledWith({
         where: { projectId: projectId, request: { requestorId: userId } },

--- a/src/analysis/analysis.controller.ts
+++ b/src/analysis/analysis.controller.ts
@@ -11,6 +11,7 @@ import {
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
+  ApiInternalServerErrorResponse,
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
@@ -18,10 +19,8 @@ import {
   ApiUnauthorizedResponse,
   getSchemaPath,
 } from '@nestjs/swagger';
-import { KeycloakAdminService } from 'src/admin/keycloak/keycloak-admin.service';
 import {
   AnalysisArchetypeResponseDto,
-  AuthTokenResponseDto,
   DatasetDto,
   LoginDto,
 } from './dto/analysis.dto';
@@ -34,6 +33,10 @@ import type { CurrentUserInfo } from 'src/common/decorators/user.decorator';
 import { AnalysisRequestService } from 'src/analysis-request/analysis-request.service';
 import { ResourceGuard } from 'src/common/guards/resource.guard';
 import { Scopes } from 'src/common/decorators/scopes.decorator';
+import { KeycloakTokenResponseDto } from 'src/auth/dto';
+import { KeycloakService } from 'src/auth/keycloak/keycloak.service';
+import { Credentials } from '@epsilon-data/keycloak-admin-client';
+import { ConfigService } from '@nestjs/config';
 
 @ApiTags('Analysis')
 @ApiBearerAuth()
@@ -42,8 +45,9 @@ import { Scopes } from 'src/common/decorators/scopes.decorator';
 export class AnalysisController {
   constructor(
     private readonly archetypeService: ArchetypeService,
-    private readonly keycloakService: KeycloakAdminService,
+    private readonly keycloakService: KeycloakService,
     private readonly analysisRequestService: AnalysisRequestService,
+    private configService: ConfigService,
   ) {}
 
   @Public()
@@ -51,8 +55,8 @@ export class AnalysisController {
   @ApiOperation({ summary: 'Get access token for SDK (Public endpoint)' })
   @HttpCode(HttpStatus.OK)
   @ApiOkResponse({
-    description: 'List of user owned projects are returned',
-    type: AuthTokenResponseDto,
+    description: 'Access token response is returned',
+    type: KeycloakTokenResponseDto,
   })
   @ApiUnauthorizedResponse({
     description: 'Invalid credentials',
@@ -67,8 +71,28 @@ export class AnalysisController {
       },
     },
   })
+  @ApiInternalServerErrorResponse({
+    description: 'Authorisation service error',
+    content: {
+      'application/json': {
+        schema: { $ref: getSchemaPath(GenericErrorResponseDto) },
+        example: {
+          statusCode: 500,
+          message: 'Authorisation service is currently unavailable',
+          error: 'AuthorisationServiceError',
+        },
+      },
+    },
+  })
   async getAccessToken(@Body() login: LoginDto) {
-    return await this.keycloakService.getAccessToken(login);
+    const credentials: Credentials = {
+      grantType: login.password ? 'password' : 'refresh_token',
+      clientId: this.configService.get<string>('sdk.clientId')!,
+      username: login.username,
+      password: login.password,
+      refreshToken: login.refreshToken,
+    };
+    return await this.keycloakService.getAccessToken(credentials);
   }
 
   @Get('datasets')

--- a/src/analysis/dto/analysis.dto.ts
+++ b/src/analysis/dto/analysis.dto.ts
@@ -5,44 +5,37 @@ import {
   IsDefined,
   IsNotEmpty,
   IsObject,
+  IsOptional,
   IsString,
   IsUUID,
 } from 'class-validator';
 import { transformDateString } from 'src/utils/class.util';
 
 export class LoginDto {
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Username used to log in (can also be an email)',
     example: 'owner.user@example.com',
   })
   @IsString()
-  @IsDefined()
-  @IsNotEmpty()
+  @IsOptional()
   username!: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: 'Plain-text password for the user',
     example: '*********',
   })
   @IsString()
-  @IsDefined()
-  @IsNotEmpty()
+  @IsOptional()
   password!: string;
-}
-
-export class AuthTokenResponseDto {
-  @ApiProperty({
-    description: 'The JWT access token issued after successful authentication',
-    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
-  })
-  access_token!: string;
 
   @ApiPropertyOptional({
-    description:
-      'Token lifetime in seconds (optional depending on identity provider)',
-    example: 3600,
+    description: 'JWT refresh token',
+    example:
+      'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2tleWNsb2FrLmV4YW1wbGUuY29tL3JlYWxtcy9teS1yZWFsbSIsImF6cCI6ImJhY2tlbmQtY29vcmRpbmF0b3IiLCJzY29wZSI6ImJhY2tlbmQ6c3luYyJ9.signature',
   })
-  expires_in?: number;
+  @IsString()
+  @IsOptional()
+  refreshToken!: string;
 }
 
 export class DatasetDto {

--- a/src/archetype/archetype.controller.ts
+++ b/src/archetype/archetype.controller.ts
@@ -247,11 +247,7 @@ export class ArchetypeController {
     @Param('projectId', ParseUUIDPipe) projectId: string,
     @Body() archetype: ArchetypeDto,
   ) {
-    return this.archetypeService.createArchetype(
-      user.username,
-      projectId,
-      archetype,
-    );
+    return this.archetypeService.createArchetype(user.id, projectId, archetype);
   }
 
   @UseGuards(ResourceGuard)

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -583,7 +583,7 @@ export class ArchetypeService {
   }
 
   async createArchetype(
-    username: string,
+    owner: string,
     projectId: string,
     archetype: ArchetypeDto,
   ) {
@@ -591,11 +591,11 @@ export class ArchetypeService {
       throw new BadRequestException(
         `ProjectId and Archetype projectId mismatch`,
       );
-    return await this.queue.addArchetypeJob(username, projectId, archetype);
+    return await this.queue.addArchetypeJob(owner, projectId, archetype);
   }
 
   async updateArchetype(
-    username: string,
+    userId: string,
     projectId: string,
     archetypeId: string,
     archetype: ArchetypeDto,
@@ -605,7 +605,7 @@ export class ArchetypeService {
         `ProjectId and Archetype projectId mismatch`,
       );
     return await this.queue.updateArchetypeJob(
-      username,
+      userId,
       projectId,
       archetypeId,
       archetype,

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -1,9 +1,12 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   IsArray,
   IsDefined,
+  IsInt,
   IsOptional,
   IsString,
+  Min,
   ValidateNested,
 } from 'class-validator';
 
@@ -44,4 +47,68 @@ export class KeycloakAuthzRequestDto {
   @IsOptional()
   @IsString()
   audience?: string;
+}
+
+export class KeycloakTokenResponseDto {
+  @ApiProperty({
+    description: 'JWT access token issued by Keycloak',
+    example:
+      'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2tleWNsb2FrLmV4YW1wbGUuY29tL3JlYWxtcy9teS1yZWFsbSIsImF6cCI6ImJhY2tlbmQtY29vcmRpbmF0b3IiLCJzY29wZSI6ImJhY2tlbmQ6c3luYyJ9.signature',
+  })
+  @IsDefined()
+  @IsString()
+  access_token!: string;
+
+  @ApiProperty({
+    description: 'Token lifetime in seconds',
+    example: 300,
+  })
+  @IsDefined()
+  @IsInt()
+  @Min(0)
+  expires_in!: number;
+
+  @ApiProperty({
+    description: 'Refresh token lifetime in seconds (0 for client_credentials)',
+    example: 1800,
+  })
+  @IsDefined()
+  @IsInt()
+  @Min(0)
+  refresh_expires_in!: number;
+
+  @ApiPropertyOptional({
+    description:
+      'Refresh token (not always returned, e.g. may be absent for client_credentials)',
+    example: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.refresh-token.signature',
+  })
+  @IsOptional()
+  @IsString()
+  refresh_token?: string;
+
+  @ApiProperty({
+    description: 'OAuth2 token type',
+    example: 'Bearer',
+  })
+  @IsDefined()
+  @IsString()
+  token_type!: string;
+
+  @ApiProperty({
+    description:
+      'Keycloak not-before policy timestamp (used for token invalidation)',
+    example: 0,
+  })
+  @IsDefined()
+  @IsInt()
+  @Min(0)
+  'not-before-policy'!: number;
+
+  @ApiPropertyOptional({
+    description: 'Granted scopes (space-separated)',
+    example: 'openid profile email backend:sync',
+  })
+  @IsOptional()
+  @IsString()
+  scope?: string;
 }

--- a/src/auth/keycloak/keycloak.service.ts
+++ b/src/auth/keycloak/keycloak.service.ts
@@ -3,6 +3,8 @@ import {
   AuthorizationServerException,
   Grant,
 } from '@epsilon-data/epsilon-api-middleware';
+
+import { Credentials } from '@epsilon-data/keycloak-admin-client';
 import {
   Inject,
   Injectable,
@@ -16,15 +18,59 @@ import { AUTH_CONFIG } from '../config.interface';
 import {
   KeycloakAuthzRequestDto,
   KeycloakPermissionDto,
+  KeycloakTokenResponseDto,
   PermissionDto,
 } from '../dto';
 import { Request } from 'express';
-
+// TODO: worth moving all these methods to token-handler
 @Injectable()
 export class KeycloakService {
   private readonly logger = new Logger('KeycloakService');
 
   constructor(@Inject(AUTH_CONFIG) private config: AuthModuleConfig) {}
+
+  async getAccessToken(credentials: Credentials) {
+    const params = {
+      grant_type: credentials.grantType,
+      client_id: credentials.clientId,
+      ...(credentials.grantType === 'client_credentials'
+        ? { client_secret: credentials.clientSecret }
+        : {}),
+      ...(credentials.grantType === 'password'
+        ? { username: credentials.username, password: credentials.password }
+        : {}),
+      ...(credentials.grantType === 'refresh_token'
+        ? { refresh_token: credentials.refreshToken }
+        : {}),
+    };
+
+    const data = querystring.stringify(params);
+    const res = (await fetch(
+      `${this.config.issuerBaseURL}/protocol/openid-connect/token`,
+      {
+        method: 'POST',
+        body: data,
+      },
+    )) as unknown as Response;
+    // Read text if it exists
+    const text = await res.text();
+
+    if (res.status >= 500) {
+      throw AuthorizationServerException(
+        `Server error response in a Permission request: ${text}`,
+      );
+    }
+
+    if (res.status >= 400) {
+      throw AuthorizationClientException(
+        // Add exception
+        Grant.AuthorizationCode,
+        res.status,
+        text,
+      );
+    }
+    return JSON.parse(text) as KeycloakTokenResponseDto[];
+  }
 
   async checkPermission(
     authzRequest: KeycloakAuthzRequestDto,

--- a/src/coordinator/coordinator.controller.ts
+++ b/src/coordinator/coordinator.controller.ts
@@ -21,14 +21,16 @@ import {
   getSchemaPath,
 } from '@nestjs/swagger';
 import { Public } from 'src/common/decorators/public.decorator';
-import { KeycloakAdminService } from 'src/admin/keycloak/keycloak-admin.service';
 import { Resource } from 'src/common/decorators/resource.decorator';
 import { DatabaseService } from 'src/database/database.service';
-import { AuthTokenResponseDto } from 'src/analysis/dto';
 import { GenericErrorResponseDto } from 'src/common/dto';
 import { ClientLoginDto } from './dto';
 import { ScopesGuard } from 'src/common/guards/scopes.guard';
 import { DatasetDetailsResponseDto } from 'src/database/dto';
+import { KeycloakService } from 'src/auth/keycloak/keycloak.service';
+import { Credentials } from '@epsilon-data/keycloak-admin-client';
+import { ConfigService } from '@nestjs/config';
+import { KeycloakTokenResponseDto } from 'src/auth/dto';
 
 @ApiTags('Coordinator')
 @ApiBearerAuth()
@@ -37,7 +39,8 @@ import { DatasetDetailsResponseDto } from 'src/database/dto';
 export class CoordinatorController {
   constructor(
     private readonly databaseService: DatabaseService,
-    private readonly keycloakService: KeycloakAdminService,
+    private readonly keycloakService: KeycloakService,
+    private configService: ConfigService,
   ) {}
 
   @Public()
@@ -48,8 +51,8 @@ export class CoordinatorController {
   })
   @HttpCode(HttpStatus.OK)
   @ApiOkResponse({
-    description: 'List of user owned projects are returned',
-    type: AuthTokenResponseDto,
+    description: 'Access token object is returned',
+    type: KeycloakTokenResponseDto,
   })
   @ApiUnauthorizedResponse({
     description: 'Invalid credentials',
@@ -64,8 +67,28 @@ export class CoordinatorController {
       },
     },
   })
+  @ApiInternalServerErrorResponse({
+    description: 'Authorisation service error',
+    content: {
+      'application/json': {
+        schema: { $ref: getSchemaPath(GenericErrorResponseDto) },
+        example: {
+          statusCode: 500,
+          message: 'Authorisation service is currently unavailable',
+          error: 'AuthorisationServiceError',
+        },
+      },
+    },
+  })
   async getAccessToken(@Body() login: ClientLoginDto) {
-    return await this.keycloakService.getAccessTokenClient(login);
+    const credentials: Credentials = {
+      grantType: 'client_credentials',
+      clientId:
+        login.clientId ??
+        this.configService.get<string>('coordinator.clientId'),
+      clientSecret: login.clientSecret,
+    };
+    return await this.keycloakService.getAccessToken(credentials);
   }
 
   @Get(':projectId/:archetypeId')

--- a/src/database/database.service.ts
+++ b/src/database/database.service.ts
@@ -221,7 +221,7 @@ export class DatabaseService {
       const node = templateEntity.referredEntities[key];
 
       if (
-        node.status !== 'ACTIVE' &&
+        node.status !== 'ACTIVE' ||
         node.typeName !== AtlasArchetypeTypeName.Node
       )
         continue;

--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -109,7 +109,6 @@ export class ProjectController {
     @CurrentUser() user: CurrentUserInfo,
     @Body() dto: CreateProjectDto,
   ) {
-    // TODO: we need to make sure that we actually use usernames because these will be needed for atlas authorization as emails will change which break ownership lookups and Ranger policies
     return await this.projectService.createProject(user, dto);
   }
 

--- a/src/project/project.service.spec.ts
+++ b/src/project/project.service.spec.ts
@@ -340,9 +340,6 @@ describe('ProjectService', () => {
       await service.createProject(user, dto);
 
       expect(prismaMock.project.create).toHaveBeenCalled();
-      expect(queueMock.addResourceJob).toHaveBeenCalledWith('proj-1', 'user1', [
-        'member1@example.com',
-      ]);
       expect(prismaMock.comment.create).toHaveBeenCalledWith({
         data: {
           requestId: 'mocked-request-id',
@@ -387,7 +384,7 @@ describe('ProjectService', () => {
       await service.createProject(user, dto);
 
       expect(queueMock.dataBrokerJob).toHaveBeenCalledWith(
-        'owner-user',
+        'user1',
         'proj-1',
         'mocked-request-id',
         dto.connection.tempDbDetails,

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -334,6 +334,7 @@ export class ProjectService {
       project.projectId,
       project.ownerId,
       memberEmails.length ? memberEmails : undefined,
+      project.connection?.orgAdminEmail ?? undefined,
     );
 
     if (createRequest) {
@@ -358,7 +359,7 @@ export class ProjectService {
           },
         });
         await this.queue.dataBrokerJob(
-          user.username,
+          user.id,
           project.projectId,
           requestId,
           dto.connection.tempDbDetails,

--- a/src/queue/keycloak.processor.spec.ts
+++ b/src/queue/keycloak.processor.spec.ts
@@ -1,0 +1,392 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+
+import { KeycloakProcessor } from './keycloak.processor';
+import { KeycloakAdminService } from 'src/admin/keycloak/keycloak-admin.service';
+import {
+  resourcePrefix,
+  projectScopes,
+  ownerPolicyPrefix,
+  ownerPermissionPrefix,
+  ownerPermissions,
+  groupPrefix,
+  analysisPermissionPrefix,
+  analysisPermissions,
+  analysisPolicyPrefix,
+  groupPolicyPrefix,
+  groupPermissions,
+  groupPermissionPrefix,
+  custodianPolicyPrefix,
+  custodianPermissionPrefix,
+  custodianPermissions,
+} from 'src/utils/options.util';
+import {
+  Credentials,
+  DecisionStrategy,
+  Logic,
+  UserRepresentation,
+} from '@epsilon-data/keycloak-admin-client';
+import type { Job } from 'bull';
+import { ADMIN_CONFIG } from 'src/admin/admin-config.interface';
+
+describe('KeycloakProcessor.handleAddResource', () => {
+  let processor: KeycloakProcessor;
+
+  const keycloakMock = {
+    auth: jest.fn(),
+    getUserById: jest.fn(),
+    getClientById: jest.fn(),
+    createResource: jest.fn(),
+    createPolicy: jest.fn(),
+    createPermission: jest.fn(),
+    createGroup: jest.fn(),
+    addUserToGroup: jest.fn(),
+    checkUser: jest.fn(),
+    createUser: jest.fn(),
+    setUserActions: jest.fn(),
+  };
+
+  const configServiceMock = {
+    get: jest.fn(),
+  };
+
+  // Bull job mock
+  const makeJob = (data: unknown): Job =>
+    ({
+      id: 'job-1',
+      name: 'process-add-resource',
+      data,
+    }) as Job;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        KeycloakProcessor,
+        {
+          provide: ADMIN_CONFIG,
+          useValue: {
+            clientId: 'epsilon-admin-api',
+            clientSecret: 'epsilon-admin-api-secret',
+          },
+        },
+        { provide: KeycloakAdminService, useValue: keycloakMock },
+        { provide: ConfigService, useValue: configServiceMock },
+      ],
+    }).compile();
+
+    processor = module.get(KeycloakProcessor);
+
+    // epsilon-token-handler client
+    configServiceMock.get.mockImplementation((key: string) => {
+      if (key === 'auth.clientId') return 'authorisation-service-client';
+      return undefined;
+    });
+
+    // default mock stubs
+    keycloakMock.auth.mockResolvedValue(undefined);
+    keycloakMock.getUserById.mockResolvedValue({
+      id: 'owner-1',
+      username: 'ownerUser',
+    });
+    keycloakMock.getClientById.mockResolvedValue({
+      id: 'kc-client-1',
+      clientId: 'authorisation-service-client',
+    });
+    keycloakMock.createResource.mockResolvedValue(undefined);
+    keycloakMock.createPolicy.mockResolvedValue(undefined);
+    keycloakMock.createPermission.mockResolvedValue(undefined);
+    keycloakMock.createGroup.mockResolvedValue({
+      id: 'group-1',
+      name: 'group',
+    });
+    keycloakMock.addUserToGroup.mockResolvedValue(undefined);
+    keycloakMock.checkUser.mockResolvedValue([]);
+    keycloakMock.createUser.mockResolvedValue({ id: 'new-user-1' });
+    keycloakMock.setUserActions.mockResolvedValue(undefined);
+  });
+
+  it('authenticates with client credentials and creates resource/policies/permissions/group (no collaborators, no custodian)', async () => {
+    const job = makeJob({
+      id: 'proj-123',
+      ownerId: 'owner-1',
+      collaborators: undefined,
+      custodian: undefined,
+    });
+
+    await processor.handleAddResource(job);
+
+    const expectedCredentials: Credentials = {
+      grantType: 'client_credentials',
+      clientId: 'epsilon-admin-api',
+      clientSecret: 'epsilon-admin-api-secret',
+    };
+
+    expect(keycloakMock.auth).toHaveBeenCalledWith(expectedCredentials);
+    expect(keycloakMock.getUserById).toHaveBeenCalledWith('owner-1');
+
+    expect(configServiceMock.get).toHaveBeenCalledWith('auth.clientId');
+    expect(keycloakMock.getClientById).toHaveBeenCalledWith(
+      'authorisation-service-client',
+    );
+
+    // create resource
+    expect(keycloakMock.createResource).toHaveBeenCalledWith(
+      { id: 'kc-client-1', clientId: 'authorisation-service-client' },
+      {
+        name: `${resourcePrefix}proj-123`,
+        type: 'project',
+        displayName: `${resourcePrefix}proj-123`,
+        uris: [`project/proj-123`],
+        scopes: projectScopes,
+      },
+    );
+
+    // owner policy
+    expect(keycloakMock.createPolicy).toHaveBeenCalledWith(
+      { id: 'kc-client-1', clientId: 'authorisation-service-client' },
+      'user',
+      {
+        name: `${ownerPolicyPrefix}proj-123`,
+        decisionStrategy: DecisionStrategy.UNANIMOUS,
+        logic: Logic.POSITIVE,
+        users: ['ownerUser'],
+      },
+    );
+
+    // owner permission (no custodian then includes connect)
+    expect(keycloakMock.createPermission).toHaveBeenCalledWith(
+      { id: 'kc-client-1', clientId: 'authorisation-service-client' },
+      'scope',
+      expect.objectContaining({
+        name: `${ownerPermissionPrefix}proj-123`,
+        resources: [`${resourcePrefix}proj-123`],
+        scopes: [...ownerPermissions, 'connect'],
+        policies: [`${ownerPolicyPrefix}proj-123`],
+      }),
+    );
+
+    // group created + owner added
+    expect(keycloakMock.createGroup).toHaveBeenCalledWith({
+      name: `${groupPrefix}proj-123`,
+    });
+    expect(keycloakMock.addUserToGroup).toHaveBeenCalledWith(
+      'owner-1',
+      'group-1',
+    );
+
+    // group policy + permission
+    expect(keycloakMock.createPolicy).toHaveBeenCalledWith(
+      { id: 'kc-client-1', clientId: 'authorisation-service-client' },
+      'group',
+      expect.objectContaining({
+        name: `${groupPolicyPrefix}proj-123`,
+        groups: ['group-1'],
+      }),
+    );
+
+    expect(keycloakMock.createPermission).toHaveBeenCalledWith(
+      { id: 'kc-client-1', clientId: 'authorisation-service-client' },
+      'scope',
+      expect.objectContaining({
+        name: `${groupPermissionPrefix}proj-123`,
+        resources: [`${resourcePrefix}proj-123`],
+        scopes: groupPermissions,
+        policies: [`${groupPolicyPrefix}proj-123`],
+      }),
+    );
+
+    // analysis policy + permission
+    expect(keycloakMock.createPolicy).toHaveBeenCalledWith(
+      { id: 'kc-client-1', clientId: 'authorisation-service-client' },
+      'user',
+      expect.objectContaining({
+        name: `${analysisPolicyPrefix}proj-123`,
+      }),
+    );
+
+    expect(keycloakMock.createPermission).toHaveBeenCalledWith(
+      { id: 'kc-client-1', clientId: 'authorisation-service-client' },
+      'scope',
+      expect.objectContaining({
+        name: `${analysisPermissionPrefix}proj-123`,
+        resources: [`${resourcePrefix}proj-123`],
+        scopes: analysisPermissions,
+        policies: [`${analysisPolicyPrefix}proj-123`],
+      }),
+    );
+
+    // no collaborator/custodian paths
+    expect(keycloakMock.checkUser).not.toHaveBeenCalled();
+    expect(keycloakMock.createUser).not.toHaveBeenCalled();
+    expect(keycloakMock.setUserActions).not.toHaveBeenCalled();
+  });
+
+  it('invites collaborators: creates missing users (and sets user actions), adds existing users to group', async () => {
+    // collaborator1 => no existing user => createUser + setUserActions
+    // collaborator2 => existing users => addUserToGroup for each
+    keycloakMock.checkUser.mockImplementation(
+      ({ email }: { email: string }) => {
+        if (email === 'new@ex.com') return [];
+        if (email === 'existing@ex.com')
+          return [{ id: 'u1', username: 'existing@ex.com' }];
+        return [];
+      },
+    );
+
+    keycloakMock.createUser.mockResolvedValueOnce({ id: 'created-1' });
+
+    const job = makeJob({
+      id: 'proj-123',
+      ownerId: 'owner-1',
+      collaborators: ['new@ex.com', 'existing@ex.com'],
+      custodian: undefined,
+    });
+
+    await processor.handleAddResource(job);
+
+    // group created
+    expect(keycloakMock.createGroup).toHaveBeenCalledWith({
+      name: `${groupPrefix}proj-123`,
+    });
+
+    // new collaborator created and added to the created group
+    expect(keycloakMock.createUser).toHaveBeenCalledWith({
+      email: 'new@ex.com',
+      enabled: true,
+      groups: [`${groupPrefix}proj-123`],
+    });
+    expect(keycloakMock.setUserActions).toHaveBeenCalledWith('created-1');
+
+    // existing collaborator added to the
+    expect(keycloakMock.addUserToGroup).toHaveBeenCalledWith('u1', 'group-1');
+  });
+
+  it('custodian: creates missing custodian user and creates custodian policy/permission', async () => {
+    keycloakMock.checkUser.mockResolvedValueOnce([]); // custodian not found
+    keycloakMock.createUser.mockResolvedValueOnce({ id: 'custodian-1' });
+
+    const job = makeJob({
+      id: 'proj-123',
+      ownerId: 'owner-1',
+      collaborators: undefined,
+      custodian: 'custodian@ex.com',
+    });
+
+    await processor.handleAddResource(job);
+
+    // for owner permission, custodian present => ownerPermissions only (no connect)
+    expect(keycloakMock.createPermission).toHaveBeenCalledWith(
+      expect.anything(),
+      'scope',
+      expect.objectContaining({
+        name: `${ownerPermissionPrefix}proj-123`,
+        scopes: ownerPermissions,
+      }),
+    );
+
+    // custodian user created + actions set
+    expect(keycloakMock.createUser).toHaveBeenCalledWith({
+      email: 'custodian@ex.com',
+      enabled: true,
+      groups: [`${groupPrefix}proj-123`],
+    });
+    expect(keycloakMock.setUserActions).toHaveBeenCalledWith('custodian-1');
+
+    // set custodian policy (email = )
+    expect(keycloakMock.createPolicy).toHaveBeenCalledWith(
+      expect.anything(),
+      'user',
+      expect.objectContaining({
+        name: `${custodianPolicyPrefix}proj-123`,
+        users: ['custodian@ex.com'],
+      }),
+    );
+
+    expect(keycloakMock.createPermission).toHaveBeenCalledWith(
+      expect.anything(),
+      'scope',
+      expect.objectContaining({
+        name: `${custodianPermissionPrefix}proj-123`,
+        resources: [`${resourcePrefix}proj-123`],
+        scopes: custodianPermissions,
+        policies: [`${custodianPolicyPrefix}proj-123`],
+      }),
+    );
+  });
+
+  it('custodian: existing user -> adds to group and uses username in custodian policy', async () => {
+    keycloakMock.checkUser.mockResolvedValueOnce([
+      { id: 'cust-uid', username: 'custodianUser' },
+    ] as UserRepresentation[]);
+
+    const job = makeJob({
+      id: 'proj-123',
+      ownerId: 'owner-1',
+      collaborators: undefined,
+      custodian: 'custodian@ex.com',
+    });
+
+    await processor.handleAddResource(job);
+
+    expect(keycloakMock.addUserToGroup).toHaveBeenCalledWith(
+      'cust-uid',
+      'group-1',
+    );
+
+    expect(keycloakMock.createPolicy).toHaveBeenCalledWith(
+      expect.anything(),
+      'user',
+      expect.objectContaining({
+        name: `${custodianPolicyPrefix}proj-123`,
+        users: ['custodianUser'],
+      }),
+    );
+  });
+
+  it('logs error and stops further work when owner cannot be resolved', async () => {
+    const errorSpy = jest
+      .spyOn((processor as any).logger, 'error')
+      .mockImplementation(() => undefined);
+
+    keycloakMock.getUserById.mockResolvedValueOnce(null);
+
+    const job = makeJob({
+      id: 'proj-123',
+      ownerId: 'owner-missing',
+      collaborators: undefined,
+      custodian: undefined,
+    });
+
+    await processor.handleAddResource(job);
+
+    expect(errorSpy).toHaveBeenCalled();
+    // should fail before creating anything
+    expect(keycloakMock.createResource).not.toHaveBeenCalled();
+    expect(keycloakMock.createGroup).not.toHaveBeenCalled();
+  });
+
+  it('logs error if keycloak.auth throws', async () => {
+    const errorSpy = jest
+      .spyOn((processor as any).logger, 'error')
+      .mockImplementation(() => undefined);
+
+    keycloakMock.auth.mockRejectedValueOnce(new Error('auth failed'));
+
+    const job = makeJob({
+      id: 'proj-123',
+      ownerId: 'owner-1',
+      collaborators: undefined,
+      custodian: undefined,
+    });
+
+    await processor.handleAddResource(job);
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(keycloakMock.getUserById).not.toHaveBeenCalled();
+    expect(keycloakMock.createResource).not.toHaveBeenCalled();
+  });
+});

--- a/src/queue/keycloak.processor.ts
+++ b/src/queue/keycloak.processor.ts
@@ -145,14 +145,12 @@ export class KeycloakProcessor {
       });
 
       // invite collaborators and add them to the group
-      // TODO: improve this
       if (collaborators) {
         const collabQueries = collaborators.map(async (email) => {
           const users = (await this.keycloak.checkUser({ email })) || [];
           if (!users.length) {
             // TODO: add realm roles to user
             const user = await this.keycloak.createUser({
-              username: email,
               email,
               enabled: true,
               groups: [`${groupPrefix}${id}`],
@@ -166,16 +164,14 @@ export class KeycloakProcessor {
         });
         await Promise.all(collabQueries);
       }
-
       if (custodian) {
         // temp username
-        let custodianUserName = custodian.split('@')[0];
+        let custodianUserName = custodian;
         const users =
           (await this.keycloak.checkUser({ email: custodian })) || [];
         if (!users.length) {
-          // TODO: add realmroles to user
+          // TODO: add realmroles to user (not needed as not using scopes)
           const user = await this.keycloak.createUser({
-            username: custodianUserName,
             email: custodian,
             enabled: true,
             groups: [`${groupPrefix}${id}`],

--- a/src/queue/keycloak.processor.ts
+++ b/src/queue/keycloak.processor.ts
@@ -50,8 +50,6 @@ export class KeycloakProcessor {
       job.data as AddResourceJobDataDto;
     this.logger.log(`Handling 'process-add-resource' for resource id ${id}...`);
     try {
-      // auth
-      // add keycloak resource
       // TODO: better error handling
       const credentials: Credentials = {
         grantType: 'client_credentials',
@@ -96,7 +94,6 @@ export class KeycloakProcessor {
         decisionStrategy: DecisionStrategy.UNANIMOUS,
         logic: Logic.POSITIVE,
         resources: [`${resourcePrefix}${id}`],
-        // TODO: add these as constants
         scopes: custodian ? ownerPermissions : [...ownerPermissions, 'connect'],
         policies: [`${ownerPolicyPrefix}${id}`],
       });
@@ -149,7 +146,6 @@ export class KeycloakProcessor {
         const collabQueries = collaborators.map(async (email) => {
           const users = (await this.keycloak.checkUser({ email })) || [];
           if (!users.length) {
-            // TODO: add realm roles to user
             const user = await this.keycloak.createUser({
               email,
               enabled: true,
@@ -170,7 +166,6 @@ export class KeycloakProcessor {
         const users =
           (await this.keycloak.checkUser({ email: custodian })) || [];
         if (!users.length) {
-          // TODO: add realmroles to user (not needed as not using scopes)
           const user = await this.keycloak.createUser({
             email: custodian,
             enabled: true,


### PR DESCRIPTION
When adding collaborators or database orgAdminEmail for new project then it creates users onto the system automatically and sends them magic links out to add passwords for login.

**BREAKING CHANGES**
- we need to use emails as usernames in Keycloak - this also means using keycloak UUID for Atlas entity ownerships because emails can change
- Keycloak realm update is needed before this PR - https://github.com/Epsilon-Data/platform/pull/55 needs to go in first

**Changes:***
- changed atlas owner as from keycloak username to keycloak uuid
- added collaborator and custodian (database admin) checks for existing user - adds existing user to project or creates user
- set userAction to send out Magic Links to new users for onboarding
- local setup for email testing


**Future:**
- change default email for userActions, currently it is:

> Your administrator has just requested that you update your Epsilon account by performing the following action(s): Update Password. Click on the link below to start this process.
> 
> [Link to account update](link-here)
> 
> This link will expire within 12 hours.
> 
> If you are unaware that your administrator has requested this, just ignore this message and nothing will be changed.
- cleanup keycloak variables and add keycloak cli for updates
- exchange test email to proper SMTP server in production