### PR TITLE
Move db credentials to vault

### DIFF
--- a/prisma/migrations/20251217185123_drop_db_details/migration.sql
+++ b/prisma/migrations/20251217185123_drop_db_details/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `tempDbDetails` on the `Connection` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Connection" DROP COLUMN "tempDbDetails";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,7 +34,6 @@ model Connection {
   requestId     String?  @unique @db.Uuid
   projectId     String   @unique @db.Uuid
   orgAdminEmail String?  @db.Text
-  tempDbDetails Json?    @db.Json
   request       Request? @relation(fields: [requestId], references: [requestId], onDelete: NoAction, onUpdate: NoAction, map: "fk_connection_request_id")
   project       Project  @relation(fields: [projectId], references: [projectId], onDelete: Cascade, onUpdate: NoAction, map: "fk_connection_project_id")
 }

--- a/src/auth/keycloak/keycloak.service.ts
+++ b/src/auth/keycloak/keycloak.service.ts
@@ -11,7 +11,6 @@ import {
   Logger,
   UnauthorizedException,
 } from '@nestjs/common';
-import fetch from 'node-fetch';
 import * as querystring from 'querystring';
 import type { AuthModuleConfig } from '../config.interface';
 import { AUTH_CONFIG } from '../config.interface';

--- a/src/common/decorators/user.decorator.ts
+++ b/src/common/decorators/user.decorator.ts
@@ -12,7 +12,7 @@ export const CurrentUser = createParamDecorator(
   (_data: unknown, ctx: ExecutionContext) => {
     const req = ctx.switchToHttp().getRequest<
       Request & {
-        auth?: { payload?: Record<string, unknown> };
+        auth?: { payload?: Record<string, unknown>; token: string };
       }
     >();
     const id = req?.auth?.payload?.sub?.toString?.();
@@ -20,7 +20,6 @@ export const CurrentUser = createParamDecorator(
     const given_name = req?.auth?.payload?.given_name?.toString?.();
     const family_name = req?.auth?.payload?.family_name?.toString?.();
     const email = req?.auth?.payload?.email?.toString?.();
-    console.log(req?.auth);
     return { id, username, email, given_name, family_name };
   },
 );

--- a/src/common/decorators/user.decorator.ts
+++ b/src/common/decorators/user.decorator.ts
@@ -20,6 +20,7 @@ export const CurrentUser = createParamDecorator(
     const given_name = req?.auth?.payload?.given_name?.toString?.();
     const family_name = req?.auth?.payload?.family_name?.toString?.();
     const email = req?.auth?.payload?.email?.toString?.();
+    console.log(req?.auth);
     return { id, username, email, given_name, family_name };
   },
 );

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -9,8 +9,8 @@ const trustedWebOrigins = () =>
     .map((origin) => origin.trim());
 
 export default () => ({
-  appUrl: process.env.APP_URL || 'http://localhost:3000',
-  isDev: process.env.NODE_ENV === 'development' ? true : false,
+  appUrl: env.APP_URL || 'http://localhost:3000',
+  isDev: env.NODE_ENV === 'development' ? true : false,
   apiBaseUrl: env.API_BASE_URL || '/api/v1/hub',
   apiPort: parseInt(env.API_SERVICE_PORT || '3334'),
   brokerImage: env.BROKER_IMAGE || 'ghcr.io/epsilon-data/data-broker:latest',
@@ -66,4 +66,5 @@ export default () => ({
   tokenEndpoint:
     env.EPSILON_TOKEN_ENDPOINT ||
     'http://keycloak:8080/realms/epsilon/protocol/openid-connect/token',
+  keystoreUrl: env.VAULT_API_ADDR || 'http://0.0.0.0:8200',
 });

--- a/src/connection-request/connection-request.controller.ts
+++ b/src/connection-request/connection-request.controller.ts
@@ -10,10 +10,10 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  Req,
   ServiceUnavailableException,
   UnauthorizedException,
   UseGuards,
-  // UseGuards,
 } from '@nestjs/common';
 import { ConnectionRequestService } from './connection-request.service';
 import {
@@ -42,6 +42,8 @@ import { Resource } from 'src/common/decorators/resource.decorator';
 import { Scopes } from 'src/common/decorators/scopes.decorator';
 import { ResourceGuard } from 'src/common/guards/resource.guard';
 import { GenericErrorResponseDto } from 'src/common/dto';
+
+import type { Request } from 'express';
 
 @ApiTags('Connection Request')
 @ApiBearerAuth()
@@ -217,6 +219,7 @@ export class ConnectionRequestController {
     },
   })
   async approve(
+    @Req() request: Request,
     @CurrentUser() user: CurrentUserInfo,
     @Param('requestId', ParseUUIDPipe) requestId: string,
     @Param('projectId', ParseUUIDPipe) projectId: string,
@@ -227,6 +230,7 @@ export class ConnectionRequestController {
       requestId,
       projectId,
       dto,
+      request.auth?.token || '',
     );
   }
 }

--- a/src/connection-request/connection-request.module.ts
+++ b/src/connection-request/connection-request.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ConnectionRequestController } from './connection-request.controller';
 import { ConnectionRequestService } from './connection-request.service';
