### PR TITLE
refactor: return archetype author name instead of the user id

### DIFF
--- a/src/archetype/archetype.service.spec.ts
+++ b/src/archetype/archetype.service.spec.ts
@@ -19,11 +19,13 @@ import {
 import { ArchetypeNodeType, ArchetypePermission, ArchetypeStatus } from './dto';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { $Enums } from 'src/generated/prisma/client';
+import { KeycloakAdminService } from 'src/admin/keycloak/keycloak-admin.service';
 
 describe('ArchetypeService', () => {
   let service: ArchetypeService;
   let atlas: jest.Mocked<AtlasService>;
   let prisma: jest.Mocked<PrismaService>;
+  let keycloak: jest.Mocked<KeycloakAdminService>;
   let moduleRef: TestingModule;
 
   const mockQueue = {} as unknown as jest.Mocked<QueueService>;
@@ -45,12 +47,19 @@ describe('ArchetypeService', () => {
           },
         },
         { provide: QueueService, useValue: mockQueue },
+        {
+          provide: KeycloakAdminService,
+          useValue: {
+            getUserInfoById: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
     service = moduleRef.get(ArchetypeService);
     atlas = moduleRef.get(AtlasService);
     prisma = moduleRef.get(PrismaService);
+    keycloak = moduleRef.get(KeycloakAdminService);
     jest.clearAllMocks();
   });
 
@@ -117,6 +126,16 @@ describe('ArchetypeService', () => {
 
       atlas.post.mockResolvedValueOnce(atlasResponse);
 
+      // mock keycloak lookup for owner -> we'll prefer `username` in display logic
+      (keycloak.getUserInfoById as jest.Mock).mockResolvedValue({
+        id: 'owner',
+        username: 'ownerUser',
+        firstName: 'Owner',
+        lastName: 'User',
+        email: 'owner@example.com',
+        lastLogin: null,
+      } as any);
+
       const result = await service.fetchArchetypes(projectId, token);
 
       // Assert atlas.post called with endpoint, body, token
@@ -155,7 +174,7 @@ describe('ArchetypeService', () => {
         id: 'Xa7BAIWZCA8u',
         name: 'Test Draft Update 8',
         status: 'DRAFT',
-        createdBy: 'owner',
+        createdBy: 'Owner User',
         created: new Date(ts),
         lastModified: new Date(modTs),
       });
@@ -163,10 +182,13 @@ describe('ArchetypeService', () => {
         id: 'Xmh_T6fKZnqY',
         name: 'Details Updated 6',
         status: 'PUBLISHED',
-        createdBy: 'owner',
+        createdBy: 'Owner User',
         created: new Date(ts + 1000),
         lastModified: new Date(modTs + 1000),
       });
+
+      expect(keycloak.getUserInfoById).toHaveBeenCalledTimes(1);
+      expect(keycloak.getUserInfoById).toHaveBeenCalledWith('owner');
     });
 
     it('returns [] when response has no entities', async () => {

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -29,6 +29,7 @@ import {
   AtlasSearchBasicResponseDto,
 } from 'src/atlas/dto';
 import { AnalysisArchetypeResponseDto } from 'src/analysis/dto';
+import { KeycloakAdminService } from 'src/admin/keycloak/keycloak-admin.service';
 
 @Injectable()
 export class ArchetypeService {
@@ -37,6 +38,7 @@ export class ArchetypeService {
     private atlas: AtlasService,
     private readonly queue: QueueService,
     private prisma: PrismaService,
+    private keycloak: KeycloakAdminService,
   ) {}
 
   // Queries
@@ -68,13 +70,50 @@ export class ArchetypeService {
       body,
       token,
     );
+
     const entities = res?.entities ?? [];
+
+    const ownerIds = Array.from(
+      new Set(
+        entities
+          .map((e) => e.attributes?.owner)
+          .filter((v): v is string => typeof v === 'string' && v.length > 0),
+      ),
+    );
+
+    const userFetchResults = await Promise.allSettled(
+      ownerIds.map((ownerId) =>
+        this.keycloak.getUserInfoById(ownerId).catch((err) => {
+          this.logger?.debug?.(
+            `Failed to fetch Keycloak user ${ownerId} for archetypes: ${String(
+              err,
+            )}`,
+          );
+          return null;
+        }),
+      ),
+    );
+
+    const ownerIdToName = new Map<string, string>();
+    for (let i = 0; i < ownerIds.length; i++) {
+      const ownerId = ownerIds[i];
+      const r = userFetchResults[i];
+      if (r.status === 'fulfilled' && r.value) {
+        const user = r.value;
+        const display = `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim();
+        ownerIdToName.set(ownerId, display);
+      } else {
+        ownerIdToName.set(ownerId, ownerId);
+      }
+    }
     return entities.map((entity) => ({
       // use nanoid as the archetypeID
       id: (entity.attributes!.qualifiedName as string).split('@').at(-1),
       name: entity.displayText,
       status: entity.attributes!.status,
-      createdBy: entity.attributes!.owner,
+      createdBy: entity.attributes!.owner
+        ? ownerIdToName.get(entity.attributes!.owner as string)
+        : entity.attributes!.owner,
       created: new Date(entity.attributes!.__timestamp as number),
       lastModified: new Date(
         entity.attributes!.__modificationTimestamp as number,


### PR DESCRIPTION
Return the user's first name and last name instead of the user's id when fetching the archetype list for a project