### PR TITLE
fix: add projectId constraint when getting connection requests

### DIFF
--- a/src/project/project.service.spec.ts
+++ b/src/project/project.service.spec.ts
@@ -274,6 +274,7 @@ describe('ProjectService', () => {
       expect(prismaMock.connection.findMany).toHaveBeenCalledWith({
         where: {
           orgAdminEmail: email,
+          projectId: projectId,
         },
         select: {
           project: {

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -118,6 +118,7 @@ export class ProjectService {
     const connections = await this.prisma.connection.findMany({
       where: {
         orgAdminEmail: email,
+        projectId: projectId,
       },
       select: {
         project: {


### PR DESCRIPTION
Add projectId constraint when getting connection requests