### PR TITLE
refactor: change approve endpoint to update request status endpoint

### DIFF
--- a/src/analysis-request/analysis-request.controller.ts
+++ b/src/analysis-request/analysis-request.controller.ts
@@ -16,10 +16,10 @@ import {
 } from '@nestjs/common';
 import { AnalysisRequestService } from './analysis-request.service';
 import {
-  AnalysisDecisionDto,
   AnalysisDto,
   AnalysisRequestDetailsResponseDto,
   AnalysisRequestSummaryInfoDto,
+  AnalysisStatusDto,
 } from './dto';
 import {
   ApiTags,
@@ -255,16 +255,15 @@ export class AnalysisRequestController {
     );
   }
 
-  // TODO: should this not also have to be reject?
   @UseGuards(ResourceGuard)
   @Scopes('view', 'approve')
   @Patch(':projectId/:requestId')
   @ApiOperation({
-    summary: 'Approve analysis request',
+    summary: 'Update analysis request status',
   })
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiNoContentResponse({
-    description: 'Analysis request approved',
+    description: 'Analysis request status updated',
   })
   @ApiBadRequestResponse({
     description: 'Invalid request data for database operation',
@@ -305,12 +304,12 @@ export class AnalysisRequestController {
       },
     },
   })
-  approve(
+  updateStatus(
     @Param('requestId', ParseUUIDPipe) requestId: string,
     @Param('projectId', ParseUUIDPipe) projectId: string,
-    @Body() dto: AnalysisDecisionDto,
+    @Body() dto: AnalysisStatusDto,
   ) {
-    return this.analysisRequestService.approve(requestId, projectId, dto);
+    return this.analysisRequestService.updateStatus(requestId, projectId, dto);
   }
 
   @Put(':requestId')

--- a/src/analysis-request/analysis-request.service.spec.ts
+++ b/src/analysis-request/analysis-request.service.spec.ts
@@ -4,7 +4,7 @@ import { AnalysisRequestService } from './analysis-request.service';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { KeycloakAdminService } from 'src/admin/keycloak/keycloak-admin.service';
 import { $Enums } from 'src/generated/prisma/client';
-import { AnalysisDecisionDto, AnalysisDto } from './dto';
+import { AnalysisDto, AnalysisStatusDto } from './dto';
 import { ProjectMember } from 'src/project/dto';
 import { RequestCommentDto } from 'src/common/dto';
 
@@ -397,11 +397,11 @@ describe('AnalysisRequestService', () => {
     });
   });
 