+import { VaultModule } from 'src/vault/vault.module';
 
 @Module({
+  imports: [VaultModule],
   controllers: [ConnectionRequestController],
   providers: [ConnectionRequestService],
 })

--- a/src/connection-request/connection-request.service.spec.ts
+++ b/src/connection-request/connection-request.service.spec.ts
@@ -2,9 +2,10 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConnectionRequestService } from './connection-request.service';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { QueueService } from 'src/queue/queue.service';
-import { $Enums, Prisma } from 'src/generated/prisma/client';
+import { $Enums } from 'src/generated/prisma/client';
 
 import { CurrentUserInfo } from 'src/common/decorators/user.decorator';
+import { VaultService } from 'src/vault/vault.service';
 
 describe('ConnectionRequestService', () => {
   let service: ConnectionRequestService;
@@ -18,6 +19,12 @@ describe('ConnectionRequestService', () => {
   let queueMock: {
     dataBrokerJob: jest.Mock;
   };
+
+  const vaultMock = {
+    auth: jest.fn(),
+    transitEncrypt: jest.fn(),
+    writeProjectCiphertext: jest.fn(),
+  } as unknown as VaultService;
 
   beforeEach(async () => {
     prismaMock = {
@@ -46,6 +53,10 @@ describe('ConnectionRequestService', () => {
         {
           provide: QueueService,
           useValue: queueMock,
+        },
+        {
+          provide: VaultService,
+          useValue: vaultMock,
         },
       ],
     }).compile();
@@ -135,17 +146,18 @@ describe('ConnectionRequestService', () => {
       prismaMock.project.update.mockResolvedValue({});
       prismaMock.request.update.mockResolvedValue({});
 
-      const result = await service.approve(user, requestId, projectId, dto);
+      const result = await service.approve(
+        user,
+        requestId,
+        projectId,
+        dto,
+        'test-token',
+      );
 
       expect(prismaMock.project.update).toHaveBeenCalledWith({
         where: { projectId },
         data: {
           status: 'CRAWLING',
-          connection: {
-            update: {
-              tempDbDetails: tempDbDetails as unknown as Prisma.JsonObject,
-            },
-          },
         },
       });
 
@@ -178,7 +190,13 @@ describe('ConnectionRequestService', () => {
 
       prismaMock.request.update.mockResolvedValue({});
 
-      const result = await service.approve(user, requestId, projectId, dto);
+      const result = await service.approve(
+        user,
+        requestId,
+        projectId,
+        dto,
+        'test-token',
+      );
 
       expect(prismaMock.project.update).not.toHaveBeenCalled();
       expect(queueMock.dataBrokerJob).not.toHaveBeenCalled();
@@ -205,7 +223,13 @@ describe('ConnectionRequestService', () => {
 
       prismaMock.request.update.mockResolvedValue({});
 
-      const result = await service.approve(user, requestId, projectId, dto);
+      const result = await service.approve(
+        user,
+        requestId,
+        projectId,
+        dto,
+        'test-token',
+      );
 
       expect(prismaMock.project.update).not.toHaveBeenCalled();
       expect(queueMock.dataBrokerJob).not.toHaveBeenCalled();

--- a/src/connection-request/connection-request.service.ts
+++ b/src/connection-request/connection-request.service.ts
@@ -7,14 +7,16 @@ import {
 } from './dto';
 import { testConnection } from '@epsilon-data/epsilon-connector';
 import { QueueService } from 'src/queue/queue.service';
-import { $Enums, Prisma } from 'src/generated/prisma/client';
+import { $Enums } from 'src/generated/prisma/client';
 import { CurrentUserInfo } from 'src/common/decorators/user.decorator';
+import { VaultService } from 'src/vault/vault.service';
 
 @Injectable()
 export class ConnectionRequestService {
   constructor(
     private prisma: PrismaService,
     private queue: QueueService,
+    private readonly vaultService: VaultService,
   ) {}
 
   async getList(userId: string): Promise<ConnectionRequestResponseDto[]> {
@@ -63,6 +65,7 @@ export class ConnectionRequestService {
     requestId: string,
     projectId: string,
     dto: ConnectionDecisionDto,
+    accessToken: string,
   ) {
     const status = dto.isApproved
       ? $Enums.RequestStatus.APPROVED
@@ -74,13 +77,25 @@ export class ConnectionRequestService {
         where: { projectId: projectId },
         data: {
           status: 'CRAWLING',
-          connection: {
-            update: {
-              tempDbDetails: dto.tempDbDetails as unknown as Prisma.JsonObject,
-            },
-          },
         },
       });
+      //add secrets
+      const token = await this.vaultService.auth(accessToken);
+
+      // encrypt with transit (user token only needs encrypt)
+      const ciphertext = await this.vaultService.transitEncrypt(
+        token,
+        'connector-db',
+        {
+          ...dto.tempDbDetails,
+        },
+      );
+      // store project-scoped copy for Coordinator (EC2)
+      await this.vaultService.writeProjectCiphertext(
+        token,
+        projectId,
+        ciphertext,
+      );
       await this.queue.dataBrokerJob(
         user.username,
         projectId,

--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -106,10 +106,15 @@ export class ProjectController {
     },
   })
   async createProject(
+    @Req() request: Request,
     @CurrentUser() user: CurrentUserInfo,
     @Body() dto: CreateProjectDto,
   ) {
-    return await this.projectService.createProject(user, dto);
+    return await this.projectService.createProject(
+      user,
+      dto,
+      request.auth?.token || '',
+    );
   }
 
   @Get()

--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -404,10 +404,15 @@ export class ProjectController {
     description: 'Project details updated',
   })
   updateProject(
+    @Req() request: Request,
     @Param('projectId', ParseUUIDPipe) projectId: string,
     @Body() dto: UpdateProjectDto,
   ) {
-    return this.projectService.updateProject(projectId, dto);
+    return this.projectService.updateProject(
+      projectId,
+      dto,
+      request.auth?.token || '',
+    );
   }
 
   @UseGuards(ResourceGuard)

--- a/src/project/project.module.ts
+++ b/src/project/project.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ProjectController } from './project.controller';
 import { ProjectService } from './project.service';
+import { VaultModule } from 'src/vault/vault.module';
 
 @Module({
+  imports: [VaultModule],
   controllers: [ProjectController],
   providers: [ProjectService],
 })

--- a/src/project/project.service.spec.ts
+++ b/src/project/project.service.spec.ts
@@ -9,6 +9,7 @@ import { KeycloakAdminService } from 'src/admin/keycloak/keycloak-admin.service'
 import { Prisma, RequestStatus } from 'src/generated/prisma/client';
 import { SettingsDto } from './dto';
 import { NotFoundException } from '@nestjs/common/exceptions';
+import { VaultService } from 'src/vault/vault.service';
 
 // mock nanoid + uuid to make tests deterministic
 jest.mock('nanoid', () => ({
@@ -57,6 +58,12 @@ describe('ProjectService', () => {
     auth: jest.fn(),
   } as unknown as KeycloakAdminService;
 
+  const vaultMock = {
+    auth: jest.fn(),
+    transitEncrypt: jest.fn(),
+    writeProjectCiphertext: jest.fn(),
+  } as unknown as VaultService;
+
   beforeEach(async () => {
     jest.clearAllMocks();
 
@@ -67,6 +74,7 @@ describe('ProjectService', () => {
         { provide: QueueService, useValue: queueMock },
         { provide: FileStorageService, useValue: fileStorageMock },
         { provide: KeycloakAdminService, useValue: keycloakMock },
+        { provide: VaultService, useValue: vaultMock },
       ],
     }).compile();
 
@@ -337,7 +345,7 @@ describe('ProjectService', () => {
         },
       });
 
-      await service.createProject(user, dto);
+      await service.createProject(user, dto, 'test-token');
 
       expect(prismaMock.project.create).toHaveBeenCalled();
       expect(prismaMock.comment.create).toHaveBeenCalledWith({
@@ -381,7 +389,7 @@ describe('ProjectService', () => {
         },
       });
 
-      await service.createProject(user, dto);
+      await service.createProject(user, dto, 'test-token');
 
       expect(queueMock.dataBrokerJob).toHaveBeenCalledWith(
         'user1',
@@ -456,7 +464,7 @@ describe('ProjectService', () => {
 
       (prismaMock.project.update as jest.Mock).mockResolvedValue({});
 
-      await service.updateProject(projectId, dto);
+      await service.updateProject(projectId, dto, 'test-token');
 
       expect(prismaMock.project.update).toHaveBeenCalledWith({
         where: { projectId },
@@ -472,11 +480,6 @@ describe('ProjectService', () => {
           lastModified: expect.any(Date),
           participantsNum: dto.participantsNum,
           dbKeywords: dto.dbKeywords,
-          connection: {
-            update: {
-              tempDbDetails: dto.connection.tempDbDetails,
-            },
-          },
         },
       });
     });

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -202,11 +202,6 @@ export class ProjectService {
         lastModified: true,
         dbKeywords: true,
         createdDate: true,
-        connection: {
-          select: {
-            tempDbDetails: true, // TODO: need to move database and nature out from there
-          },
-        },
       },
     });
     if (!projectInfo) {
@@ -216,12 +211,6 @@ export class ProjectService {
     // TODO: get member names from keycloak
     // const members = projectInfo.members as string[];
     // if (members.length)
-
-    const { name, type } =
-      projectInfo.connection?.tempDbDetails &&
-      typeof projectInfo.connection?.tempDbDetails === 'object'
-        ? (projectInfo.connection?.tempDbDetails as Partial<DatabaseInfoDto>)
-        : {};
     return {
       projectId: projectInfo.projectId,
       status: projectInfo.status,
@@ -238,10 +227,6 @@ export class ProjectService {
       participantsNum: projectInfo.participantsNum,
       dbKeywords: projectInfo.dbKeywords,
       members: projectInfo.members,
-      // TODO: need to fix these things
-      connection: {
-        tempDbDetails: { name, type },
-      },
     };
   }
 
@@ -302,10 +287,6 @@ export class ProjectService {
     const createRequest = dto.connection.orgAdminEmail ? true : false;
     const requestId = uuidv4();
 
-    // check if any DB temp details
-    const tempDbDetails = dto.connection.tempDbDetails
-      ? (dto.connection.tempDbDetails as unknown as Prisma.JsonObject)
-      : undefined;
     const project = await this.prisma.project.create({
       data: {
         ...request,
@@ -313,7 +294,6 @@ export class ProjectService {
           create: {
             // if no orgAdminEmail provider make owner admin
             orgAdminEmail: dto.connection.orgAdminEmail ?? user.email,
-            tempDbDetails,
             ...(createRequest && {
               request: {
                 create: {
@@ -357,16 +337,10 @@ export class ProjectService {
     } else {
       // database credentials should exist so run database crawling
       if (dto.connection.tempDbDetails?.url) {
-        // add secrets
-        const vaultToken = await this.vaultService.auth(accessToken);
-        const entityId = await this.vaultService.getEntityId(vaultToken);
-        await this.vaultService.writeSecret(
-          vaultToken,
-          entityId,
+        await this.addSecrets(
+          accessToken,
           project.projectId,
-          {
-            ...dto.connection.tempDbDetails,
-          },
+          dto.connection.tempDbDetails,
         );
         await this.prisma.project.update({
           where: { projectId: project.projectId },
@@ -386,7 +360,11 @@ export class ProjectService {
     return;
   }
 
-  async updateProject(projectId: string, dto: UpdateProjectDto) {
+  async updateProject(
+    projectId: string,
+    dto: UpdateProjectDto,
+    accessToken: string,
+  ) {
     // should not update on invalid projectId
     if (projectId !== dto.projectId)
       throw new BadRequestException(`Update projectIds do not match`);
@@ -419,22 +397,18 @@ export class ProjectService {
     );
 
     // Check if connection details are updated
-    const connection =
-      dto.connection?.tempDbDetails !== undefined
-        ? {
-            connection: {
-              update: {
-                tempDbDetails: dto.connection
-                  .tempDbDetails as unknown as Prisma.JsonObject,
-              },
-            },
-          }
-        : {};
+    if (dto.connection?.tempDbDetails) {
+      await this.addSecrets(
+        accessToken,
+        dto.projectId,
+        dto.connection.tempDbDetails,
+      );
+    }
+
     return await this.prisma.project.update({
       where: { projectId: projectId },
       data: {
         ...data,
-        ...connection,
       },
     });
   }
@@ -494,5 +468,29 @@ export class ProjectService {
       .replace(/^_+|_+$/g, '');
     const packageId = `${packageName}_${customId.slice(0, 6)}`;
     return { packageId, customId };
+  }
+
+  private async addSecrets(
+    accessToken: string,
+    projectId: string,
+    dbDetails: DatabaseInfoDto,
+  ) {
+    // add secrets
+    const token = await this.vaultService.auth(accessToken);
+
+    // encrypt with transit (user token only needs encrypt)
+    const ciphertext = await this.vaultService.transitEncrypt(
+      token,
+      'connector-db',
+      {
+        ...dbDetails,
+      },
+    );
+    // store project-scoped copy for Coordinator (EC2)
+    await this.vaultService.writeProjectCiphertext(
+      token,
+      projectId,
+      ciphertext,
+    );
   }
 }

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -15,7 +15,6 @@ import {
   UpdateProjectDto,
 } from './dto';
 import { FileStorageService } from 'src/file-storage/file_storage.service';
-import { KeycloakAdminService } from 'src/admin/keycloak/keycloak-admin.service';
 import { nanoid } from 'nanoid';
 import { QueueService } from 'src/queue/queue.service';
 
@@ -28,6 +27,7 @@ import {
 } from 'src/connection-request/dto';
 import { AnalysisRequestResponseDto } from 'src/analysis-request/dto';
 import { Prisma } from 'src/generated/prisma/client';
+import { VaultService } from 'src/vault/vault.service';
 
 @Injectable()
 export class ProjectService {
@@ -36,7 +36,7 @@ export class ProjectService {
     private prisma: PrismaService,
     private queue: QueueService,
     private fileStorage: FileStorageService,
-    private readonly keycloakAdminService: KeycloakAdminService,
+    private readonly vaultService: VaultService,
   ) {}
 
   // Queries
@@ -267,7 +267,11 @@ export class ProjectService {
   }
 
   // Commands
-  async createProject(user: CurrentUserInfo, dto: CreateProjectDto) {
+  async createProject(
+    user: CurrentUserInfo,
+    dto: CreateProjectDto,
+    accessToken: string,
+  ) {
     const { packageId, customId } = this.createIds(dto.name, dto.customId);
     const ownerId = user.id; //using current logged in user details rather than post
     // check if members are added
@@ -297,6 +301,7 @@ export class ProjectService {
     // check if database credential request is needed
     const createRequest = dto.connection.orgAdminEmail ? true : false;
     const requestId = uuidv4();
+
     // check if any DB temp details
     const tempDbDetails = dto.connection.tempDbDetails
       ? (dto.connection.tempDbDetails as unknown as Prisma.JsonObject)
@@ -352,6 +357,17 @@ export class ProjectService {
     } else {
       // database credentials should exist so run database crawling
       if (dto.connection.tempDbDetails?.url) {
+        // add secrets
+        const vaultToken = await this.vaultService.auth(accessToken);
+        const entityId = await this.vaultService.getEntityId(vaultToken);
+        await this.vaultService.writeSecret(
+          vaultToken,
+          entityId,
+          project.projectId,
+          {
+            ...dto.connection.tempDbDetails,
+          },
+        );
         await this.prisma.project.update({
           where: { projectId: project.projectId },
           data: {

--- a/src/vault/vault.module.ts
+++ b/src/vault/vault.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { VaultService } from './vault.service';
+
+@Module({
+  providers: [VaultService],
+  exports: [VaultService],
+})
+export class VaultModule {}

--- a/src/vault/vault.service.spec.ts
+++ b/src/vault/vault.service.spec.ts
@@ -1,0 +1,360 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  InternalServerErrorException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { VaultService } from './vault.service';
+
+type MockFetchResponse = {
+  ok: boolean;
+  status: number;
+  json: jest.Mock<Promise<unknown>, []>;
+};
+
+const fetchMock = jest.fn();
+globalThis.fetch = fetchMock;
+
+const makeResponse = (
+  opts: Partial<MockFetchResponse> & { jsonBody?: unknown },
+): MockFetchResponse => {
+  return {
+    ok: opts.ok ?? true,
+    status: opts.status ?? 200,
+    json: jest.fn().mockResolvedValue(opts.jsonBody ?? {}),
+  };
+};
+
+describe('VaultService', () => {
+  let service: VaultService;
+  let config: { get: jest.Mock };
+
+  const keystoreUrl = 'http://vault:8200';
+
+  beforeEach(async () => {
+    fetchMock.mockReset();
+
+    config = {
+      get: jest.fn((key: string) => {
+        if (key === 'keystoreUrl') return keystoreUrl;
+        return undefined;
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [VaultService, { provide: ConfigService, useValue: config }],
+    }).compile();
+
+    service = module.get(VaultService);
+  });
+
+  describe('auth', () => {
+    it('exchanges keycloak token for vault token', async () => {
+      fetchMock.mockResolvedValueOnce(
+        makeResponse({
+          ok: true,
+          status: 200,
+          jsonBody: { auth: { client_token: 'vault-token-123' } },
+        }),
+      );
+
+      const result = await service.auth('kc-token');
+
+      expect(result).toBe('vault-token-123');
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+
+      expect(url).toBe(`${keystoreUrl}/v1/auth/jwt/login`);
+      expect(init.method).toBe('POST');
+      expect(init.headers).toEqual({
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      });
+      expect(init.body).toBe(
+        JSON.stringify({ role: 'default', jwt: 'kc-token' }),
+      );
+    });
+
+    it('throws UnauthorizedException when client_token missing', async () => {
+      fetchMock.mockResolvedValueOnce(
+        makeResponse({
+          ok: true,
+          status: 200,
+          jsonBody: { auth: {} },
+        }),
+      );
+
+      await expect(service.auth('kc-token')).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+    });
+
+    it('throws UnauthorizedException when vault returns 4xx', async () => {
+      fetchMock.mockResolvedValueOnce(
+        makeResponse({
+          ok: false,
+          status: 403,
+          jsonBody: { errors: ['permission denied'] },
+        }),
+      );
+
+      await expect(service.auth('kc-token')).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+    });
+
+    it('throws InternalServerErrorException when vault returns 5xx', async () => {
+      fetchMock.mockResolvedValueOnce(
+        makeResponse({
+          ok: false,
+          status: 500,
+          jsonBody: { errors: ['something broke'] },
+        }),
+      );
+
+      await expect(service.auth('kc-token')).rejects.toBeInstanceOf(
+        InternalServerErrorException,
+      );
+    });
+  });
+
+  describe('writeProjectSecretCiphertext', () => {
+    it('writes ciphertext to connector/data/projects/<projectId>/db', async () => {
+      fetchMock.mockResolvedValueOnce(
+        makeResponse({
+          ok: true,
+          status: 200,
+          jsonBody: { data: { written: true } },
+        }),
+      );
+
+      const projectId = 'cc0716f5-86a0-44c7-8c70-af6be4de2780';
+
+      const result = await service.writeProjectCiphertext(
+        'vault-token',
+        projectId,
+        'vault:v1:abc',
+      );
+
+      expect(result).toEqual({ data: { written: true } });
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe(
+        `${keystoreUrl}/v1/connector/data/projects/${encodeURIComponent(projectId)}/db`,
+      );
+      expect(init.method).toBe('POST');
+      expect(init.headers).toEqual({
+        'X-Vault-Token': 'vault-token',
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      });
+      expect(init.body).toBe(
+        JSON.stringify({ data: { ciphertext: 'vault:v1:abc' } }),
+      );
+    });
+
+    it('throws UnauthorizedException on 4xx', async () => {
+      fetchMock.mockResolvedValueOnce(
+        makeResponse({
+          ok: false,
+          status: 401,
+          jsonBody: { errors: ['bad token'] },
+        }),
+      );
+
+      await expect(
+        service.writeProjectCiphertext('vault-token', 'proj', 'vault:v1:abc'),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('throws InternalServerErrorException on 5xx', async () => {
+      fetchMock.mockResolvedValueOnce(
+        makeResponse({
+          ok: false,
+          status: 503,
+          jsonBody: { errors: ['unavailable'] },
+        }),
+      );
+
+      await expect(
+        service.writeProjectCiphertext('vault-token', 'proj', 'vault:v1:abc'),
+      ).rejects.toBeInstanceOf(InternalServerErrorException);
+    });
+  });
+
+  describe('transitEncrypt', () => {
+    it('encrypts payload via transit and returns ciphertext', async () => {
+      fetchMock.mockResolvedValueOnce(
+        makeResponse({
+          ok: true,
+          status: 200,
+          jsonBody: { data: { ciphertext: 'vault:v1:encrypted' } },
+        }),
+      );
+
+      const ciphertext = await service.transitEncrypt(
+        'vault-token',
+        'connector-db',
+        { user: 'u', pass: 'p' },
+      );
+
+      expect(ciphertext).toBe('vault:v1:encrypted');
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${keystoreUrl}/v1/transit/encrypt/connector-db`);
+      expect(init.method).toBe('POST');
+      expect(init.headers).toEqual({
+        'X-Vault-Token': 'vault-token',
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      });
+
+      const body = JSON.parse(init.body as string) as { plaintext: string };
+      const decoded = Buffer.from(body.plaintext, 'base64').toString('utf8');
+      expect(decoded).toBe(JSON.stringify({ user: 'u', pass: 'p' }));
+    });
+
+    it('throws NotFoundException when ciphertext missing', async () => {
+      fetchMock.mockResolvedValueOnce(
+        makeResponse({
+          ok: true,
+          status: 200,
+          jsonBody: { data: {} },
+        }),
+      );
+
+      await expect(
+        service.transitEncrypt('vault-token', 'connector-db', { a: 1 }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('transitDecrypt', () => {
+    it('decrypts ciphertext via transit and returns parsed object', async () => {
+      const payload = { host: 'db', port: 5432 };
+      const plaintextB64 = Buffer.from(
+        JSON.stringify(payload),
+        'utf8',
+      ).toString('base64');
+
+      fetchMock.mockResolvedValueOnce(
+        makeResponse({
+          ok: true,
+          status: 200,
+          jsonBody: { data: { plaintext: plaintextB64 } },
+        }),
+      );
+
+      const result = await service.transitDecrypt<typeof payload>(
+        'vault-token',
+        'connector-db',
+        'vault:v1:encrypted',
+      );
+
+      expect(result).toEqual(payload);
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe(`${keystoreUrl}/v1/transit/decrypt/connector-db`);
+      expect(init.method).toBe('POST');
+      expect(init.headers).toEqual({
+        'X-Vault-Token': 'vault-token',
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      });
+
+      expect(JSON.parse(init.body as string)).toEqual({
+        ciphertext: 'vault:v1:encrypted',
+      });
+    });
+
+    it('throws NotFoundException when plaintext missing', async () => {
+      fetchMock.mockResolvedValueOnce(
+        makeResponse({
+          ok: true,
+          status: 200,
+          jsonBody: { data: {} },
+        }),
+      );
+
+      await expect(
+        service.transitDecrypt('vault-token', 'connector-db', 'vault:v1:x'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('throws UnauthorizedException on 4xx', async () => {
+      fetchMock.mockResolvedValueOnce(
+        makeResponse({
+          ok: false,
+          status: 403,
+          jsonBody: { errors: ['permission denied'] },
+        }),
+      );
+
+      await expect(
+        service.transitDecrypt('vault-token', 'connector-db', 'vault:v1:x'),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+  });
+
+  describe('readProjectCiphertext', () => {
+    it('reads ciphertext from project path', async () => {
+      fetchMock.mockResolvedValueOnce(
+        makeResponse({
+          ok: true,
+          status: 200,
+          jsonBody: { data: { data: { ciphertext: 'vault:v1:abc' } } },
+        }),
+      );
+
+      const projectId = 'proj-123';
+      const ciphertext = await service.readProjectCiphertext(
+        'vault-token',
+        projectId,
+      );
+
+      expect(ciphertext).toBe('vault:v1:abc');
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe(
+        `${keystoreUrl}/v1/connector/data/projects/${encodeURIComponent(projectId)}/db`,
+      );
+      expect(init.method).toBe('GET');
+      expect(init.headers).toEqual({
+        'X-Vault-Token': 'vault-token',
+        Accept: 'application/json',
+      });
+    });
+
+    it('throws NotFoundException when ciphertext missing', async () => {
+      fetchMock.mockResolvedValueOnce(
+        makeResponse({
+          ok: true,
+          status: 200,
+          jsonBody: { data: { data: {} } },
+        }),
+      );
+
+      await expect(
+        service.readProjectCiphertext('vault-token', 'proj-123'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('throws InternalServerErrorException on 5xx', async () => {
+      fetchMock.mockResolvedValueOnce(
+        makeResponse({
+          ok: false,
+          status: 502,
+          jsonBody: { errors: ['bad gateway'] },
+        }),
+      );
+
+      await expect(
+        service.readProjectCiphertext('vault-token', 'proj-123'),
+      ).rejects.toBeInstanceOf(InternalServerErrorException);
+    });
+  });
+});

--- a/src/vault/vault.service.ts
+++ b/src/vault/vault.service.ts
@@ -1,0 +1,109 @@
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import fetch, { type RequestInit, type Response } from 'node-fetch';
+
+type VaultLoginResponse = {
+  auth?: { client_token?: string };
+  errors?: string[];
+};
+
+type VaultLookupSelfResponse = {
+  data?: { entity_id?: string };
+  errors?: string[];
+};
+
+type VaultKvWriteResponse = {
+  data?: unknown;
+  errors?: string[];
+};
+
+type VaultError = { errors?: string[] };
+
+@Injectable()
+export class VaultService {
+  private readonly logger = new Logger(VaultService.name);
+
+  constructor(private config: ConfigService) {}
+
+  private async vaultRequest<T>(path: string, init: RequestInit): Promise<T> {
+    const res: Response = await fetch(
+      `${this.config.get<string>('keystoreUrl')}${path}`,
+      {
+        ...init,
+        headers: {
+          Accept: 'application/json',
+          ...(init.headers ?? {}),
+        },
+      },
+    );
+
+    const json = (await res.json()) as T & VaultError;
+
+    if (!res.ok) {
+      const msg = json.errors?.join('; ') ?? `HTTP ${res.status}`;
+      this.logger.warn(`Vault ${init.method ?? 'GET'} ${path} failed: ${msg}`);
+      throw new UnauthorizedException(`Vault request failed: ${msg}`);
+    }
+
+    return json as T;
+  }
+
+  async auth(kcToken: string): Promise<string> {
+    const json = await this.vaultRequest<VaultLoginResponse>(
+      '/v1/auth/jwt/login',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({ role: 'default', jwt: kcToken }),
+      },
+    );
+
+    const token = json.auth?.client_token;
+    if (!token)
+      throw new UnauthorizedException(
+        'Vault login succeeded but no client_token returned',
+      );
+    return token;
+  }
+
+  async getEntityId(vaultToken: string): Promise<string> {
+    const json = await this.vaultRequest<VaultLookupSelfResponse>(
+      '/v1/auth/token/lookup-self',
+      {
+        method: 'GET',
+        headers: {
+          'X-Vault-Token': vaultToken,
+          Accept: 'application/json',
+        },
+      },
+    );
+
+    const entityId = json.data?.entity_id;
+    if (!entityId)
+      throw new UnauthorizedException('Vault token has no entity_id');
+    return entityId;
+  }
+
+  async writeSecret(
+    vaultToken: string,
+    entityId: string,
+    projectId: string,
+    payload: Record<string, unknown>,
+  ): Promise<VaultKvWriteResponse> {
+    return this.vaultRequest<VaultKvWriteResponse>(
+      `/v1/connector/data/users/${encodeURIComponent(entityId)}/${encodeURIComponent(projectId)}`,
+      {
+        method: 'POST',
+        headers: {
+          'X-Vault-Token': vaultToken,
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({ data: payload }), // KV v2 expects { data: {...} }
+      },
+    );
+  }
+}

--- a/src/vault/vault.service.ts
+++ b/src/vault/vault.service.ts
@@ -1,19 +1,37 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import fetch, { type RequestInit, type Response } from 'node-fetch';
 
 type VaultLoginResponse = {
   auth?: { client_token?: string };
   errors?: string[];
 };
 
-type VaultLookupSelfResponse = {
-  data?: { entity_id?: string };
+type VaultKvWriteResponse = {
+  data?: unknown;
   errors?: string[];
 };
 
-type VaultKvWriteResponse = {
-  data?: unknown;
+type VaultKvReadResponse<T> = {
+  data?: {
+    data?: T; // KV v2 payload lives here
+    metadata?: unknown;
+  };
+  errors?: string[];
+};
+
+type VaultTransitEncryptResponse = {
+  data?: { ciphertext?: string };
+  errors?: string[];
+};
+
+type VaultTransitDecryptResponse = {
+  data?: { plaintext?: string }; // base64 plaintext
   errors?: string[];
 };
 
@@ -42,68 +60,137 @@ export class VaultService {
     if (!res.ok) {
       const msg = json.errors?.join('; ') ?? `HTTP ${res.status}`;
       this.logger.warn(`Vault ${init.method ?? 'GET'} ${path} failed: ${msg}`);
-      throw new UnauthorizedException(`Vault request failed: ${msg}`);
+      if (res.status >= 500) {
+        throw new InternalServerErrorException(`Unexpected keystore error`);
+      }
+
+      if (res.status >= 400) {
+        throw new UnauthorizedException('Authorisation token not found');
+      }
     }
 
     return json as T;
   }
 
+  /**
+   * Auth with vault - exchange keycloak token for vault token
+   */
   async auth(kcToken: string): Promise<string> {
     const json = await this.vaultRequest<VaultLoginResponse>(
       '/v1/auth/jwt/login',
       {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Accept: 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ role: 'default', jwt: kcToken }),
       },
     );
 
     const token = json.auth?.client_token;
-    if (!token)
-      throw new UnauthorizedException(
-        'Vault login succeeded but no client_token returned',
-      );
+    if (!token) {
+      throw new UnauthorizedException('Authorisation token not found');
+    }
     return token;
   }
 
-  async getEntityId(vaultToken: string): Promise<string> {
-    const json = await this.vaultRequest<VaultLookupSelfResponse>(
-      '/v1/auth/token/lookup-self',
-      {
-        method: 'GET',
-        headers: {
-          'X-Vault-Token': vaultToken,
-          Accept: 'application/json',
-        },
-      },
-    );
-
-    const entityId = json.data?.entity_id;
-    if (!entityId)
-      throw new UnauthorizedException('Vault token has no entity_id');
-    return entityId;
-  }
-
-  async writeSecret(
+  /**
+   * Write into project-scoped store for Coordinator (EC2): connector/data/projects/<projectId>/db
+   */
+  async writeProjectCiphertext(
     vaultToken: string,
-    entityId: string,
     projectId: string,
-    payload: Record<string, unknown>,
+    ciphertext: string,
   ): Promise<VaultKvWriteResponse> {
     return this.vaultRequest<VaultKvWriteResponse>(
-      `/v1/connector/data/users/${encodeURIComponent(entityId)}/${encodeURIComponent(projectId)}`,
+      `/v1/connector/data/projects/${encodeURIComponent(projectId)}/db`,
       {
         method: 'POST',
         headers: {
           'X-Vault-Token': vaultToken,
           'Content-Type': 'application/json',
-          Accept: 'application/json',
         },
-        body: JSON.stringify({ data: payload }), // KV v2 expects { data: {...} }
+        body: JSON.stringify({ data: { ciphertext } }),
       },
     );
+  }
+
+  /**
+   * Encrypts JSON payload using Transit
+   * Returns Vault ciphertext (e.g. vault:v1:...)
+   * Storing ciphertext in KV so NO plaintext values
+   */
+  async transitEncrypt(
+    vaultToken: string,
+    keyName: string,
+    payload: Record<string, unknown>,
+  ): Promise<string> {
+    const plaintext = Buffer.from(JSON.stringify(payload), 'utf8').toString(
+      'base64',
+    );
+
+    const json = await this.vaultRequest<VaultTransitEncryptResponse>(
+      `/v1/transit/encrypt/${encodeURIComponent(keyName)}`,
+      {
+        method: 'POST',
+        headers: {
+          'X-Vault-Token': vaultToken,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ plaintext }),
+      },
+    );
+
+    const ciphertext = json.data?.ciphertext;
+    if (!ciphertext)
+      throw new NotFoundException('Transit encrypt returned no ciphertext');
+    return ciphertext;
+  }
+
+  /**
+   * Decrypts Vault ciphertext - parsed object
+   * Requires transit/decrypt permission
+   */
+  async transitDecrypt<T>(
+    vaultToken: string,
+    keyName: string,
+    ciphertext: string,
+  ): Promise<T> {
+    const json = await this.vaultRequest<VaultTransitDecryptResponse>(
+      `/v1/transit/decrypt/${encodeURIComponent(keyName)}`,
+      {
+        method: 'POST',
+        headers: {
+          'X-Vault-Token': vaultToken,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ ciphertext }),
+      },
+    );
+
+    const b64 = json.data?.plaintext;
+    if (!b64)
+      throw new NotFoundException('Transit decrypt returned no plaintext');
+
+    const raw = Buffer.from(b64, 'base64').toString('utf8');
+    return JSON.parse(raw) as T;
+  }
+
+  /**
+   *  Read ciphertext from project path.
+   */
+  async readProjectCiphertext(
+    vaultToken: string,
+    projectId: string,
+  ): Promise<string> {
+    const json = await this.vaultRequest<
+      VaultKvReadResponse<{ ciphertext?: string }>
+    >(`/v1/connector/data/projects/${encodeURIComponent(projectId)}/db`, {
+      method: 'GET',
+      headers: { 'X-Vault-Token': vaultToken },
+    });
+
+    const ciphertext = json.data?.data?.ciphertext;
+    if (!ciphertext)
+      throw new NotFoundException('No ciphertext found for project');
+    return ciphertext;
   }
 }


### PR DESCRIPTION
This will save db credentials into our secrets store (Vault). Platform PR needs to go in first to enable communication with vault - https://github.com/Epsilon-Data/platform/pull/57

**BREAKING CHANGES:**
- removed dbDetails from the database connections table - `pnpm prisma migrate dev` needs to be run

**Changes:**
- added vault service to communicate with Vault - uses JWT token from keycloak for auth
- changed add and update project methods to save database credentials into Vault

@khajievN  and @chuleeshen added you both here because this change will affect both. @khajievN, you should be using vault transit engine to pull the credentials out. See example - https://github.com/Epsilon-Data/ts-packages/pull/9