### PR TITLE
Delete Keycloak resource

### DIFF
--- a/src/admin/keycloak/keycloak-admin.service.spec.ts
+++ b/src/admin/keycloak/keycloak-admin.service.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { Test, TestingModule } from '@nestjs/testing';
@@ -301,7 +302,7 @@ describe('KeycloakAdminService', () => {
   describe('addUserToUserPolicy', () => {
     it('updates existing policy, merging users', async () => {
       // set defaultClient directly
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
       (service as any).defaultClient = {
         id: 'client-1',
       } as ClientRepresentation;
@@ -342,7 +343,6 @@ describe('KeycloakAdminService', () => {
     });
 
     it('creates permission when policy does not exist', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (service as any).defaultClient = {
         id: 'client-1',
       } as ClientRepresentation;

--- a/src/admin/keycloak/keycloak-admin.service.spec.ts
+++ b/src/admin/keycloak/keycloak-admin.service.spec.ts
@@ -54,6 +54,9 @@ describe('KeycloakAdminService', () => {
       createPermission: jest.fn(),
       delResource: jest.fn(),
       findPolicyByName: jest.fn(),
+      listResources: jest.fn(),
+      listPolicies: jest.fn(),
+      delPolicy: jest.fn(),
     },
     roles: {
       create: jest.fn(),
@@ -66,6 +69,7 @@ describe('KeycloakAdminService', () => {
       create: jest.fn(),
       findOne: jest.fn(),
       find: jest.fn(),
+      del: jest.fn(),
     },
     clientScopes: {
       create: jest.fn(),
@@ -400,6 +404,179 @@ describe('KeycloakAdminService', () => {
       expect(result).toEqual({
         access_token: 'token-123',
       });
+    });
+  });
+
+  describe('deleteResource', () => {
+    it('returns early when defaultClient.id is missing', async () => {
+      (service as any).defaultClient = { id: undefined };
+
+      await service.deleteResource('proj-1');
+
+      expect(mockKcAdminClient.clients.listResources).not.toHaveBeenCalled();
+    });
+
+    it('handles resource not found', async () => {
+      (service as any).defaultClient = {
+        id: 'client-1',
+      } as ClientRepresentation;
+      // Spy only where you assert catch-path behavior
+      const handleSpy = jest
+        .spyOn(service as any, 'handleKeycloakError')
+        .mockImplementation((_fn: string, err: unknown) => err);
+
+      mockKcAdminClient.clients.listResources.mockResolvedValue([]);
+
+      await service.deleteResource('uuid');
+
+      expect(handleSpy).toHaveBeenCalledWith(
+        'deleteResource',
+        expect.anything(),
+      );
+    });
+
+    it('deletes resource then deletes any remaining (orphan) policies', async () => {
+      (service as any).defaultClient = { id: 'client-uuid' };
+      (service as any).config = { realm: 'test-realm' };
+
+      const projectId = 'cedb48f3-cf26-4b0c-8cb2-cebd60df5083';
+
+      jest
+        .spyOn(service as any, 'handleKeycloakError')
+        .mockImplementation((_fn: string, err: unknown) => err);
+
+      jest.spyOn(service as any, 'getGroupByName').mockResolvedValue([]);
+
+      mockKcAdminClient.clients.listResources.mockResolvedValue([
+        { _id: 'resource-id-1' },
+      ]);
+      mockKcAdminClient.clients.delResource.mockResolvedValue(undefined);
+
+      // orphan policies (single pass)
+      const getPoliciesSpy = jest
+        .spyOn(service as any, 'getProjectPolicies')
+        .mockResolvedValue([
+          {
+            id: 'orphan-1',
+            name: `Analysis orphan ${projectId}`,
+            type: 'user',
+          },
+          { id: 'orphan-2', name: `More orphan ${projectId}`, type: 'scope' },
+        ]);
+
+      mockKcAdminClient.clients.delPolicy.mockResolvedValue(undefined);
+
+      await service.deleteResource(projectId);
+
+      expect(mockKcAdminClient.clients.delResource).toHaveBeenCalled();
+
+      expect(getPoliciesSpy).toHaveBeenCalledTimes(1);
+      expect(getPoliciesSpy).toHaveBeenCalledWith(projectId);
+
+      expect(mockKcAdminClient.clients.delPolicy).toHaveBeenCalledTimes(2);
+      expect(mockKcAdminClient.clients.delPolicy).toHaveBeenNthCalledWith(1, {
+        id: 'client-uuid',
+        policyId: 'orphan-1',
+        realm: 'test-realm',
+      });
+      expect(mockKcAdminClient.clients.delPolicy).toHaveBeenNthCalledWith(2, {
+        id: 'client-uuid',
+        policyId: 'orphan-2',
+        realm: 'test-realm',
+      });
+    });
+
+    it('ignores 404 policy delete failures (isNotFound=true) and continues', async () => {
+      (service as any).defaultClient = {
+        id: 'client-1',
+      } as ClientRepresentation;
+      (service as any).config = { realm: 'test-realm' };
+
+      const projectId = 'cedb48f3-cf26-4b0c-8cb2-cebd60df5083';
+
+      mockKcAdminClient.clients.listResources.mockResolvedValue([
+        { _id: 'resource-id-1' },
+      ]);
+      mockKcAdminClient.clients.delResource.mockResolvedValue(undefined);
+
+      jest.spyOn(service as any, 'getProjectPolicies').mockResolvedValueOnce([
+        { id: 'scope-1', name: `Analysis ${projectId}`, type: 'scope' },
+        { id: 'user-1', name: `Analysis of ${projectId}`, type: 'user' },
+      ]);
+
+      jest.spyOn(service as any, 'getGroupByName').mockResolvedValue([]);
+
+      jest
+        .spyOn(service as any, 'isNotFound')
+        .mockImplementation((e: unknown) => {
+          const err = e as any;
+          return err?.response?.status === 404;
+        });
+
+      const handleSpy = jest
+        .spyOn(service as any, 'handleKeycloakError')
+        .mockImplementation((_fn: string, err: unknown) => err);
+
+      const notFoundErr = { response: { status: 404 } };
+      mockKcAdminClient.clients.delPolicy
+        .mockRejectedValueOnce(notFoundErr)
+        .mockResolvedValueOnce(undefined);
+
+      await service.deleteResource(projectId);
+
+      expect(mockKcAdminClient.clients.delResource).toHaveBeenCalled();
+      expect(handleSpy).not.toHaveBeenCalled();
+    });
+
+    it('routes through handleKeycloakError when an orphan policy delete fails with non-404', async () => {
+      (service as any).defaultClient = { id: 'client-uuid' };
+      (service as any).config = { realm: 'test-realm' };
+
+      const projectId = 'cedb48f3-cf26-4b0c-8cb2-cebd60df5083';
+
+      const handleSpy = jest
+        .spyOn(service as any, 'handleKeycloakError')
+        .mockImplementation((_fn: string, err: unknown) => err);
+
+      jest.spyOn(service as any, 'getGroupByName').mockResolvedValue([]);
+
+      mockKcAdminClient.clients.listResources.mockResolvedValue([
+        { _id: 'resource-id-1' },
+      ]);
+      mockKcAdminClient.clients.delResource.mockResolvedValue(undefined);
+
+      // orphan policies returned AFTER resource delete
+      jest.spyOn(service as any, 'getProjectPolicies').mockResolvedValue([
+        { id: 'scope-1', name: `Analysis ${projectId}`, type: 'scope' },
+        { id: 'user-1', name: `Analysis of ${projectId}`, type: 'user' },
+      ]);
+
+      jest.spyOn(service as any, 'isNotFound').mockReturnValue(false);
+
+      // Make one delete fail with non-404
+      const err500 = { response: { status: 500 }, message: 'boom' };
+      mockKcAdminClient.clients.delPolicy
+        .mockRejectedValueOnce(err500)
+        .mockResolvedValueOnce(undefined);
+
+      const res = await service.deleteResource(projectId);
+
+      // Resource delete happens BEFORE orphan cleanup
+      expect(mockKcAdminClient.clients.delResource).toHaveBeenCalledWith({
+        id: 'client-uuid',
+        resourceId: 'resource-id-1',
+        realm: 'test-realm',
+      });
+
+      // Then it tries to delete orphan policies
+      expect(mockKcAdminClient.clients.delPolicy).toHaveBeenCalled();
+
+      // Non-404 failure should be treated as error and routed via handleKeycloakError
+      expect(handleSpy).toHaveBeenCalledWith(
+        'deleteResource',
+        expect.anything(),
+      );
+      expect(res).toBeTruthy();
     });
   });
 });

--- a/src/admin/keycloak/keycloak-admin.service.ts
+++ b/src/admin/keycloak/keycloak-admin.service.ts
@@ -27,6 +27,7 @@ import {
   analysisPolicyPrefix,
   analysisPermissionPrefix,
   analysisPermissions,
+  groupPrefix,
 } from 'src/utils/options.util';
 
 import {
@@ -579,27 +580,101 @@ export class KeycloakAdminService implements OnModuleInit {
     return { access_token: token || '' };
   }
 
-  //FIXME: not working properly
-  async deleteResource(id: string) {
-    this.logger.debug('Deleting resource', id);
+  async deleteResource(projectId: string) {
+    const resourceName = `${resourcePrefix}${projectId}`;
     try {
-      if (this.defaultClient) {
-        this.logger.debug(
-          `Deleting resource ${id}, for client ${this.defaultClient.id}`,
+      if (!this.defaultClient?.id) return;
+      this.logger.debug(
+        `Deleting resource ${resourceName}, for client ${this.defaultClient.id}...`,
+      );
+      // check if resource/project exists
+      const resources = await this.kcAdminClient.clients.listResources(
+        {
+          name: resourceName,
+          id: this.defaultClient.id,
+          realm: this.config.realm,
+        },
+        { catchNotFound: false },
+      );
+      if (!resources.length) {
+        throw new KeycloakNotFoundError(
+          `Keycloak resource '${resourceName}' does not exist`,
         );
-        const deleteResource = await this.kcAdminClient.clients.delResource({
-          id: this.defaultClient.id!,
-          resourceId: id,
+      }
+      // delete resource
+      // note that this will also delete any permissions/leaf policies attached
+      await this.kcAdminClient.clients.delResource({
+        id: this.defaultClient.id,
+        resourceId: resources[0]._id!,
+        realm: this.config.realm,
+      });
+
+      // remove any remaining policies (orphans)
+      const policies = await this.getProjectPolicies(projectId);
+      if (policies.length) {
+        const results = await Promise.allSettled(
+          policies.map((p) =>
+            this.kcAdminClient.clients.delPolicy({
+              id: this.defaultClient.id!,
+              policyId: p.id!,
+              realm: this.config.realm,
+            }),
+          ),
+        );
+
+        const failures = results
+          .map((r, i) => ({ r, p: policies[i] }))
+          .filter(({ r }) => r.status === 'rejected')
+          .filter(
+            ({ r }) => !this.isNotFound((r as PromiseRejectedResult).reason),
+          );
+
+        if (failures.length) {
+          throw new KeycloakAdminError(
+            `Failed to delete ${failures.length} remaining policies`,
+            failures.map((f) => ({
+              id: f.p.id,
+              name: f.p.name,
+              type: f.p.type,
+              reason: f.r,
+            })),
+          );
+        }
+      }
+      // delete group for this resource
+      const group = await this.getGroupByName(`${groupPrefix}${projectId}`);
+      if (group.length)
+        await this.kcAdminClient.groups.del({
+          id: group[0].id!,
           realm: this.config.realm,
         });
-        // const group = await this.getGroupByName(`${groupPrefix}${id}`);
-        // if (group.length)
-        //   await this.kcAdminClient.groups.del({ id: group[0].id });
-        return deleteResource;
-      }
     } catch (error) {
-      return this.handleKeycloakError('createPermission', error);
+      return this.handleKeycloakError('deleteResource', error);
     }
+  }
+
+  async getProjectPolicies(projectId: string) {
+    const policiesQuery = await this.kcAdminClient.clients.listPolicies(
+      {
+        id: this.defaultClient.id!,
+        realm: this.config.realm,
+      },
+      { catchNotFound: false },
+    );
+    const policies = Array.isArray(policiesQuery) ? policiesQuery : [];
+    return policies.filter(
+      (p) => typeof p.name === 'string' && p.name.includes(projectId),
+    );
+  }
+
+  private isNotFound(error: unknown): boolean {
+    const err = error as {
+      response?: { status?: number; data?: unknown };
+      code?: string;
+      message?: string;
+    };
+    const status = err?.response?.status ?? err?.code;
+    return status === 404;
   }
 
   private handleKeycloakError(context: string, error: unknown): never {

--- a/src/project/project.service.spec.ts
+++ b/src/project/project.service.spec.ts
@@ -59,6 +59,7 @@ describe('ProjectService', () => {
     newResource: jest.fn(),
     auth: jest.fn(),
     getUserById: jest.fn(),
+    deleteResource: jest.fn(),
   } as unknown as KeycloakAdminService;
 
   const vaultMock = {
@@ -537,7 +538,7 @@ describe('ProjectService', () => {
 
       (prismaMock.project.delete as jest.Mock).mockResolvedValue(deleted);
 
-      const result = await service.deleteProject(projectId);
+      await service.deleteProject(projectId);
 
       expect(prismaMock.project.delete).toHaveBeenCalledWith({
         where: { projectId },
@@ -546,7 +547,6 @@ describe('ProjectService', () => {
           analysis: true,
         },
       });
-      expect(result).toEqual(deleted);
     });
   });
 

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -513,7 +513,8 @@ export class ProjectService {
   }
 
   async deleteProject(projectId: string) {
-    return await this.prisma.project.delete({
+    // delete project information
+    await this.prisma.project.delete({
       where: {
         projectId: projectId,
       },
@@ -522,6 +523,10 @@ export class ProjectService {
         analysis: true,
       },
     });
+    // delete keycloak resource
+    await this.keycloak.auth();
+    await this.keycloak.deleteResource(projectId);
+    return;
   }
 
   async updateCredentials(


### PR DESCRIPTION
Expanded delete project with also deleting Keycloak resource, group, policies and permissions that link to that project.


**Future:**
We might want to move the `delete-resource` as a background process if it has performance issues.