### PR TITLE
Properly return null to the frontend rather than empty string

### DIFF
--- a/src/analysis-request/analysis-request.controller.ts
+++ b/src/analysis-request/analysis-request.controller.ts
@@ -12,6 +12,7 @@ import {
   HttpStatus,
   HttpCode,
   Query,
+  UseInterceptors,
 } from '@nestjs/common';
 import { AnalysisRequestService } from './analysis-request.service';
 import {
@@ -39,6 +40,7 @@ import { Scopes } from 'src/common/decorators/scopes.decorator';
 import { ResourceGuard } from 'src/common/guards/resource.guard';
 import { GenericErrorResponseDto, GetRequestCommentsDto } from 'src/common/dto';
 import { RequestCommentDto } from 'src/common/dto';
+import { SerializeNullInterceptor } from 'src/common/interceptors/serialize-null.interceptor';
 
 @ApiTags('Analysis Request')
 @ApiBearerAuth()
@@ -139,6 +141,7 @@ export class AnalysisRequestController {
   }
 
   @Get(':projectId')
+  @UseInterceptors(SerializeNullInterceptor)
   @ApiOperation({
     summary: 'Get analysis request for a project',
   })

--- a/src/common/interceptors/serialize-null.interceptor.ts
+++ b/src/common/interceptors/serialize-null.interceptor.ts
@@ -1,12 +1,10 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
 import {
   Injectable,
   NestInterceptor,
   ExecutionContext,
   CallHandler,
 } from '@nestjs/common';
+import { Response } from 'express';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -16,7 +14,7 @@ export class SerializeNullInterceptor implements NestInterceptor {
     return next.handle().pipe(
       map((data: unknown) => {
         if (data === null || data === undefined) {
-          const response = context.switchToHttp().getResponse();
+          const response = context.switchToHttp().getResponse<Response>();
           response.setHeader('Content-Type', 'application/json');
           response.send('null');
           return;

--- a/src/common/interceptors/serialize-null.interceptor.ts
+++ b/src/common/interceptors/serialize-null.interceptor.ts
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable()
+export class SerializeNullInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    return next.handle().pipe(
+      map((data: unknown) => {
+        if (data === null || data === undefined) {
+          const response = context.switchToHttp().getResponse();
+          response.setHeader('Content-Type', 'application/json');
+          response.send('null');
+          return;
+        }
+        return data;
+      }),
+    );
+  }
+}


### PR DESCRIPTION
- Add an interceptor to `analysis-request/:projectId` to explicitly return `null` instead of empty string to the frontend

Notes:
- This was causing a logic error on the frontend side when checking for whether a researcher has already requested access to a dataset

Previous:
<img width="2012" height="244" alt="image" src="https://github.com/user-attachments/assets/59411208-5aab-4a99-8ded-81eecb2babb8" />


After:
<img width="2158" height="254" alt="image" src="https://github.com/user-attachments/assets/cb021a47-b8d2-424c-9491-d9d36189bf4f" />
