### PR TITLE
Add coordinator job analysis approval endpoint

### DIFF
--- a/src/analysis-request/analysis-request.service.spec.ts
+++ b/src/analysis-request/analysis-request.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { AnalysisRequestService } from './analysis-request.service';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { KeycloakAdminService } from 'src/admin/keycloak/keycloak-admin.service';
@@ -675,6 +675,66 @@ describe('AnalysisRequestService', () => {
       const result = await service.getAnalysisProjects('user-456');
 
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('checkAnalysisAccess', () => {
+    it('throws BadRequestException when projectId is missing', async () => {
+      await expect(service.checkAnalysisAccess('', 'user-1')).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.checkAnalysisAccess('', 'user-1')).rejects.toThrow(
+        'Missing parameters projectId and userId are required',
+      );
+
+      expect(prisma.analysis.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when userId is missing', async () => {
+      await expect(service.checkAnalysisAccess('proj-1', '')).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.checkAnalysisAccess('proj-1', '')).rejects.toThrow(
+        'Missing parameters projectId and userId are required',
+      );
+
+      expect(prisma.analysis.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('queries prisma with correct where/select and returns isApproved=true when an approved request exists', async () => {
+      prisma.analysis.findFirst.mockResolvedValueOnce({
+        requestId: 'req-123',
+      });
+
+      const projectId = 'proj-1';
+      const userId = 'user-1';
+
+      const result = await service.checkAnalysisAccess(projectId, userId);
+
+      expect(prisma.analysis.findFirst).toHaveBeenCalledTimes(1);
+      expect(prisma.analysis.findFirst).toHaveBeenCalledWith({
+        where: {
+          projectId,
+          request: {
+            requestorId: userId,
+            status: $Enums.RequestStatus.APPROVED,
+          },
+        },
+        select: {
+          requestId: true,
+        },
+      });
+
+      expect(result).toEqual({ isApproved: true });
+    });
+
+    it('returns isApproved=false when no approved request exists', async () => {
+      prisma.analysis.findFirst.mockResolvedValueOnce(null);
+
+      const result = await service.checkAnalysisAccess('proj-1', 'user-1');
+
+      expect(prisma.analysis.findFirst).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ isApproved: false });
     });
   });
 });

--- a/src/analysis-request/analysis-request.service.ts
+++ b/src/analysis-request/analysis-request.service.ts
@@ -202,6 +202,26 @@ export class AnalysisRequestService {
     return;
   }
 
+  async checkAnalysisAccess(projectId: string, userId: string) {
+    if (!projectId || !userId)
+      throw new BadRequestException(
+        'Missing parameters projectId and userId are required',
+      );
+    const request = await this.prisma.analysis.findFirst({
+      where: {
+        projectId: projectId,
+        request: {
+          requestorId: userId,
+          status: $Enums.RequestStatus.APPROVED,
+        },
+      },
+      select: {
+        requestId: true,
+      },
+    });
+    return request ? { isApproved: true } : { isApproved: false };
+  }
+
   async update(userId: string, requestId: string, dto: AnalysisDto) {
     return await this.prisma.analysis.update({
       where: {

--- a/src/coordinator/coordinator.controller.ts
+++ b/src/coordinator/coordinator.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   ParseUUIDPipe,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import {
@@ -31,6 +32,8 @@ import { KeycloakService } from 'src/auth/keycloak/keycloak.service';
 import { Credentials } from '@epsilon-data/keycloak-admin-client';
 import { ConfigService } from '@nestjs/config';
 import { KeycloakTokenResponseDto } from 'src/auth/dto';
+import { AnalysisDecisionDto } from 'src/analysis-request/dto';
+import { AnalysisRequestService } from 'src/analysis-request/analysis-request.service';
 
 @ApiTags('Coordinator')
 @ApiBearerAuth()
@@ -40,6 +43,7 @@ export class CoordinatorController {
   constructor(
     private readonly databaseService: DatabaseService,
     private readonly keycloakService: KeycloakService,
+    private readonly analysisRequestService: AnalysisRequestService,
     private configService: ConfigService,
   ) {}
 
@@ -89,6 +93,62 @@ export class CoordinatorController {
       clientSecret: login.clientSecret,
     };
     return await this.keycloakService.getAccessToken(credentials);
+  }
+
+  @Get(':projectId')
+  @UseGuards(new ScopesGuard('epsilon.coordinator'))
+  @ApiOperation({ summary: 'Check user access to project analysis' })
+  @ApiOkResponse({
+    description: 'Project analysis decision returned',
+    type: AnalysisDecisionDto,
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid request data for database operation',
+    content: {
+      'application/json': {
+        schema: { $ref: getSchemaPath(GenericErrorResponseDto) },
+        example: {
+          statusCode: 400,
+          message: 'Invalid request data for database operation',
+          error: 'DatabaseError',
+        },
+      },
+    },
+  })
+  @ApiNotFoundResponse({
+    description: 'Request not found',
+    content: {
+      'application/json': {
+        schema: { $ref: getSchemaPath(GenericErrorResponseDto) },
+        example: {
+          statusCode: 404,
+          message: 'Requested resource could not be found',
+          error: 'DatabaseError',
+        },
+      },
+    },
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Unexpected database error',
+    content: {
+      'application/json': {
+        schema: { $ref: getSchemaPath(GenericErrorResponseDto) },
+        example: {
+          statusCode: 500,
+          message: 'Database is temporarily unavailable',
+          error: 'DatabaseError',
+        },
+      },
+    },
+  })
+  async checkAccess(
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+    @Query('userId') userId: string,
+  ) {
+    return await this.analysisRequestService.checkAnalysisAccess(
+      projectId,
+      userId,
+    );
   }
 
   @Get(':projectId/:archetypeId')

--- a/src/coordinator/coordinator.module.ts
+++ b/src/coordinator/coordinator.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { CoordinatorController } from './coordinator.controller';
 import { DatabaseModule } from 'src/database/database.module';
+import { AnalysisRequestModule } from 'src/analysis-request/analysis-request.module';
 
 @Module({
-  imports: [DatabaseModule],
+  imports: [DatabaseModule, AnalysisRequestModule],
   controllers: [CoordinatorController],
 })
 export class CoordinatorModule {}


### PR DESCRIPTION
@khajievN, this can be used to check if a user (userId) is allowed to run analysis jobs against a project (projectId)

**Needs to follow PR #118** - and possible rebase

**Changes:**
- added GET `/api/v1/hub/coordinator/{projectId}?userId=<userId>` endpoint for checking access to project analysis - successful response is (true/false):
```json 
{
  "isApproved": true
}
```

