### PR TITLE
Include ssl input in connection details

### DIFF
--- a/src/connection-request/connection-request.service.ts
+++ b/src/connection-request/connection-request.service.ts
@@ -92,8 +92,9 @@ export class ConnectionRequestService {
       user: database.username,
       password: database.password,
       database: database.name,
-      ssl: database.ssl ?? false,
+      ssl: database.ssl,
     };
+
     // on success it returns now() - current db datetime
     return await testConnection(connectionData);
   }

--- a/src/connection-request/dto/connection-request.dto.ts
+++ b/src/connection-request/dto/connection-request.dto.ts
@@ -75,6 +75,14 @@ export class DatabaseInfoDto {
   @IsOptional()
   @IsString()
   password?: string;
+
+  @ApiPropertyOptional({
+    description: 'SSL connection enabled',
+    example: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  ssl?: boolean;
 }
 export class DatabaseTestDto {
   @ApiProperty({

--- a/src/docker/docker.service.ts
+++ b/src/docker/docker.service.ts
@@ -49,11 +49,9 @@ export class DockerService {
       `OWNER=${ownerId}`,
       `DATABASE_URL=${
         this.isDev
-          ? database.url?.replace('localhost', 'host.docker.internal') +
-            '?sslmode=disable'
-          : database.url +
-            (database.ssl ? '?sslmode=require' : '?sslmode=disable')
-      }`,
+          ? database.url?.replace('localhost', 'host.docker.internal')
+          : database.url
+      }${database.ssl ? '?sslmode=require' : '?sslmode=disable'}`,
       `PROJECT_ID=${projectId}`,
     ];
 

--- a/src/docker/docker.service.ts
+++ b/src/docker/docker.service.ts
@@ -47,7 +47,13 @@ export class DockerService {
       `ATLAS_ADMIN_USER=${this.username}`,
       `ATLAS_ADMIN_PASSWORD=${this.password}`,
       `OWNER=${ownerId}`,
-      `DATABASE_URL=${this.isDev ? database.url?.replace('localhost', 'host.docker.internal') + '?sslmode=disable' : database.url}`,
+      `DATABASE_URL=${
+        this.isDev
+          ? database.url?.replace('localhost', 'host.docker.internal') +
+            '?sslmode=disable'
+          : database.url +
+            (database.ssl ? '?sslmode=require' : '?sslmode=disable')
+      }`,
       `PROJECT_ID=${projectId}`,
     ];
 


### PR DESCRIPTION
**Changes:**
- Add ssl field to testConnection and DatabaseInfoDto
- Modify sslmode for `DATABASE_URL` variable of the data crawler