### PR TITLE
Removed packageId and customId from project

### DIFF
--- a/prisma/migrations/20260108120042_drop_package_id/migration.sql
+++ b/prisma/migrations/20260108120042_drop_package_id/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `packageId` on the `Project` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Project" DROP COLUMN "packageId";

--- a/prisma/migrations/20260108120720_drop_custom_id/migration.sql
+++ b/prisma/migrations/20260108120720_drop_custom_id/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `customId` on the `Project` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[ownerId,projectId]` on the table `Project` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "Project_ownerId_customId_key";
+
+-- AlterTable
+ALTER TABLE "Project" DROP COLUMN "customId";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Project_ownerId_projectId_key" ON "Project"("ownerId", "projectId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,8 +60,6 @@ model Analysis {
 model Project {
   projectId       String        @id(map: "project_pkey") @default(uuid()) @db.Uuid
   ownerId         String        @db.Uuid
-  customId        String        @db.VarChar(12)
-  packageId       String        @db.Text
   name            String        @db.Text
   lead            String        @db.Text
   university      String        @db.Text
@@ -80,7 +78,7 @@ model Project {
   connection      Connection?
   analysis        Analysis[]
 
-  @@unique([ownerId, customId])
+  @@unique([ownerId, projectId])
 }
 
 model Notification {

--- a/src/analysis-request/analysis-request.service.spec.ts
+++ b/src/analysis-request/analysis-request.service.spec.ts
@@ -619,11 +619,13 @@ describe('AnalysisRequestService', () => {
           project: {
             projectId: 'proj-1',
             lastModified: now,
-            packageId: 'pkg-1',
           },
         },
         {
-          project: { projectId: 'proj-2', lastModified: now, packageId: null },
+          project: {
+            projectId: 'proj-2',
+            lastModified: now,
+          },
         },
       ];
 
@@ -650,15 +652,20 @@ describe('AnalysisRequestService', () => {
             select: {
               projectId: true,
               lastModified: true,
-              packageId: true,
             },
           },
         },
       });
 
       expect(result).toEqual([
-        { datasetId: 'proj-1', packageId: 'pkg-1', lastModified: now },
-        { datasetId: 'proj-2', packageId: null, lastModified: now },
+        {
+          datasetId: 'proj-1',
+          lastModified: now,
+        },
+        {
+          datasetId: 'proj-2',
+          lastModified: now,
+        },
       ]);
     });
 

--- a/src/analysis-request/analysis-request.service.ts
+++ b/src/analysis-request/analysis-request.service.ts
@@ -314,7 +314,6 @@ export class AnalysisRequestService {
           select: {
             projectId: true,
             lastModified: true,
-            packageId: true,
           },
         },
       },
@@ -322,7 +321,6 @@ export class AnalysisRequestService {
     const formatted = analysisProjectList.map((request) => {
       return {
         datasetId: request.project.projectId,
-        packageId: request.project.packageId,
         lastModified: request.project.lastModified,
       };
     });

--- a/src/analysis/dto/analysis.dto.ts
+++ b/src/analysis/dto/analysis.dto.ts
@@ -49,14 +49,6 @@ export class DatasetDto {
   datasetId!: string;
 
   @ApiProperty({
-    description: 'Identifier of the associated package',
-    example: 'test_db_creds_dGDZ6c',
-  })
-  @IsString()
-  @IsNotEmpty()
-  packageId!: string;
-
-  @ApiProperty({
     description: 'Timestamp when the dataset was last modified',
     type: String,
     format: 'date-time',

--- a/src/archetype/archetype.service.spec.ts
+++ b/src/archetype/archetype.service.spec.ts
@@ -1139,7 +1139,7 @@ describe('ArchetypeService', () => {
         token,
       );
 
-      expect(schema.$id).toBe(archetypeId);
+      expect(schema.$id).toBe(`${projectId}/${archetypeId}`);
       // Schema basics
       expect(schema.$schema).toBe(
         'https://json-schema.org/draft/2020-12/schema#',

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -369,7 +369,7 @@ export class ArchetypeService {
         .split('@')
         .at(-1) as string;
       const schema = {
-        $id: archetypeId,
+        $id: `${projectId}/${archetypeId}`,
         $schema: 'https://json-schema.org/draft/2020-12/schema#',
         title: res.attributes?.values[0][0],
         type: 'object',

--- a/src/connection-request/connection-request.service.spec.ts
+++ b/src/connection-request/connection-request.service.spec.ts
@@ -80,7 +80,6 @@ describe('ConnectionRequestService', () => {
         {
           project: {
             projectId: 'proj-1',
-            customId: 'P-001',
             name: 'Test Project',
           },
           request: {
@@ -106,7 +105,6 @@ describe('ConnectionRequestService', () => {
           project: {
             select: {
               projectId: true,
-              customId: true,
               name: true,
             },
           },

--- a/src/connection-request/connection-request.service.ts
+++ b/src/connection-request/connection-request.service.ts
@@ -31,7 +31,6 @@ export class ConnectionRequestService {
         project: {
           select: {
             projectId: true,
-            customId: true,
             name: true,
           },
         },

--- a/src/project/dto/project.dto.ts
+++ b/src/project/dto/project.dto.ts
@@ -64,13 +64,6 @@ export class ProjectSummaryInfoDto {
   projectId!: string;
 
   @ApiProperty({
-    description: 'Custom human-readable project identifier',
-    example: 'HRT-2025-001',
-  })
-  @IsString()
-  customId!: string;
-
-  @ApiProperty({
     description: 'Project name',
     example: 'Example Health Study',
   })
@@ -140,15 +133,6 @@ export class ProjectSummaryInfoDto {
   dbKeywords?: string[];
 }
 export class CreateProjectDto {
-  @ApiPropertyOptional({
-    description: 'Custom project identifier',
-    example: 'customid123',
-  })
-  @IsOptional()
-  @IsNotEmpty()
-  @IsString()
-  customId?: string;
-
   @ApiProperty({
     description: 'Human-readable name of the project',
     example: 'Health Research Study',
@@ -407,14 +391,6 @@ export class ProjectDetailsResponseDto {
   @IsEnum($Enums.ProjectStatus)
   @IsOptional()
   status?: $Enums.ProjectStatus;
-
-  @ApiPropertyOptional({
-    description: 'Custom project identifier',
-    example: 'customid123',
-  })
-  @IsOptional()
-  @IsString()
-  customId?: string;
 
   @ApiProperty({
     description: 'Owner user ID (UUID)',

--- a/src/project/project.service.spec.ts
+++ b/src/project/project.service.spec.ts
@@ -88,7 +88,6 @@ describe('ProjectService', () => {
       const projects = [
         {
           projectId: 'p1',
-          customId: 'c1',
           name: 'Project 1',
           lastModified: new Date(),
           createdDate: new Date(),
@@ -106,7 +105,6 @@ describe('ProjectService', () => {
         where: { ownerId: userId },
         select: {
           projectId: true,
-          customId: true,
           name: true,
           lastModified: true,
           createdDate: true,
@@ -143,7 +141,6 @@ describe('ProjectService', () => {
       const projects = [
         {
           projectId: 'p1',
-          customId: 'c1',
           name: 'Project 1',
           lastModified: new Date(),
           status: 'MAPPED',
@@ -153,7 +150,6 @@ describe('ProjectService', () => {
         },
         {
           projectId: 'p3',
-          customId: 'c3',
           name: 'Project 3',
           lastModified: new Date(),
           status: 'MAPPED',
@@ -175,7 +171,6 @@ describe('ProjectService', () => {
         },
         select: {
           projectId: true,
-          customId: true,
           name: true,
           createdDate: true,
           lastModified: true,
@@ -194,7 +189,6 @@ describe('ProjectService', () => {
       const projects = [
         {
           projectId: 'p1',
-          customId: 'c1',
           name: 'Project 1',
           lastModified: new Date(),
           createdDate: new Date(),
@@ -215,7 +209,6 @@ describe('ProjectService', () => {
         },
         select: {
           projectId: true,
-          customId: true,
           name: true,
           lastModified: true,
           createdDate: true,

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -16,7 +16,6 @@ import {
   UpdateProjectDto,
 } from './dto';
 import { FileStorageService } from 'src/file-storage/file_storage.service';
-import { nanoid } from 'nanoid';
 import { QueueService } from 'src/queue/queue.service';
 
 import { KeycloakPermissionDto } from 'src/auth/dto';
@@ -46,7 +45,6 @@ export class ProjectService {
       },
       select: {
         projectId: true,
-        customId: true,
         name: true,
         lastModified: true,
         status: true,
@@ -75,7 +73,6 @@ export class ProjectService {
       },
       select: {
         projectId: true,
-        customId: true,
         name: true,
         lastModified: true,
         createdDate: true,
@@ -96,7 +93,6 @@ export class ProjectService {
       },
       select: {
         projectId: true,
-        customId: true,
         name: true,
         lastModified: true,
         createdDate: true,
@@ -290,7 +286,6 @@ export class ProjectService {
       select: {
         projectId: true,
         status: true,
-        customId: true,
         ownerId: true,
         name: true,
         lead: true,
@@ -317,7 +312,6 @@ export class ProjectService {
     return {
       projectId: projectInfo.projectId,
       status: projectInfo.status,
-      customId: projectInfo.customId,
       ownerId: projectInfo.ownerId,
       name: projectInfo.name,
       lead: projectInfo.lead,
@@ -360,7 +354,6 @@ export class ProjectService {
     dto: CreateProjectDto,
     accessToken: string,
   ) {
-    const { packageId, customId } = this.createIds(dto.name, dto.customId);
     const ownerId = user.id; //using current logged in user details rather than post
     // check if members are added
     const members = dto.members
@@ -368,8 +361,6 @@ export class ProjectService {
       : undefined;
     const request = {
       ownerId,
-      customId,
-      packageId,
       name: dto.name,
       lead: dto.lead,
       university: dto.university,
@@ -475,11 +466,9 @@ export class ProjectService {
       ? (dto.members as unknown as Prisma.JsonArray)
       : undefined;
     const data = {
-      // NOTE: can you change name as that changes package???
       name: dto.name,
       lead: dto.lead,
       status: dto.status,
-      // NOTE: can you change customId as that also changes package??
       university: dto.university,
       faculty: dto.faculty,
       ethicsId: dto.ethicsId,
@@ -560,17 +549,6 @@ export class ProjectService {
     // FIXME: not sure if forcing jpg is good, it should use the ext it has been uploaded
     await this.fileStorage.putFile('cover', `${projectId}/cover.jpg`, file);
     return file.buffer;
-  }
-
-  // TODO: review this generation
-  private createIds(name: string, id?: string) {
-    const customId = id ?? nanoid(12);
-    const packageName = name
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '_')
-      .replace(/^_+|_+$/g, '');
-    const packageId = `${packageName}_${customId.slice(0, 6)}`;
-    return { packageId, customId };
   }
 
   private async addSecrets(


### PR DESCRIPTION
As the SDK does not need packageId anymore I removed it. Also I don't think we have a place in the frontend for entering customId so I removed that as well. Correct me if I am wrong @chuleeshen 

**Changes:**
- removed `customId` and `packageId` from db schema and api responses 
GET `/api/v1/hub/analysis/datasets` will give you an array with datasetId's, e.g.:
```json
[
    {
        "datasetId": "f6c981e7-2e7a-4595-82f4-caf973f5c747",
        "lastModified": "2025-12-12T16:15:46.073Z"
    }
]
```
- changed archetype JSONSchema `$id` to include projectId and archetypeId e.g. `"$id" : "<projectId>/<archetypeId>"` in the archetype response
GET `/api/v1/hub/analysis/datasets/f6c981e7-2e7a-4595-82f4-caf973f5c747` will give you e.g.:
```json

{
    "$id": "f6c981e7-2e7a-4595-82f4-caf973f5c747/14KMKCMNkO5n",
    "$schema": "https://json-schema.org/draft/2020-12/schema#",
    "title": "Test template",
    "type": "object",
    "properties": {
        "health": {
            "type": "object",
            "properties": {
                "heart_rate": {
                    "type": "integer",
                    "description": "Heart rate"
                },
                "condition": {
                    "type": "boolean",
                    "description": "Condition"
                }
            }
        },
        "patient": {
            "type": "object",
            "properties": {
                "age": {
                    "type": "integer",
                    "description": "Age"
                }
            }
        }
    }
}
```



TODO:
- @khajievN, it should still work with the SDK as you are not relaying on the packageId anymore, but worth checking