-  describe('approve', () => {
-    it('should set status APPROVED and call keycloak when isApproved is true', async () => {
+  describe('updateStatus', () => {
+    it('should set status APPROVED and call keycloak', async () => {
       const requestId = 'req-1';
-      const projectId = '8b7e2f36-9217-4ea0-8d6e-b621fb6e5230';
-      const dto: AnalysisDecisionDto = { isApproved: true };
+      const projectId = 'proj-1';
+      const dto = { status: $Enums.RequestStatus.APPROVED };
 
       prisma.request.update.mockResolvedValue({
         requestId,
@@ -409,20 +409,29 @@ describe('AnalysisRequestService', () => {
         requestorId: 'requestor-123',
       });
 
-      await service.approve(requestId, projectId, dto);
+      await service.updateStatus(
+        requestId,
+        projectId,
+        dto as AnalysisStatusDto,
+      );
 
       expect(prisma.request.update).toHaveBeenCalledWith({
         where: { requestId },
         data: { status: $Enums.RequestStatus.APPROVED },
       });
 
-      expect(keycloakMock.addUserToUserPolicy).toHaveBeenCalled();
+      expect(keycloakMock.auth).toHaveBeenCalledTimes(1);
+      expect(keycloakMock.addUserToUserPolicy).toHaveBeenCalledTimes(1);
+      expect(keycloakMock.addUserToUserPolicy).toHaveBeenCalledWith(
+        projectId,
+        'requestor-123',
+      );
     });
 
-    it('should set status REJECTED and NOT call keycloak when isApproved is false', async () => {
+    it('should only set status REJECTED and not call keycloak', async () => {
       const requestId = 'req-1';
-      const projectId = '8b7e2f36-9217-4ea0-8d6e-b621fb6e5230';
-      const dto: AnalysisDecisionDto = { isApproved: false };
+      const projectId = 'proj-1';
+      const dto = { status: $Enums.RequestStatus.REJECTED };
 
       prisma.request.update.mockResolvedValue({
         requestId,
@@ -430,13 +439,70 @@ describe('AnalysisRequestService', () => {
         requestorId: 'requestor-123',
       });
 
-      await service.approve(requestId, projectId, dto);
+      await service.updateStatus(
+        requestId,
+        projectId,
+        dto as AnalysisStatusDto,
+      );
 
       expect(prisma.request.update).toHaveBeenCalledWith({
         where: { requestId },
         data: { status: $Enums.RequestStatus.REJECTED },
       });
 
+      expect(keycloakMock.auth).not.toHaveBeenCalled();
+      expect(keycloakMock.addUserToUserPolicy).not.toHaveBeenCalled();
+    });
+
+    it('should only set status PENDING and not call keycloak', async () => {
+      const requestId = 'req-1';
+      const projectId = 'proj-1';
+      const dto = { status: $Enums.RequestStatus.PENDING };
+
+      prisma.request.update.mockResolvedValue({
+        requestId,
+        status: $Enums.RequestStatus.PENDING,
+        requestorId: 'requestor-123',
+      });
+
+      await service.updateStatus(
+        requestId,
+        projectId,
+        dto as AnalysisStatusDto,
+      );
+
+      expect(prisma.request.update).toHaveBeenCalledWith({
+        where: { requestId },
+        data: { status: $Enums.RequestStatus.PENDING },
+      });
+
+      expect(keycloakMock.auth).not.toHaveBeenCalled();
+      expect(keycloakMock.addUserToUserPolicy).not.toHaveBeenCalled();
+    });
+
+    it('should only set status REVISION and not call keycloak', async () => {
+      const requestId = 'req-1';
+      const projectId = 'proj-1';
+      const dto = { status: $Enums.RequestStatus.REVISION };
+
+      prisma.request.update.mockResolvedValue({
+        requestId,
+        status: $Enums.RequestStatus.REVISION,
+        requestorId: 'requestor-123',
+      });
+
+      await service.updateStatus(
+        requestId,
+        projectId,
+        dto as AnalysisStatusDto,
+      );
+
+      expect(prisma.request.update).toHaveBeenCalledWith({
+        where: { requestId },
+        data: { status: $Enums.RequestStatus.REVISION },
+      });
+
+      expect(keycloakMock.auth).not.toHaveBeenCalled();
       expect(keycloakMock.addUserToUserPolicy).not.toHaveBeenCalled();
     });
   });

--- a/src/analysis-request/analysis-request.service.ts
+++ b/src/analysis-request/analysis-request.service.ts
@@ -6,10 +6,10 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import {
-  AnalysisDecisionDto,
   AnalysisDto,
   AnalysisRequestDetailsResponseDto,
   AnalysisRequestSummaryInfoDto,
+  AnalysisStatusDto,
 } from './dto';
 import { $Enums, Prisma } from 'src/generated/prisma/client';
 import { ProjectMember } from 'src/project/dto';
@@ -182,14 +182,12 @@ export class AnalysisRequestService {
     return; // no content return
   }
 
-  async approve(
+  async updateStatus(
     requestId: string,
     projectId: string,
-    dto: AnalysisDecisionDto,
+    dto: AnalysisStatusDto,
   ) {
-    const status = dto.isApproved
-      ? $Enums.RequestStatus.APPROVED
-      : $Enums.RequestStatus.REJECTED;
+    const { status } = dto;
     const result = await this.prisma.request.update({
       where: { requestId: requestId },
       data: {

--- a/src/analysis-request/dto/analysis-request.dto.ts
+++ b/src/analysis-request/dto/analysis-request.dto.ts
@@ -258,6 +258,17 @@ export class AnalysisRequestDetailsResponseDto extends AnalysisDto {
   project?: UpdateProjectDto | null;
 }
 
+export class AnalysisStatusDto {
+  @ApiProperty({
+    description: 'Current status of the access request',
+    enum: $Enums.RequestStatus,
+    example: $Enums.RequestStatus.PENDING,
+  })
+  @IsDefined()
+  @IsEnum($Enums.RequestStatus)
+  status!: $Enums.RequestStatus;
+}
+
 export class AnalysisDecisionDto {
   @ApiProperty({
     description: 'Approval decision for the analysis request',


### PR DESCRIPTION
Modified the approve endpoint to update request statuses rather than just for `APPROVED` or `REJECTED`