### PR TITLE
[DRAFT] feat(api): Archetype Generation Endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "clean-install": "pnpm i && pnpm prune && pnpm store prune"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.65.0",
     "@aws-sdk/client-s3": "^3.925.0",
     "@aws-sdk/s3-request-presigner": "^3.925.0",
     "@epsilon-data/epsilon-api-middleware": "^0.0.4",
@@ -55,8 +56,10 @@
     "@prisma/adapter-pg": "^7.0.1",
     "@prisma/client": "^7.0.1",
     "@prisma/client-runtime-utils": "7.0.1",
+    "@types/chroma-js": "^3.1.2",
     "axios": "^1.13.2",
     "bull": "^4.16.5",
+    "chroma-js": "^3.1.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",
     "cookie-parser": "^1.4.7",
@@ -68,13 +71,16 @@
     "multer": "^2.0.2",
     "nanoid": "^5.1.6",
     "node-fetch": "^3.3.2",
+    "openai": "^4.98.0",
+    "pdf-parse": "^1.1.1",
     "pg": "^8.16.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "socket.io": "^4.8.1",
     "swagger-ui-express": "^5.0.1",
     "typeorm": "^0.3.27",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "zod-to-json-schema": "^3.24.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -106,6 +112,9 @@
     "tsx": "^4.20.6",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.20.0"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.65.0
+        version: 0.65.0(zod@3.25.76)
       '@aws-sdk/client-s3':
         specifier: ^3.925.0
         version: 3.925.0
@@ -67,12 +70,18 @@ importers:
       '@prisma/client-runtime-utils':
         specifier: 7.0.1
         version: 7.0.1
+      '@types/chroma-js':
+        specifier: ^3.1.2
+        version: 3.1.2
       axios:
         specifier: ^1.13.2
         version: 1.13.2
       bull:
         specifier: ^4.16.5
         version: 4.16.5
+      chroma-js:
+        specifier: ^3.1.2
+        version: 3.2.0
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -106,6 +115,12 @@ importers:
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
+      openai:
+        specifier: ^4.98.0
+        version: 4.104.0(zod@3.25.76)
+      pdf-parse:
+        specifier: ^1.1.1
+        version: 1.1.4
       pg:
         specifier: ^8.16.3
         version: 8.16.3
@@ -127,6 +142,12 @@ importers:
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
+      zod-to-json-schema:
+        specifier: ^3.24.6
+        version: 3.25.1(zod@3.25.76)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.2.0
@@ -248,6 +269,15 @@ packages:
   '@angular-devkit/schematics@19.2.17':
     resolution: {integrity: sha512-ADfbaBsrG8mBF6Mfs+crKA/2ykB8AJI50Cv9tKmZfwcUcyAdmTr+vVvhsBCfvUAEokigSsgqgpYxfkJVxhJYeg==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
+
+  '@anthropic-ai/sdk@0.65.0':
+    resolution: {integrity: sha512-zIdPOcrCVEI8t3Di40nH4z9EoeyGZfXbYSvWdDLsB/KkaSYMnEgC7gmcgWu83g2NTn1ZTpbMvpdttWDGGIk6zw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -561,6 +591,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
@@ -1727,6 +1761,9 @@ packages:
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
+  '@types/chroma-js@3.1.2':
+    resolution: {integrity: sha512-YBTQqArPN8A0niHXCwrO1z5x++a+6l0mLBykncUpr23oIPW7L4h39s6gokdK/bDrPmSh8+TjMmrhBPnyiaWPmQ==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
@@ -1777,6 +1814,12 @@ packages:
 
   '@types/multer@2.0.0':
     resolution: {integrity: sha512-C3Z9v9Evij2yST3RSBktxP9STm6OdMc5uR1xF1SGr98uv8dUlAL2hqwrZ3GVB3uyMyiegnscEK6PGtYvNrjTjw==}
+
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
   '@types/node@20.19.24':
     resolution: {integrity: sha512-FE5u0ezmi6y9OZEzlJfg37mqqf6ZDSF2V/NLjUyGrR9uTZ7Sb9F7bLNZ03S4XVUNRWGA7Ck4c1kK+YnuWjl+DA==}
@@ -2031,6 +2074,10 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -2062,6 +2109,10 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -2385,12 +2436,15 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  chroma-js@3.2.0:
+    resolution: {integrity: sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==}
+
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
 
-  chromedriver@142.0.3:
-    resolution: {integrity: sha512-1Ibm/tuJRTaIpRfGi6M3IEb61CAlPirkFHvfiLiiu3h8OEtJFKat/FSr8Rn8pBsJlCCRlb5UWdj+nZeAmRLQUg==}
+  chromedriver@144.0.0:
+    resolution: {integrity: sha512-/tJRUsIroqvqlOMstecDXYIJpq0r441tIOnk951rAbT7OCMRZB98StG+NWp0m31TIKwuizOZobr/PP7ekVaSig==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2937,6 +2991,10 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
@@ -3081,9 +3139,16 @@ packages:
       typescript: '>3.6.0'
       webpack: ^5.11.0
 
+  form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
+
+  formdata-node@4.4.1:
+    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
+    engines: {node: '>= 12.20'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -3309,6 +3374,9 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -3711,6 +3779,10 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -4037,8 +4109,20 @@ packages:
   node-emoji@1.11.0:
     resolution: {integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==}
 
+  node-ensure@0.0.0:
+    resolution: {integrity: sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==}
+
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
@@ -4112,6 +4196,18 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  openai@4.104.0:
+    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -4211,6 +4307,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pdf-parse@1.1.4:
+    resolution: {integrity: sha512-XRIRcLgk6ZnUbsHsYXExMw+krrPE81hJ6FQPLdBNhhBefqIQKXu/WeTgNBGSwPrfU0v+UCEwn7AoAUOsVKHFvQ==}
+    engines: {node: '>=6.8.1'}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -4940,9 +5040,15 @@ packages:
     resolution: {integrity: sha512-kh9LVIWH5CnL63Ipf0jhlBIy0UsrMj/NJDfpsy1SqOXlLKEVyXXYrnFxFT1yOOYVGBSApeVnjPw/sBz5BfEjAQ==}
     engines: {node: '>=14.16'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -5150,6 +5256,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -5244,6 +5353,13 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  web-streams-polyfill@4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webpack-node-externals@3.0.0:
     resolution: {integrity: sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==}
     engines: {node: '>=6'}
@@ -5261,6 +5377,9 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -5371,6 +5490,14 @@ packages:
   zeptomatch@2.0.2:
     resolution: {integrity: sha512-H33jtSKf8Ijtb5BW6wua3G5DhnFjbFML36eFu+VdOoVY4HD9e7ggjqdM6639B+L87rjnR6Y+XeRzBXZdy52B/g==}
 
+  zod-to-json-schema@3.25.1:
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
 snapshots:
 
   '@angular-devkit/core@19.2.15(chokidar@4.0.3)':
@@ -5426,6 +5553,12 @@ snapshots:
       rxjs: 7.8.1
     transitivePeerDependencies:
       - chokidar
+
+  '@anthropic-ai/sdk@0.65.0(zod@3.25.76)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 3.25.76
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -6075,6 +6208,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/runtime@7.28.6': {}
 
   '@babel/template@7.27.2':
     dependencies:
@@ -7472,6 +7607,8 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/node': 22.19.0
 
+  '@types/chroma-js@3.1.2': {}
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 22.19.0
@@ -7533,6 +7670,15 @@ snapshots:
   '@types/multer@2.0.0':
     dependencies:
       '@types/express': 5.0.5
+
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 22.19.0
+      form-data: 4.0.4
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
 
   '@types/node@20.19.24':
     dependencies:
@@ -7826,6 +7972,10 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -7852,6 +8002,10 @@ snapshots:
 
   agent-base@7.1.4:
     optional: true
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
 
   ajv-formats@2.1.1(ajv@8.17.1):
     optionalDependencies:
@@ -8231,9 +8385,11 @@ snapshots:
 
   chownr@1.1.4: {}
 
+  chroma-js@3.2.0: {}
+
   chrome-trace-event@1.0.4: {}
 
-  chromedriver@142.0.3:
+  chromedriver@144.0.0:
     dependencies:
       '@testim/chrome-version': 1.1.4
       axios: 1.13.2
@@ -8842,6 +8998,8 @@ snapshots:
 
   etag@1.8.1: {}
 
+  event-target-shim@5.0.1: {}
+
   eventemitter3@5.0.1: {}
 
   events@3.3.0: {}
@@ -9087,6 +9245,8 @@ snapshots:
       typescript: 5.8.3
       webpack: 5.100.2
 
+  form-data-encoder@1.7.2: {}
+
   form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
@@ -9094,6 +9254,11 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+
+  formdata-node@4.4.1:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 4.0.0-beta.3
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -9332,6 +9497,10 @@ snapshots:
     optional: true
 
   human-signals@2.1.0: {}
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
 
   iconv-lite@0.4.24:
     dependencies:
@@ -9917,6 +10086,11 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.28.6
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -9943,7 +10117,7 @@ snapshots:
     dependencies:
       jwk-to-pem: 2.0.7
     optionalDependencies:
-      chromedriver: 142.0.3
+      chromedriver: 144.0.0
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -10210,7 +10384,13 @@ snapshots:
     dependencies:
       lodash: 4.17.21
 
+  node-ensure@0.0.0: {}
+
   node-fetch-native@1.6.7: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-fetch@3.3.2:
     dependencies:
@@ -10294,6 +10474,20 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  openai@4.104.0(zod@3.25.76):
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    optionalDependencies:
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - encoding
 
   optionator@0.9.4:
     dependencies:
@@ -10406,6 +10600,10 @@ snapshots:
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
+
+  pdf-parse@1.1.4:
+    dependencies:
+      node-ensure: 0.0.0
 
   pend@1.2.0:
     optional: true
@@ -11235,7 +11433,11 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
+  tr46@0.0.3: {}
+
   tree-kill@1.2.2: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
@@ -11426,6 +11628,8 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  undici-types@5.26.5: {}
+
   undici-types@6.21.0: {}
 
   universalify@2.0.1: {}
@@ -11518,6 +11722,10 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  web-streams-polyfill@4.0.0-beta.3: {}
+
+  webidl-conversions@3.0.1: {}
+
   webpack-node-externals@3.0.0: {}
 
   webpack-sources@3.3.3: {}
@@ -11553,6 +11761,11 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -11675,3 +11888,9 @@ snapshots:
   zeptomatch@2.0.2:
     dependencies:
       grammex: 3.1.12
+
+  zod-to-json-schema@3.25.1(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod@3.25.76: {}

--- a/src/archetype/archetype.controller.ts
+++ b/src/archetype/archetype.controller.ts
@@ -7,11 +7,14 @@ import {
   HttpStatus,
   Logger,
   Param,
+  ParseFilePipe,
   ParseUUIDPipe,
   Patch,
   Post,
   Put,
+  UploadedFile,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 import { ArchetypeService } from './archetype.service';
 import {
@@ -40,6 +43,7 @@ import { Resource } from 'src/common/decorators/resource.decorator';
 import { Scopes } from 'src/common/decorators/scopes.decorator';
 import { ResourceGuard } from 'src/common/guards/resource.guard';
 import { GenericErrorResponseDto } from 'src/common/dto';
+import { FileInterceptor } from '@nestjs/platform-express';
 
 @ApiTags('Archetype')
 @ApiBearerAuth()
@@ -285,5 +289,64 @@ export class ArchetypeController {
     @Param('archetypeId') archetypeId: string,
   ) {
     return await this.archetypeService.deleteArchetype(projectId, archetypeId);
+  }
+
+  @UseGuards(ResourceGuard)
+  @Scopes('view', 'edit')
+  @Post(':projectId/upload-codebook')
+  @UseInterceptors(FileInterceptor('file'))
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ApiOperation({
+    summary: 'Upload codebook PDF and generate archetype graph (async)',
+  })
+  @ApiAcceptedResponse({
+    description: 'Upload accepted, returns jobId for polling',
+    schema: {
+      type: 'object',
+      properties: {
+        jobId: {
+          type: 'string',
+          example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+        },
+      },
+    },
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid file format or size',
+    type: GenericErrorResponseDto,
+  })
+  uploadCodebookAndGenerateGraph(
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+    @UploadedFile(new ParseFilePipe()) file: Express.Multer.File,
+  ) {
+    const jobId = this.archetypeService.processCodebookUpload(projectId, file);
+
+    return { jobId };
+  }
+
+  @Get('jobs/:jobId')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Get upload job status and result' })
+  @ApiOkResponse({
+    description: 'Job status and result',
+    schema: {
+      type: 'object',
+      properties: {
+        status: {
+          type: 'string',
+          enum: ['pending', 'processing', 'completed', 'failed'],
+        },
+        result: {
+          type: 'object',
+          properties: {
+            nodes: { type: 'array' },
+            edges: { type: 'array' },
+          },
+        },
+      },
+    },
+  })
+  getUploadJobStatus(@Param('jobId') jobId: string) {
+    return this.archetypeService.getUploadJobStatus(jobId);
   }
 }

--- a/src/archetype/archetype.controller.ts
+++ b/src/archetype/archetype.controller.ts
@@ -323,30 +323,4 @@ export class ArchetypeController {
 
     return { jobId };
   }
-
-  @Get('jobs/:jobId')
-  @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Get upload job status and result' })
-  @ApiOkResponse({
-    description: 'Job status and result',
-    schema: {
-      type: 'object',
-      properties: {
-        status: {
-          type: 'string',
-          enum: ['pending', 'processing', 'completed', 'failed'],
-        },
-        result: {
-          type: 'object',
-          properties: {
-            nodes: { type: 'array' },
-            edges: { type: 'array' },
-          },
-        },
-      },
-    },
-  })
-  getUploadJobStatus(@Param('jobId') jobId: string) {
-    return this.archetypeService.getUploadJobStatus(jobId);
-  }
 }

--- a/src/archetype/archetype.module.ts
+++ b/src/archetype/archetype.module.ts
@@ -2,9 +2,19 @@ import { forwardRef, Module } from '@nestjs/common';
 import { ArchetypeService } from './archetype.service';
 import { ArchetypeController } from './archetype.controller';
 import { DatabaseModule } from 'src/database/database.module';
+import { UploadModule } from 'src/upload/upload.module';
+import { JobsModule } from 'src/jobs/jobs.module';
+import { GraphModule } from 'src/graph/graph.module';
+import { LlmModule } from 'src/llm/llm.module';
 
 @Module({
-  imports: [forwardRef(() => DatabaseModule)],
+  imports: [
+    forwardRef(() => DatabaseModule),
+    UploadModule,
+    JobsModule,
+    GraphModule,
+    LlmModule,
+  ],
   controllers: [ArchetypeController],
   providers: [ArchetypeService],
   exports: [ArchetypeService],

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -29,6 +29,8 @@ import {
   AtlasSearchBasicResponseDto,
 } from 'src/atlas/dto';
 import { AnalysisArchetypeResponseDto } from 'src/analysis/dto';
+import { UploadService } from 'src/upload/upload.service';
+import { JobsService } from 'src/jobs/jobs.service';
 
 @Injectable()
 export class ArchetypeService {
@@ -37,6 +39,8 @@ export class ArchetypeService {
     private atlas: AtlasService,
     private readonly queue: QueueService,
     private prisma: PrismaService,
+    private readonly uploadService: UploadService,
+    private readonly jobService: JobsService,
   ) {}
 
   // Queries
@@ -610,6 +614,22 @@ export class ArchetypeService {
       archetypeId,
       archetype,
     );
+  }
+
+  processCodebookUpload(projectId: string, file: Express.Multer.File): string {
+    this.logger.log(`Processing codebook upload for project ${projectId}`);
+
+    // Queue the PDF processing job
+    const jobId = this.uploadService.processFile(
+      file,
+      `Project: ${projectId}`, // context for LLM
+    );
+
+    return jobId;
+  }
+
+  getUploadJobStatus(jobId: string) {
+    return this.jobService.status(jobId);
   }
 
   // private methods

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -8,6 +8,8 @@ const trustedWebOrigins = () =>
     .split(',')
     .map((origin) => origin.trim());
 
+const UPLOAD_MAX_FILE_SIZE = 10 * 1024 * 1024;
+
 export default () => ({
   appUrl: env.APP_URL || 'http://localhost:3000',
   isDev: env.NODE_ENV === 'development' ? true : false,
@@ -67,4 +69,15 @@ export default () => ({
     env.EPSILON_TOKEN_ENDPOINT ||
     'http://keycloak:8080/realms/epsilon/protocol/openid-connect/token',
   keystoreUrl: env.VAULT_API_ADDR || 'http://0.0.0.0:8200',
+  openai: {
+    apiKey: process.env.OPENAI_API_KEY,
+  },
+  defaultProvider: process.env.DEFAULT_PROVIDER || 'openai',
+  modelWhitelist: {
+    openai: ['gpt-5-mini-2025-08-07', 'gpt-5-2025-08-07'],
+  },
+  upload: {
+    maxSize: UPLOAD_MAX_FILE_SIZE,
+    tmpDir: '/tmp/archetype-discovery',
+  },
 });

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -70,9 +70,9 @@ export default () => ({
     'http://keycloak:8080/realms/epsilon/protocol/openid-connect/token',
   keystoreUrl: env.VAULT_API_ADDR || 'http://0.0.0.0:8200',
   openai: {
-    apiKey: process.env.OPENAI_API_KEY,
+    apiKey: env.OPENAI_API_KEY || 'OPENAI_API_KEY must be set',
   },
-  defaultProvider: process.env.DEFAULT_PROVIDER || 'openai',
+  defaultProvider: env.DEFAULT_PROVIDER || 'openai',
   modelWhitelist: {
     openai: ['gpt-5-mini-2025-08-07', 'gpt-5-2025-08-07'],
   },

--- a/src/docker/docker.service.ts
+++ b/src/docker/docker.service.ts
@@ -164,6 +164,7 @@ export class DockerService {
       // run runDataBroker function should remove the container
       HostConfig: {
         AutoRemove: false,
+        // ExtraHosts: ['host.docker.internal:host-gateway'], // fixes the `lookup host.docker.internal on 127.0.0.11:53: no such host` error
       },
       // only for dev + testing
       NetworkingConfig: {

--- a/src/graph/graph.module.ts
+++ b/src/graph/graph.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { GraphService } from './graph.service';
+import { LlmModule } from '../llm/llm.module';
+
+@Module({
+  imports: [LlmModule],
+  providers: [GraphService],
+  exports: [GraphService],
+})
+export class GraphModule {}

--- a/src/graph/graph.service.spec.ts
+++ b/src/graph/graph.service.spec.ts
@@ -1,0 +1,134 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Test, TestingModule } from '@nestjs/testing';
+import { GraphService } from './graph.service';
+import { LlmService } from '../llm/llm.service';
+import { GraphPayload } from './types';
+
+describe('GraphService', () => {
+  let service: GraphService;
+  let llmService: jest.Mocked<LlmService>;
+
+  const mockAnalyseFileResponse: GraphPayload = {
+    nodes: [
+      { id: 'node_1', label: 'Root', depth: 0, colour: '#0ea5e9' },
+      { id: 'node_2', label: 'Child A', depth: 1, colour: '#eab308' },
+      { id: 'node_3', label: 'Child B', depth: 1, colour: '#eab308' },
+      { id: 'node_4', label: 'Grandchild', depth: 2, colour: '#ec4899' },
+    ],
+    edges: [
+      { source: 'node_1', target: 'node_2' },
+      { source: 'node_1', target: 'node_3' },
+      { source: 'node_2', target: 'node_4' },
+    ],
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GraphService,
+        {
+          provide: LlmService,
+          useValue: {
+            analyseFile: jest.fn(), // im not calling the actual function so we dont use up tokens
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(GraphService);
+    llmService = module.get(LlmService);
+
+    jest.clearAllMocks();
+  });
+
+  describe('generateGraphFromFile', () => {
+    it('should assign colours scaled by depth and return nodes with edges', async () => {
+      llmService.analyseFile.mockResolvedValueOnce(mockAnalyseFileResponse);
+
+      const result = await service.generateGraphFromFile(
+        'test.pdf',
+        '/tmp/test.pdf',
+        'application/pdf',
+        'some context',
+        'some-model-id',
+      );
+
+      expect(llmService.analyseFile).toHaveBeenCalledTimes(1);
+      expect(llmService.analyseFile).toHaveBeenCalledWith(
+        'test.pdf',
+        '/tmp/test.pdf',
+        'application/pdf',
+        'some context',
+        'some-model-id',
+      );
+
+      expect(result.edges).toEqual(mockAnalyseFileResponse.edges);
+
+      expect(result.nodes).toHaveLength(4);
+      result.nodes.forEach((node, i) => {
+        expect(node.id).toBe(mockAnalyseFileResponse.nodes[i].id);
+        expect(node.label).toBe(mockAnalyseFileResponse.nodes[i].label);
+        expect(node.depth).toBe(mockAnalyseFileResponse.nodes[i].depth);
+      });
+
+      // colour is valid hex
+      result.nodes.forEach((node) => {
+        expect(node.colour).toMatch(/^#[0-9a-f]{6}$/i);
+      });
+
+      const rootColour = result.nodes.find((n) => n.depth === 0)?.colour;
+      const leafColour = result.nodes.find((n) => n.depth === 2)?.colour;
+      expect(rootColour).not.toBe(leafColour);
+    });
+
+    it('should handle a single node at depth 0', async () => {
+      llmService.analyseFile.mockResolvedValueOnce({
+        nodes: [{ id: 'solo', label: 'Alone', depth: 0, colour: '#ec4899' }],
+        edges: [],
+      });
+
+      const result = await service.generateGraphFromFile(
+        'single.pdf',
+        '/tmp/single.pdf',
+        'application/pdf',
+      );
+
+      expect(result.nodes).toHaveLength(1);
+      expect(result.nodes[0].colour).toMatch(/^#[0-9a-f]{6}$/i);
+      expect(result.edges).toEqual([]);
+    });
+
+    it('should work when optional context and modelId are not present', async () => {
+      llmService.analyseFile.mockResolvedValueOnce(mockAnalyseFileResponse);
+
+      const result = await service.generateGraphFromFile(
+        'test.pdf',
+        '/tmp/test.pdf',
+        'application/pdf',
+        // no context, no modelId
+      );
+
+      expect(llmService.analyseFile).toHaveBeenCalledWith(
+        'test.pdf',
+        '/tmp/test.pdf',
+        'application/pdf',
+        undefined,
+        undefined,
+      );
+
+      expect(result.nodes).toHaveLength(4);
+    });
+
+    it('should propagate errors thrown by analyseFile', async () => {
+      llmService.analyseFile.mockRejectedValueOnce(new Error('API timeout'));
+
+      await expect(
+        service.generateGraphFromFile(
+          'bad.pdf',
+          '/tmp/bad.pdf',
+          'application/pdf',
+        ),
+      ).rejects.toThrow('API timeout');
+    });
+  });
+});

--- a/src/graph/graph.service.ts
+++ b/src/graph/graph.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, Logger } from '@nestjs/common';
+import chroma, { Color } from 'chroma-js';
+import { LlmService } from '../llm/llm.service';
+import { GraphNode, GraphPayload } from './types';
+
+@Injectable()
+export class GraphService {
+  private readonly logger = new Logger('GraphService');
+
+  constructor(private readonly llm: LlmService) {}
+
+  async generateGraphFromFile(
+    filename: string,
+    filePath: string,
+    mimetype: string,
+    context?: string,
+    modelId?: string,
+  ): Promise<GraphPayload> {
+    const raw = await this.llm.analyseFile(
+      filename,
+      filePath,
+      mimetype,
+      context,
+      modelId,
+    );
+
+    this.logger.log(
+      `Raw graph data received: ${JSON.stringify(raw)}, type of raw data: ${typeof raw}`,
+    );
+
+    const palette: chroma.Scale<Color> = chroma
+      .scale(['#0ea5e9', '#eab308', '#ec4899'])
+      .mode('lch');
+    // Make color scaling more dynamic based on actual max depth
+    const maxDepth = raw.nodes.reduce(
+      (max, node) => Math.max(max, node.depth),
+      0,
+    );
+    const nodes: GraphNode[] = raw.nodes.map((n) => ({
+      ...n,
+      colour: palette(maxDepth > 0 ? n.depth / maxDepth : 0).hex(),
+    }));
+
+    return { nodes, edges: raw.edges };
+  }
+}

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -1,0 +1,55 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GraphNode {
+  @ApiProperty({
+    description: 'Unique node identifier',
+    example: 'node-1',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'Node label text',
+    example: 'Root Category',
+  })
+  label: string;
+
+  @ApiProperty({
+    description: 'Hierarchical depth (0 = root)',
+    example: 0,
+  })
+  depth: number;
+
+  @ApiProperty({
+    description: 'Node color in hex format',
+    example: '#0ea5e9',
+  })
+  colour: string;
+}
+
+export class GraphEdge {
+  @ApiProperty({
+    description: 'Source node ID (parent)',
+    example: 'node-1',
+  })
+  source: string;
+
+  @ApiProperty({
+    description: 'Target node ID (child)',
+    example: 'node-2',
+  })
+  target: string;
+}
+
+export class GraphPayload {
+  @ApiProperty({
+    description: 'Graph nodes',
+    type: [GraphNode],
+  })
+  nodes: GraphNode[];
+
+  @ApiProperty({
+    description: 'Graph edges (parent → child)',
+    type: [GraphEdge],
+  })
+  edges?: GraphEdge[];
+}

--- a/src/jobs/dto/job-status.dto.ts
+++ b/src/jobs/dto/job-status.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { GraphPayload } from '../../graph/types';
+
+export class JobStatusPendingDto {
+  @ApiProperty({
+    description: 'Job status',
+    enum: ['pending'],
+    example: 'pending',
+  })
+  status: 'pending';
+}
+
+export class JobStatusCompletedDto {
+  @ApiProperty({
+    description: 'Job status',
+    enum: ['completed'],
+    example: 'completed',
+  })
+  status: 'completed';
+
+  @ApiProperty({
+    description: 'Analysis result with graph data',
+    type: GraphPayload,
+  })
+  result: GraphPayload;
+}
+
+export class JobStatusErrorDto {
+  @ApiProperty({
+    description: 'Job status',
+    enum: ['error'],
+    example: 'error',
+  })
+  status: 'error';
+
+  @ApiProperty({
+    description: 'Error message',
+    example: 'Failed to parse PDF file',
+  })
+  error: string;
+}
+
+export class JobStatusDto {
+  @ApiProperty({
+    description: 'Current job status',
+    enum: ['pending', 'completed', 'error'],
+    example: 'completed',
+  })
+  status: 'pending' | 'completed' | 'error';
+
+  @ApiPropertyOptional({
+    description: 'Analysis result (only present when status is completed)',
+    type: GraphPayload,
+  })
+  result?: GraphPayload;
+
+  @ApiPropertyOptional({
+    description: 'Error message (only present when status is error)',
+    example: 'Failed to parse PDF file',
+  })
+  error?: string;
+}

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -14,10 +14,12 @@ import {
   ApiParam,
   ApiResponse,
   ApiNotFoundResponse,
+  ApiBearerAuth,
 } from '@nestjs/swagger';
 import { JobStatusDto } from './dto/job-status.dto';
 
 @ApiTags('jobs')
+@ApiBearerAuth() // is this needed? idk if this api should be protected or not -Vincent
 @Controller('jobs')
 export class JobsController {
   constructor(private readonly jobs: JobsService) {}

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -1,0 +1,59 @@
+import {
+  Controller,
+  Get,
+  Param,
+  NotFoundException,
+  HttpStatus,
+  Res,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { JobsService } from './jobs.service';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiNotFoundResponse,
+} from '@nestjs/swagger';
+import { JobStatusDto } from './dto/job-status.dto';
+
+@ApiTags('jobs')
+@Controller('jobs')
+export class JobsController {
+  constructor(private readonly jobs: JobsService) {}
+
+  @Get(':id/status')
+  @ApiOperation({
+    summary: 'Get job status',
+    description:
+      'Check the status of an analysis job by ID. Returns pending (202), completed (200), or error (200).',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Job ID returned from file upload',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Job completed or errored',
+    type: JobStatusDto,
+  })
+  @ApiResponse({
+    status: 202,
+    description: 'Job still pending',
+    type: JobStatusDto,
+  })
+  @ApiNotFoundResponse({
+    description: 'Job ID not found',
+  })
+  getStatus(@Param('id') id: string, @Res() res: Response) {
+    const st = this.jobs.status(id);
+    if (!st) throw new NotFoundException('Job id not found');
+
+    if (st.status === 'pending') {
+      return res.status(HttpStatus.ACCEPTED).json(st);
+    }
+
+    return res.status(HttpStatus.OK).json(st);
+  }
+}

--- a/src/jobs/jobs.module.ts
+++ b/src/jobs/jobs.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { JobsService } from './jobs.service';
+import { JobsController } from './jobs.controller';
+
+@Module({
+  controllers: [JobsController],
+  providers: [JobsService],
+  exports: [JobsService],
+})
+export class JobsModule {}

--- a/src/jobs/jobs.service.spec.ts
+++ b/src/jobs/jobs.service.spec.ts
@@ -1,0 +1,224 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JobsService } from './jobs.service';
+
+describe('JobsService', () => {
+  let service: JobsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [JobsService],
+    }).compile();
+
+    service = module.get<JobsService>(JobsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('enqueue', () => {
+    it('should set job status to pending immediately', () => {
+      const jobId = 'job-1';
+      const fn = jest.fn().mockResolvedValue('result');
+
+      service.enqueue(jobId, fn);
+
+      const status = service.status(jobId);
+      expect(status).toEqual({ status: 'pending' });
+    });
+
+    it('should update status to completed when job succeeds', async () => {
+      const jobId = 'job-success';
+      const expectedResult = { data: 'success' };
+      const fn = jest.fn().mockResolvedValue(expectedResult);
+
+      service.enqueue(jobId, fn);
+
+      // wait for promise to resolve or else it wont change from pending to completed
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const status = service.status(jobId);
+      expect(status).toEqual({
+        status: 'completed',
+        result: expectedResult,
+      });
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should update status to error when job fails with Error', async () => {
+      const jobId = 'job-error';
+      const errorMessage = 'Something went wrong';
+      const fn = jest.fn().mockRejectedValue(new Error(errorMessage));
+
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      service.enqueue(jobId, fn);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const status = service.status(jobId);
+      expect(status).toEqual({
+        status: 'error',
+        error: errorMessage,
+      });
+      expect(consoleSpy).toHaveBeenCalledWith('Job failed', expect.any(Error));
+      expect(fn).toHaveBeenCalledTimes(1);
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should handle non-Error rejection with stringified value', async () => {
+      const jobId = 'job-non-error';
+      const errorObj = { code: 'ERR_UNKNOWN', details: 'Unknown failure' };
+      const fn = jest.fn().mockRejectedValue(errorObj);
+
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      service.enqueue(jobId, fn);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const status = service.status(jobId);
+      expect(status).toEqual({
+        status: 'error',
+        error: JSON.stringify(errorObj),
+      });
+      expect(consoleSpy).toHaveBeenCalledWith('Job failed', errorObj);
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should handle multiple jobs independently', async () => {
+      const job1Id = 'job-1';
+      const job2Id = 'job-2';
+      const fn1 = jest.fn().mockResolvedValue('result-1');
+      const fn2 = jest.fn().mockResolvedValue('result-2');
+
+      service.enqueue(job1Id, fn1);
+      service.enqueue(job2Id, fn2);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const status1 = service.status(job1Id);
+      const status2 = service.status(job2Id);
+
+      expect(status1).toEqual({ status: 'completed', result: 'result-1' });
+      expect(status2).toEqual({ status: 'completed', result: 'result-2' });
+    });
+
+    it('should overwrite existing job with same id', async () => {
+      const jobId = 'duplicate-job';
+      const fn1 = jest.fn().mockResolvedValue('first-result');
+      const fn2 = jest.fn().mockResolvedValue('second-result');
+
+      service.enqueue(jobId, fn1);
+      service.enqueue(jobId, fn2);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const status = service.status(jobId);
+      expect(status).toEqual({ status: 'completed', result: 'second-result' });
+      expect(fn1).toHaveBeenCalledTimes(1);
+      expect(fn2).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle async job function with delay', async () => {
+      const jobId = 'delayed-job';
+      const fn = jest
+        .fn()
+        .mockImplementation(
+          () =>
+            new Promise((resolve) =>
+              setTimeout(() => resolve('delayed-result'), 50),
+            ),
+        );
+
+      service.enqueue(jobId, fn);
+
+      // Check status is pending
+      let status = service.status(jobId);
+      expect(status).toEqual({ status: 'pending' });
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      status = service.status(jobId);
+      expect(status).toEqual({ status: 'completed', result: 'delayed-result' });
+    });
+  });
+
+  describe('status', () => {
+    it('should return undefined for non-existent job', () => {
+      const status = service.status('non-existent-job');
+      expect(status).toBeUndefined();
+    });
+
+    it('should return pending status for enqueued job', () => {
+      const jobId = 'pending-job';
+      const fn = jest.fn().mockImplementation(
+        () => new Promise(() => {}), // Never resolves
+      );
+
+      service.enqueue(jobId, fn);
+
+      const status = service.status(jobId);
+      expect(status).toEqual({ status: 'pending' });
+    });
+
+    it('should return completed status with result', async () => {
+      const jobId = 'completed-job';
+      const result = { id: 123, name: 'Test' };
+      const fn = jest.fn().mockResolvedValue(result);
+
+      service.enqueue(jobId, fn);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const status = service.status(jobId);
+      expect(status).toEqual({ status: 'completed', result });
+    });
+
+    it('should return error status with error message', async () => {
+      const jobId = 'error-job';
+      const fn = jest.fn().mockRejectedValue(new Error('Job failed'));
+
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      service.enqueue(jobId, fn);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const status = service.status(jobId);
+      expect(status).toEqual({ status: 'error', error: 'Job failed' });
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should return status with correct type inference', async () => {
+      const jobId = 'typed-job';
+      type CustomResult = { count: number; items: string[] };
+      const result: CustomResult = { count: 2, items: ['a', 'b'] };
+      const fn = jest.fn().mockResolvedValue(result);
+
+      service.enqueue<CustomResult>(jobId, fn);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const status = service.status<CustomResult>(jobId);
+      expect(status?.status).toBe('completed');
+      if (status?.status === 'completed') {
+        expect(status.result).toEqual(result);
+        expect(status.result.count).toBe(2);
+      }
+    });
+  });
+});

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+
+type JobFn<T> = () => Promise<T>;
+type JobStatus<T> =
+  | { status: 'pending' }
+  | { status: 'completed'; result: T }
+  | { status: 'error'; error: string };
+
+@Injectable()
+export class JobsService {
+  private readonly store = new Map<string, JobStatus<unknown>>();
+
+  enqueue<T>(id: string, fn: JobFn<T>) {
+    this.store.set(id, { status: 'pending' });
+    fn()
+      .then((r) => this.store.set(id, { status: 'completed', result: r }))
+      .catch((e: unknown) => {
+        console.error('Job failed', e);
+        const errorMessage = e instanceof Error ? e.message : JSON.stringify(e);
+        this.store.set(id, { status: 'error', error: errorMessage });
+      });
+  }
+
+  status<T>(id: string): JobStatus<T> | undefined {
+    return this.store.get(id) as JobStatus<T> | undefined;
+  }
+}

--- a/src/llm/llm.controller.ts
+++ b/src/llm/llm.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get } from '@nestjs/common';
+import { ProviderRegistryService } from './provider-registry.service';
+import { ModelsResponse } from './types';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+@ApiTags('models')
+@Controller('models')
+export class LlmController {
+  constructor(private readonly providerRegistry: ProviderRegistryService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'List available LLM models',
+    description:
+      'Get all available LLM models across all providers with their capabilities.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of models retrieved successfully',
+    type: ModelsResponse,
+  })
+  getModels(): ModelsResponse {
+    return this.providerRegistry.listModels();
+  }
+}

--- a/src/llm/llm.module.ts
+++ b/src/llm/llm.module.ts
@@ -1,0 +1,27 @@
+import { Module, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { LlmService } from './llm.service';
+import { LlmController } from './llm.controller';
+import { OpenaiProvider } from './providers/openai.provider';
+import { ProviderRegistryService } from './provider-registry.service';
+
+@Module({
+  controllers: [LlmController],
+  providers: [LlmService, OpenaiProvider, ProviderRegistryService],
+  exports: [LlmService, ProviderRegistryService],
+})
+export class LlmModule implements OnModuleInit {
+  constructor(
+    private readonly providerRegistry: ProviderRegistryService,
+    private readonly openaiProvider: OpenaiProvider,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async onModuleInit() {
+    // Register providers
+    this.providerRegistry.registerProvider(this.openaiProvider);
+
+    // Discover models from all registered providers
+    await this.providerRegistry.discoverModels();
+  }
+}

--- a/src/llm/llm.service.spec.ts
+++ b/src/llm/llm.service.spec.ts
@@ -1,0 +1,325 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Test, TestingModule } from '@nestjs/testing';
+import { LlmService } from './llm.service';
+import { ProviderRegistryService } from './provider-registry.service';
+import {
+  InternalServerErrorException,
+  BadRequestException,
+} from '@nestjs/common';
+import fs from 'fs/promises';
+import pdfParse from 'pdf-parse';
+import { GraphPayload } from '../graph/types';
+import { LlmProvider } from './providers/base.provider';
+
+jest.mock('fs/promises');
+jest.mock('pdf-parse');
+
+describe('LlmService', () => {
+  let service: LlmService;
+  let providerRegistry: jest.Mocked<ProviderRegistryService>;
+  let fsMock: jest.Mocked<typeof fs>;
+
+  const mockProvider = {
+    call: jest.fn(),
+    name: 'openai',
+    listModels: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    fsMock = fs as jest.Mocked<typeof fs>;
+
+    fsMock.readFile.mockImplementation((filePath: string) => {
+      if (filePath.includes('prompt.md')) {
+        return Promise.resolve('Mock prompt content');
+      }
+      if (filePath.includes('structured_output.md')) {
+        return Promise.resolve('Mock structured output content');
+      }
+      return Promise.resolve(Buffer.from('mock file content'));
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LlmService,
+        {
+          provide: ProviderRegistryService,
+          useValue: {
+            getProvider: jest.fn(),
+            getDefaultModelId: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<LlmService>(LlmService);
+    providerRegistry = module.get(ProviderRegistryService);
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('loadPrompts', () => {
+    it('should load prompt files during initialization', async () => {
+      const localFsMock = fs as jest.Mocked<typeof fs>;
+      let promptLoaded = false;
+      let structuredLoaded = false;
+
+      localFsMock.readFile.mockImplementation((filePath: string) => {
+        if (filePath.includes('prompt.md')) {
+          promptLoaded = true;
+          return Promise.resolve('Mock prompt content');
+        }
+        if (filePath.includes('structured_output.md')) {
+          structuredLoaded = true;
+          return Promise.resolve('Mock structured output content');
+        }
+        return Promise.resolve(Buffer.from('mock file content'));
+      });
+
+      await Test.createTestingModule({
+        providers: [
+          LlmService,
+          {
+            provide: ProviderRegistryService,
+            useValue: {
+              getProvider: jest.fn(),
+              getDefaultModelId: jest.fn(),
+            },
+          },
+        ],
+      }).compile();
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(promptLoaded).toBe(true);
+      expect(structuredLoaded).toBe(true);
+    });
+
+    it('should handle errors during prompt loading', async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      fsMock.readFile.mockRejectedValue(new Error('File not found'));
+
+      await Test.createTestingModule({
+        providers: [
+          LlmService,
+          {
+            provide: ProviderRegistryService,
+            useValue: {
+              getProvider: jest.fn(),
+              getDefaultModelId: jest.fn(),
+            },
+          },
+        ],
+      }).compile();
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to load LLM prompts'),
+        expect.any(String),
+      );
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('analyseFile', () => {
+    const filename = 'test.pdf';
+    const filePath = '/path/to/test.pdf';
+    const mimetype = 'application/pdf';
+
+    beforeEach(() => {
+      providerRegistry.getProvider.mockReturnValue(mockProvider as LlmProvider);
+      providerRegistry.getDefaultModelId.mockReturnValue('openai:gpt-4');
+    });
+
+    it('should extract text from PDF file and call provider', async () => {
+      const mockPdfText = 'Extracted PDF content';
+      const mockGraphPayload: GraphPayload = {
+        nodes: [],
+        edges: [],
+      };
+
+      pdfParse.mockResolvedValue({ text: mockPdfText });
+      fsMock.readFile.mockResolvedValue(Buffer.from('pdf content'));
+      mockProvider.call.mockResolvedValue(mockGraphPayload);
+
+      const result = await service.analyseFile(filename, filePath, mimetype);
+
+      expect(fsMock.readFile).toHaveBeenCalledWith(filePath);
+      expect(pdfParse).toHaveBeenCalled();
+      expect(mockProvider.call).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: mockPdfText,
+          schemaType: 'graph',
+        }),
+      );
+      expect(result).toEqual(mockGraphPayload);
+    });
+
+    it('should append additional context with high precedence', async () => {
+      const mockPdfText = 'Extracted PDF content';
+      const contextInput = 'Additional user context';
+      const mockGraphPayload: GraphPayload = {
+        nodes: [],
+        edges: [],
+      };
+
+      (pdfParse as any).mockResolvedValue({ text: mockPdfText });
+      fsMock.readFile.mockResolvedValue(Buffer.from('pdf content'));
+      mockProvider.call.mockResolvedValue(mockGraphPayload);
+
+      await service.analyseFile(filename, filePath, mimetype, contextInput);
+
+      expect(mockProvider.call).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: expect.stringContaining('IMPORTANT ADDITIONAL INSTRUCTIONS'),
+        }),
+      );
+      expect(mockProvider.call).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: expect.stringContaining(contextInput),
+        }),
+      );
+    });
+
+    it('should truncate very long text to 50000 characters', async () => {
+      const longText = 'a'.repeat(60000);
+      const mockGraphPayload: GraphPayload = {
+        nodes: [],
+        edges: [],
+      };
+
+      (pdfParse as any).mockResolvedValue({ text: longText });
+      fsMock.readFile.mockResolvedValue(Buffer.from('pdf content'));
+      mockProvider.call.mockResolvedValue(mockGraphPayload);
+
+      await service.analyseFile(filename, filePath, mimetype);
+
+      expect(mockProvider.call).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: expect.stringMatching(/^a{50000}$/),
+        }),
+      );
+    });
+
+    it('should use custom modelId when provided', async () => {
+      const mockPdfText = 'Extracted PDF content';
+      const mockGraphPayload: GraphPayload = {
+        nodes: [],
+        edges: [],
+      };
+      const customModelId = 'anthropic:claude-3';
+
+      (pdfParse as any).mockResolvedValue({ text: mockPdfText });
+      fsMock.readFile.mockResolvedValue(Buffer.from('pdf content'));
+      mockProvider.call.mockResolvedValue(mockGraphPayload);
+
+      await service.analyseFile(
+        filename,
+        filePath,
+        mimetype,
+        undefined,
+        customModelId,
+      );
+
+      expect(providerRegistry.getProvider).toHaveBeenCalledWith(customModelId);
+      expect(mockProvider.call).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modelId: 'claude-3',
+        }),
+      );
+    });
+
+    it('should throw error when file extraction fails', async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      fsMock.readFile.mockRejectedValue(new Error('File read error'));
+
+      await expect(
+        service.analyseFile(filename, filePath, mimetype),
+      ).rejects.toThrow(InternalServerErrorException);
+      await expect(
+        service.analyseFile(filename, filePath, mimetype),
+      ).rejects.toThrow('Failed to process file content');
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should throw error when no content is extracted', async () => {
+      const consoleWarnSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
+
+      (service as any).promptContent = 'Mock prompt content';
+      (service as any).structuredOutputContent =
+        'Mock structured output content';
+
+      (pdfParse as any).mockResolvedValue({ text: '' });
+      fsMock.readFile.mockResolvedValue(Buffer.from('pdf content'));
+
+      await expect(
+        service.analyseFile(filename, filePath, mimetype),
+      ).rejects.toThrow(BadRequestException);
+      await expect(
+        service.analyseFile(filename, filePath, mimetype),
+      ).rejects.toThrow('No content could be derived from the file');
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('No textual content derived'),
+      );
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('should handle pdf-parse errors gracefully', async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      (pdfParse as any).mockRejectedValue(new Error('PDF parsing failed'));
+      fsMock.readFile.mockResolvedValue(Buffer.from('pdf content'));
+
+      await expect(
+        service.analyseFile(filename, filePath, mimetype),
+      ).rejects.toThrow(InternalServerErrorException);
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should pass correct prompt paths to provider', async () => {
+      const mockPdfText = 'Extracted PDF content';
+      const mockGraphPayload: GraphPayload = {
+        nodes: [],
+        edges: [],
+      };
+
+      (pdfParse as any).mockResolvedValue({ text: mockPdfText });
+      fsMock.readFile.mockResolvedValue(Buffer.from('pdf content'));
+      mockProvider.call.mockResolvedValue(mockGraphPayload);
+
+      await service.analyseFile(filename, filePath, mimetype);
+
+      expect(mockProvider.call).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: expect.stringContaining('prompt.md'),
+          structured: expect.stringContaining('structured_output.md'),
+        }),
+      );
+    });
+  });
+});

--- a/src/llm/llm.service.ts
+++ b/src/llm/llm.service.ts
@@ -1,0 +1,151 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import { ProviderRegistryService } from './provider-registry.service';
+import * as path from 'path';
+import fs from 'fs/promises';
+import { GraphPayload } from '../graph/types';
+import pdfParse from 'pdf-parse';
+import type { Result as PdfParseResult } from 'pdf-parse';
+
+@Injectable()
+export class LlmService {
+  private promptContent: string;
+  private structuredOutputContent: string;
+  private readonly logger = new Logger('LlmService');
+
+  constructor(private readonly providerRegistry: ProviderRegistryService) {
+    this.loadPrompts().catch((err) => {
+      const e: unknown = err;
+      if (e instanceof Error) {
+        console.error(
+          'Critical: Failed to load LLM prompts during LlmService initialization.',
+          e.message,
+        );
+      } else {
+        console.error(
+          'Critical: Failed to load LLM prompts during LlmService initialization.',
+          JSON.stringify(e),
+        );
+      }
+    });
+  }
+
+  private async loadPrompts() {
+    const baseDir = path.resolve(__dirname, '..', '..', 'src', 'prompts');
+    this.promptContent = await fs.readFile(
+      path.join(baseDir, 'prompt.md'),
+      'utf8',
+    );
+    this.structuredOutputContent = await fs.readFile(
+      path.join(baseDir, 'structured_output.md'),
+      'utf8',
+    );
+  }
+
+  private truncateText(text: string, maxChars: number): string {
+    return text.length > maxChars ? text.slice(0, maxChars) : text;
+  }
+
+  async analyseFile(
+    filename: string,
+    filePath: string,
+    mimetype: string,
+    contextInput?: string,
+    modelId?: string,
+  ): Promise<GraphPayload> {
+    if (!this.promptContent || !this.structuredOutputContent) {
+      throw new InternalServerErrorException(
+        'LLM prompts are not loaded. Service cannot proceed.',
+      );
+    }
+
+    let extractedText: string = '';
+
+    if (filePath) {
+      // Extract file content
+      try {
+        const buffer = await fs.readFile(filePath);
+        if (mimetype === 'application/pdf') {
+          // disable lint because pdf-parse has poor types and its not really recognized
+          /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+          const data: PdfParseResult = await pdfParse(buffer);
+          extractedText = data.text as string;
+          /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
+        }
+        // TODO: Add handlers for other mimetypes (e.g., 'application/json', 'text/plain')
+
+        // Truncate if text is very long (e.g. > 50k characters, adjust as needed for token limits)
+        // TODO: limit should ideally be configurable and related to the LLM's context window.
+        extractedText = this.truncateText(extractedText, 50000);
+      } catch (err: unknown) {
+        let msg = 'Unknown error';
+        if (err instanceof Error) {
+          msg = err.message;
+          console.error(
+            `Failed to extract text from ${filename} (mimetype: ${mimetype}):`,
+            msg,
+          );
+        } else {
+          console.error(
+            `Failed to extract text from ${filename} (mimetype: ${mimetype}):`,
+            JSON.stringify(err),
+          );
+        }
+        throw new InternalServerErrorException(
+          `Failed to process file content: ${msg}`,
+        );
+      }
+    }
+
+    // Append additional context with high precedence
+    if (contextInput?.trim()) {
+      extractedText = `${extractedText}\n\n---\n\nIMPORTANT ADDITIONAL INSTRUCTIONS:\nThe user has provided the following specific context that should take precedence over the file content above:\n\n${contextInput}\n\nPlease prioritize this additional context when analyzing and categorizing the data.`;
+    }
+
+    if (!extractedText.trim()) {
+      console.warn(
+        `No textual content derived for ${filename}. Proceeding with potentially empty content to LLM.`,
+      );
+      throw new BadRequestException(
+        'No content could be derived from the file or provided context.',
+      );
+    }
+
+    // These paths are now used by providers. Ensure they are correct.
+    const promptPath = path.join(
+      path.resolve(__dirname, '..', '..', 'src', 'prompts'),
+      'prompt.md',
+    );
+    const structuredPath = path.join(
+      path.resolve(__dirname, '..', '..', 'src', 'prompts'),
+      'structured_output.md',
+    );
+
+    // Get provider from registry (uses default if modelId not provided)
+    const provider = this.providerRegistry.getProvider(modelId);
+
+    // Extract actual model ID from full identifier (e.g., "openai:gpt-5-mini" -> "gpt-5-mini")
+    const actualModelId = modelId
+      ? modelId.split(':')[1]
+      : this.providerRegistry.getDefaultModelId().split(':')[1];
+
+    const result: GraphPayload = await provider.call({
+      headings: [],
+      context: extractedText,
+      prompt: promptPath,
+      structured: structuredPath,
+      schemaType: 'graph',
+      modelId: actualModelId,
+    });
+
+    // this.logger.log(
+    //   `LLM result: ${JSON.stringify(result)}, type: ${typeof result}`,
+    // );
+
+    return result;
+  }
+}

--- a/src/llm/provider-registry.service.ts
+++ b/src/llm/provider-registry.service.ts
@@ -1,0 +1,140 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  BadRequestException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { LlmProvider } from './providers/base.provider';
+import { ModelMetadata, ModelInfo, ModelsResponse } from './types';
+
+@Injectable()
+export class ProviderRegistryService {
+  private readonly providers = new Map<string, LlmProvider>();
+  private readonly modelMetadata = new Map<string, ModelMetadata>();
+  private defaultModelId: string = '';
+
+  constructor(private readonly configService: ConfigService) {}
+
+  /**
+   * Register a provider (models will be discovered separately)
+   */
+  registerProvider(provider: LlmProvider): void {
+    this.providers.set(provider.name, provider);
+  }
+
+  /**
+   * Discover models from all registered providers
+   */
+  async discoverModels(): Promise<void> {
+    this.modelMetadata.clear();
+    const discoveryErrors: string[] = [];
+
+    for (const [providerName, provider] of this.providers.entries()) {
+      try {
+        const models = await provider.listModels();
+
+        for (const model of models) {
+          const fullId = `${providerName}:${model.id}`;
+          this.modelMetadata.set(fullId, {
+            ...model,
+            provider: providerName,
+          });
+        }
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : 'Unknown error';
+        discoveryErrors.push(`${providerName}: ${errorMessage}`);
+        console.warn(
+          `Failed to discover models for provider ${providerName}:`,
+          errorMessage,
+        );
+      }
+    }
+
+    // Throw error if all providers failed
+    if (this.modelMetadata.size === 0) {
+      throw new InternalServerErrorException(
+        `No models available: all providers failed to initialize.\n${discoveryErrors.join('\n')}`,
+      );
+    }
+
+    // Set default model ID
+    const defaultProvider =
+      this.configService.get<string>('defaultProvider') || 'openai';
+
+    // Find first model from default provider, or any provider if not available
+    const defaultProviderModels = Array.from(
+      this.modelMetadata.entries(),
+    ).filter(([id]) => id.startsWith(`${defaultProvider}:`));
+
+    if (defaultProviderModels.length > 0) {
+      this.defaultModelId = defaultProviderModels[0][0];
+    } else if (this.modelMetadata.size > 0) {
+      // Fallback to first available model from any provider
+      this.defaultModelId = Array.from(this.modelMetadata.keys())[0];
+      console.warn(
+        `Default provider "${defaultProvider}" has no models, using fallback: ${this.defaultModelId}`,
+      );
+    }
+  }
+
+  /**
+   * Get provider instance by model ID
+   * @param modelId - Full model identifier (e.g., "openai:gpt-5-mini-2025-08-07")
+   * @returns Provider instance
+   */
+  getProvider(modelId?: string): LlmProvider {
+    const id = modelId || this.defaultModelId;
+    const [providerName] = id.split(':');
+
+    const provider = this.providers.get(providerName);
+    if (!provider) {
+      throw new BadRequestException(
+        `Provider "${providerName}" not found. Available providers: ${Array.from(this.providers.keys()).join(', ')}`,
+      );
+    }
+
+    // Verify model exists - this is user input validation, so use BadRequestException
+    if (!this.modelMetadata.has(id)) {
+      const availableModels = Array.from(this.modelMetadata.keys()).join(', ');
+      throw new BadRequestException(
+        `Model "${id}" not found. Available models: ${availableModels}`,
+      );
+    }
+
+    return provider;
+  }
+
+  /**
+   * Get model metadata by ID
+   */
+  getModelMetadata(modelId: string): ModelMetadata | undefined {
+    return this.modelMetadata.get(modelId);
+  }
+
+  /**
+   * List all available models
+   */
+  listModels(): ModelsResponse {
+    const models: ModelInfo[] = Array.from(this.modelMetadata.entries()).map(
+      ([id, metadata]) => ({
+        id,
+        displayName: metadata.displayName,
+        provider: metadata.provider,
+        capabilities: metadata.capabilities,
+      }),
+    );
+
+    return {
+      models,
+      defaultModel: this.defaultModelId,
+    };
+  }
+
+  /**
+   * Get the default model ID
+   */
+  getDefaultModelId(): string {
+    return this.defaultModelId;
+  }
+}

--- a/src/llm/providers/base.provider.ts
+++ b/src/llm/providers/base.provider.ts
@@ -1,0 +1,22 @@
+import { ModelMetadata } from '../types';
+
+export type SchemaType = 'graph' | 'csv-analysis';
+
+export interface LlmParams {
+  headings: string[];
+  context?: string;
+  prompt: string;
+  structured: string;
+  schemaType?: SchemaType;
+  modelId: string;
+  file?: {
+    base64: string;
+    filename: string;
+  };
+}
+
+export interface LlmProvider {
+  name: string;
+  call<T = unknown>(params: LlmParams): Promise<T>;
+  listModels(): Promise<ModelMetadata[]>;
+}

--- a/src/llm/providers/openai.provider.ts
+++ b/src/llm/providers/openai.provider.ts
@@ -1,0 +1,167 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { OpenAI } from 'openai';
+import { z } from 'zod';
+import { readFile } from 'node:fs/promises';
+import { LlmParams, LlmProvider, SchemaType } from './base.provider';
+import { ModelMetadata } from '../types';
+import { buildPrompt } from './prompt-builder';
+import { zodTextFormat } from 'openai/helpers/zod';
+
+const graphSchema = z.object({
+  nodes: z.array(
+    z.object({
+      id: z.string(),
+      label: z.string(),
+      depth: z.number(),
+    }),
+  ),
+  edges: z
+    .array(
+      z.object({
+        source: z.string(),
+        target: z.string(),
+      }),
+    )
+    .optional()
+    .default([]),
+});
+
+const csvAnalysisSchema = z.object({
+  columns: z.array(
+    z.object({
+      name: z.string(),
+      type: z.enum(['metric', 'ordinal', 'nominal', 'unknown']),
+    }),
+  ),
+  analysis: z.array(
+    z.object({
+      column: z.string(),
+      statistics: z.array(
+        z.object({
+          name: z.string(),
+          value: z.string(),
+          applicable: z.boolean(),
+        }),
+      ),
+    }),
+  ),
+  suggestions: z.array(z.string()),
+});
+
+@Injectable()
+export class OpenaiProvider implements LlmProvider {
+  readonly name = 'openai';
+  private readonly openai: OpenAI;
+  private readonly logger = new Logger(OpenaiProvider.name);
+
+  constructor(private readonly configService: ConfigService) {
+    const apiKey = this.configService.get<string>('openai.apiKey');
+    if (!apiKey) {
+      throw new InternalServerErrorException(
+        'OPENAI_API_KEY is required but not configured. Please check your environment variables.',
+      );
+    }
+
+    this.openai = new OpenAI({ apiKey });
+  }
+
+  async call<T = unknown>(params: LlmParams): Promise<T> {
+    const {
+      headings,
+      context,
+      prompt,
+      structured,
+      file,
+      modelId,
+      schemaType = 'graph',
+    } = params;
+    const systemPrompt = await readFile(prompt, 'utf8');
+    const outputGuard = await readFile(structured, 'utf8');
+
+    const userPrompt = buildPrompt({
+      headings: headings ?? [],
+      context,
+      encodedFile: file?.base64,
+    });
+
+    // Select appropriate schema and format name based on schema type
+    const { schema, formatName } = this.getSchemaConfig(schemaType);
+
+    const res = await this.openai.responses.parse({
+      model: modelId,
+      input: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userPrompt },
+        { role: 'system', content: outputGuard },
+      ],
+      text: {
+        format: zodTextFormat(schema, formatName),
+      },
+    });
+
+    return res.output_parsed as T;
+  }
+
+  async listModels(): Promise<ModelMetadata[]> {
+    try {
+      const whitelist = this.configService.get<string[]>(
+        'modelWhitelist.openai',
+        [],
+      );
+      const modelsList = await this.openai.models.list();
+      const models: ModelMetadata[] = [];
+
+      for await (const model of modelsList) {
+        // Only include whitelisted models
+        if (whitelist.includes(model.id)) {
+          models.push({
+            id: model.id,
+            displayName: this.formatDisplayName(model.id),
+            provider: this.name,
+            capabilities: ['graph', 'csv-analysis'],
+          });
+        }
+      }
+
+      return models;
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new InternalServerErrorException(
+        `Failed to fetch OpenAI models: ${errorMessage}`,
+      );
+    }
+  }
+
+  private formatDisplayName(modelId: string): string {
+    // Convert model ID to friendly display name
+    // e.g., "gpt-5-mini-2025-08-07" -> "GPT-5 Mini"
+    const parts = modelId.split('-');
+    if (parts[0] === 'gpt' && parts[1] === '5' && parts[2]) {
+      const variant = parts[2]; // mini, turbo, etc.
+      return `GPT-5 ${variant.charAt(0).toUpperCase() + variant.slice(1)}`;
+    }
+    return modelId; // fallback to ID if pattern doesn't match
+  }
+
+  private getSchemaConfig(schemaType: SchemaType): {
+    schema: z.ZodType;
+    formatName: string;
+  } {
+    switch (schemaType) {
+      case 'graph':
+        return { schema: graphSchema, formatName: 'graph' };
+      case 'csv-analysis':
+        return { schema: csvAnalysisSchema, formatName: 'csv_analysis' };
+      default:
+        throw new InternalServerErrorException(
+          'Unsupported schema type: ' + String(schemaType),
+        );
+    }
+  }
+}

--- a/src/llm/providers/prompt-builder.ts
+++ b/src/llm/providers/prompt-builder.ts
@@ -1,0 +1,18 @@
+export function buildPrompt(params: {
+  headings?: string[];
+  context?: string;
+  encodedFile?: string;
+}): string {
+  const { headings = [], context, encodedFile } = params;
+
+  const headingsText = `Headings:\n${headings.map((h) => `- ${h}`).join('\n')}`;
+
+  const res = [
+    headingsText,
+    encodedFile ? `\nBase64 encoded file:\n${encodedFile}` : '',
+    context ? `\nAdditional context:\n${context}` : '',
+    '\n\nReturn ONLY valid JSON.',
+  ].join('');
+
+  return res;
+}

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -1,0 +1,49 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export interface ModelMetadata {
+  id: string; // e.g., "gpt-5-mini-2025-08-07"
+  displayName: string; // e.g., "GPT-5 Mini"
+  provider: string; // e.g., "openai"
+  capabilities: string[]; // e.g., ["graph", "csv-analysis"]
+}
+
+export class ModelInfo {
+  @ApiProperty({
+    description: 'Full model identifier',
+    example: 'openai:gpt-4',
+  })
+  id: string;
+
+  @ApiProperty({
+    description: 'Human-readable model name',
+    example: 'GPT-4',
+  })
+  displayName: string;
+
+  @ApiProperty({
+    description: 'Provider name',
+    example: 'openai',
+  })
+  provider: string;
+
+  @ApiProperty({
+    description: 'Model capabilities',
+    type: [String],
+    example: ['graph', 'csv-analysis'],
+  })
+  capabilities: string[];
+}
+
+export class ModelsResponse {
+  @ApiProperty({
+    description: 'Available LLM models',
+    type: [ModelInfo],
+  })
+  models: ModelInfo[];
+
+  @ApiProperty({
+    description: 'Default model ID',
+    example: 'openai:gpt-4',
+  })
+  defaultModel: string;
+}

--- a/src/prompts/csv_analysis_prompt.md
+++ b/src/prompts/csv_analysis_prompt.md
@@ -1,0 +1,39 @@
+You are a data analysis expert specializing in statistical analysis and data type classification. Your task is to analyze CSV column headers and provide intelligent recommendations for statistical analysis.
+
+Given a list of CSV column headers, you must:
+
+1. **Classify each column** into one of these data types:
+   - **metric**: Continuous numerical data (e.g., age, weight, price, temperature)
+   - **ordinal**: Ordered categorical data (e.g., rating scales, education levels, size categories)
+   - **nominal**: Unordered categorical data (e.g., gender, country, product names)
+   - **unknown**: Cannot determine from header alone
+
+2. **Suggest appropriate statistics** for each column based on its type:
+   - **Metric variables**: Mean, Median, Mode, Sum, Standard Deviation, Variance
+   - **Ordinal variables**: Median, Mode (Mean and Sum may be meaningful depending on context)
+   - **Nominal variables**: Mode only
+   - **Unknown variables**: Provide conservative suggestions
+
+3. **Generate analysis recommendations** that explain:
+   - What types of insights can be gained from this dataset
+   - Which combinations of variables might reveal interesting patterns
+   - Suggested statistical tests or visualizations
+   - Any data quality considerations based on the column names
+
+**Rules:**
+
+- Be conservative in classification - if unsure, use "unknown"
+- Consider common naming conventions (id, name, date, etc.)
+- Look for patterns that suggest data types (e.g., "\_score", "\_count", "\_rate")
+- Provide actionable, specific recommendations
+- Focus on statistical analysis that would be valuable for research data
+
+**Example Headers and Expected Classifications:**
+
+- "participant_age" → metric (Mean, Median, Mode, Sum, Std Dev, Variance)
+- "satisfaction_rating" → ordinal (Median, Mode)
+- "gender" → nominal (Mode only)
+- "study_group" → nominal (Mode only)
+- "response_time_ms" → metric (Mean, Median, Mode, Sum, Std Dev, Variance)
+
+Output your analysis in the exact JSON format specified in the structured output template.

--- a/src/prompts/csv_analysis_structured_output.md
+++ b/src/prompts/csv_analysis_structured_output.md
@@ -1,0 +1,55 @@
+You must respond with **valid JSON** matching this TypeScript interface:
+
+```ts
+interface CsvAnalysisResult {
+  columns: {
+    name: string;
+    type: 'metric' | 'ordinal' | 'nominal' | 'unknown';
+  }[];
+  analysis: {
+    column: string;
+    statistics: {
+      name: string;
+      value: number | string;
+      applicable: boolean;
+    }[];
+  }[];
+  suggestions: string[];
+}
+```
+
+Requirements:
+
+- **columns**: Array of all column headers with their classified data types
+- **analysis**: For each column, specify which statistics are applicable
+  - Use `applicable: true` for recommended statistics
+  - Use `applicable: false` for statistics that don't make sense for this data type
+  - `value` should be the statistic name (e.g., "mean", "median") for applicable ones, or "N/A" for non-applicable
+- **suggestions**: Array of 3-5 specific, actionable analysis recommendations
+- Include all standard statistics: Mean, Median, Mode, Sum, Standard Deviation, Variance
+- Do **not** wrap the JSON in markdown fences.
+
+Example structure:
+
+```json
+{
+  "columns": [
+    { "name": "age", "type": "metric" },
+    { "name": "gender", "type": "nominal" }
+  ],
+  "analysis": [
+    {
+      "column": "age",
+      "statistics": [
+        { "name": "Mean", "value": "mean", "applicable": true },
+        { "name": "Median", "value": "median", "applicable": true },
+        { "name": "Mode", "value": "mode", "applicable": true }
+      ]
+    }
+  ],
+  "suggestions": [
+    "Analyze age distribution using descriptive statistics",
+    "Compare age groups across different categories"
+  ]
+}
+```

--- a/src/prompts/prompt.md
+++ b/src/prompts/prompt.md
@@ -1,0 +1,734 @@
+You are a highly accurate, deterministic, and detail-oriented data analyst. Never introduce variability. Always produce the same answer given the same input.
+
+I will provide you with one or more codebooks containing unstructured data fields (column names) along with their detailed descriptions.
+Your task: Carefully read and analyze each field name and its description. Group all fields into logically coherent categories based on semantic similarity and purpose, as interpreted strictly
+from the field descriptions and their field names. Create a hierarchical structure using main categories and subcategories as appropriate. For example: resident_disease_8
+should go under subcategory Diabetes, inside main category Disease. resident_disease_9 should go under subcategory Cancer, also inside Disease. Ensure all fields are
+categorized - no omissions, no uncategorized fields. If unable to categorize, leave it in a Uncategorised category. Output format: Must only display the final result
+of categories, subcategories and fields using JSON, completely listing all fields exhaustively under their respective categories without repeating any fields.
+Always follow this exact structure and output format.
+
+Rules:
+
+- Every extracted heading must appear **exactly once** in the hierarchy.
+- The root node must be a noun, which represents the overall codebook domain (use a concise, singular, descriptive noun such as "Customer", "Invoice", or "Order"; prefer a domain-level term and avoid verbs or phrases).
+- All field names **must** be leaf nodes and **must not** be intermediary nodes.
+- If a heading does not clearly fit, place it under **"Uncategorised"**. I.E., a depth 1 node labelled `Uncategorised` which will be a child of the root and parent of all uncategorised headings.
+- Leaf nodes **must** match field names
+- Return **only** the valid JSON requested below.
+
+**Here is an example codebook:**
+
+Codebook for IMDB Dataset
+
+Variable Name: name_basics_birthyear
+Variable Description: birth year (YYYY)
+Data Type: VARCHAR(45)
+
+###
+
+Variable Name: name_basics_deathyear
+Variable Description: death year if applicable, else
+Data Type: VARCHAR(45)
+
+###
+
+Variable Name: name_basics_knownfortitles
+Variable Description: titles the person is known for (array of tconsts)
+Data Type: VARCHAR(128)
+
+###
+
+Variable Name: name_basics_nconst
+Variable Description: alphanumeric unique identifier of the name/person (string)
+Data Type: VARCHAR(128)
+
+###
+
+Variable Name: name_basics_primaryname
+Variable Description: name by which the person is most often credited (string)
+Data Type: VARCHAR(128)
+
+###
+
+Variable Name: name_basics_primaryprofession
+Variable Description: the top-3 professions of the person (array of strings)
+Data Type: VARCHAR(128)
+
+###
+
+Variable Name: title_akas_attributes
+Variable Description: Additional terms to describe this alternative title (array), not enumerated
+Data Type: VARCHAR(512)
+
+###
+
+Variable Name: title_akas_isoriginaltitle
+Variable Description: 0: not original title. 1: original title (boolean)
+Data Type: VARCHAR(45)
+
+###
+
+Variable Name: title_akas_language
+Variable Description: the language of the title (string)
+Data Type: VARCHAR(128)
+
+###
+
+Variable Name: title_akas_ordering
+Variable Description: a number to uniquely identify rows for a given titleId (integer)
+Data Type: VARCHAR(128)
+
+###
+
+Variable Name: title_akas_region
+Variable Description: the region for this version of the title (string)
+Data Type: VARCHAR(128)
+
+###
+
+Variable Name: title_akas_title
+Variable Description: the localized title (string)
+Data Type: TEXT
+
+###
+
+Variable Name: title_akas_titleid
+Variable Description: a tconst (string, an alphanumeric unique identifier of the title)
+Data Type: VARCHAR(128)
+
+###
+
+Variable Name: title_akas_types
+Variable Description: Enumerated set of attributes for this alternative title (array). One or more of the following: "alternative", "dvd", "festival", "tv", "video", "working", "original", "imdbDisplay". New values may be added in the future without warning
+Data Type: VARCHAR(512)
+
+###
+
+Variable Name: title_basics_endyear
+Variable Description: TV Series end year (YYYY). ‘\N’ for all other title types
+Data Type: VARCHAR(45)
+
+###
+
+Variable Name: title_basics_genres
+Variable Description: includes up to three genres associated with the title (string array)
+Data Type: VARCHAR(256)
+
+###
+
+Variable Name: title_basics_isadult
+Variable Description: 0: non-adult title. 1: adult title (boolean)
+Data Type: VARCHAR(32)
+
+###
+
+Variable Name: title_basics_originaltitle
+Variable Description: original title (string) (in the original language)
+Data Type: VARCHAR(512)
+
+###
+
+Variable Name: title_basics_primarytitle
+Variable Description: the more popular title (string) (the title used by the filmmakers on promotional materials at the point of release)
+Data Type: VARCHAR(512)
+
+###
+
+Variable Name: title_basics_runtimeminutes
+Variable Description: primary runtime of the title (integer, in minutes)
+Data Type: VARCHAR(45)
+
+###
+
+Variable Name: title_basics_startyear
+Variable Description: represents the release year of a title (YYYY). In the case of TV Series, it is the series start year
+Data Type: VARCHAR(45)
+
+###
+
+Variable Name: title_basics_tconst
+Variable Description: alphanumeric unique identifier of the title (string)
+Data Type: VARCHAR(64)
+
+###
+
+Variable Name: title_basics_titletype
+Variable Description: the type/format of the title (string) (e.g. movie, short, tvseries, tvepisode, video, etc)
+Data Type: VARCHAR(64)
+
+###
+
+Variable Name: title_crew_directors
+Variable Description: director(s) of the given title (array of nconsts)
+Data Type: TEXT
+
+###
+
+Variable Name: title_crew_tconst
+Variable Description: alphanumeric unique identifier of the title (string)
+Data Type: VARCHAR(128)
+
+###
+
+Variable Name: title_crew_writers
+Variable Description: writer(s) of the given title (array of nconsts)
+Data Type: TEXT
+
+###
+
+Variable Name: title_episode_episodenumber
+Variable Description: episode number of the tconst in the TV series (integer)
+Data Type: TEXT
+
+###
+
+Variable Name: title_episode_parenttconst
+Variable Description: alphanumeric identifier of the parent TV Series (string)
+Data Type: VARCHAR(128)
+
+###
+
+Variable Name: title_episode_seasonnumber
+Variable Description: season number the episode belongs to (integer)
+Data Type: TEXT
+
+###
+
+Variable Name: title_episode_tconst
+Variable Description: alphanumeric identifier of episode (string)
+Data Type: VARCHAR(128)
+
+###
+
+Variable Name: title_principals_category
+Variable Description: the category of job that person was in (string)
+Data Type: TEXT
+
+###
+
+Variable Name: title_principals_characters
+Variable Description: the name of the character played if applicable, else
+Data Type: TEXT
+
+###
+
+Variable Name: title_principals_job
+Variable Description: the specific job title if applicable, else
+Data Type: TEXT
+
+###
+
+Variable Name: title_principals_nconst
+Variable Description: alphanumeric unique identifier of the name/person (string)
+Data Type: VARCHAR(128)
+
+###
+
+Variable Name: title_principals_ordering
+Variable Description: a number to uniquely identify rows for a given titleId (integer)
+Data Type: VARCHAR(45)
+
+###
+
+Variable Name: title_principals_tconst
+Variable Description: alphanumeric unique identifier of the title (string)
+Data Type: VARCHAR(128)
+
+###
+
+Variable Name: title_ratings_averagerating
+Variable Description: weighted average of all the individual user ratings (float)
+Data Type: VARCHAR(45)
+
+###
+
+Variable Name: title_ratings_numvotes
+Variable Description: number of votes the title has received (integer)
+Data Type: VARCHAR(45)
+
+###
+
+Variable Name: title_ratings_tconst
+Variable Description: alphanumeric unique identifier of the title (string)
+Data Type: VARCHAR(128)
+
+###
+
+**Resulting in the example categorised JSON:**
+
+{
+"status": "completed",
+"result": {
+"nodes": [
+{
+"id": "Media",
+"label": "Media",
+"depth": 0,
+"colour": "#0ea5e9"
+},
+{
+"id": "Name",
+"label": "Name",
+"depth": 1,
+"colour": "#eab308"
+},
+{
+"id": "TitleAkas",
+"label": "TitleAkas",
+"depth": 1,
+"colour": "#eab308"
+},
+{
+"id": "TitleBasics",
+"label": "TitleBasics",
+"depth": 1,
+"colour": "#eab308"
+},
+{
+"id": "TitleCrew",
+"label": "TitleCrew",
+"depth": 1,
+"colour": "#eab308"
+},
+{
+"id": "TitleEpisode",
+"label": "TitleEpisode",
+"depth": 1,
+"colour": "#eab308"
+},
+{
+"id": "TitlePrincipals",
+"label": "TitlePrincipals",
+"depth": 1,
+"colour": "#eab308"
+},
+{
+"id": "TitleRatings",
+"label": "TitleRatings",
+"depth": 1,
+"colour": "#eab308"
+},
+{
+"id": "name_basics_birthyear",
+"label": "name_basics_birthyear",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "name_basics_deathyear",
+"label": "name_basics_deathyear",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "name_basics_knownfortitles",
+"label": "name_basics_knownfortitles",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "name_basics_nconst",
+"label": "name_basics_nconst",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "name_basics_primaryname",
+"label": "name_basics_primaryname",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "name_basics_primaryprofession",
+"label": "name_basics_primaryprofession",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_akas_attributes",
+"label": "title_akas_attributes",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_akas_isoriginaltitle",
+"label": "title_akas_isoriginaltitle",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_akas_language",
+"label": "title_akas_language",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_akas_ordering",
+"label": "title_akas_ordering",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_akas_region",
+"label": "title_akas_region",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_akas_title",
+"label": "title_akas_title",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_akas_titleid",
+"label": "title_akas_titleid",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_akas_types",
+"label": "title_akas_types",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_basics_endyear",
+"label": "title_basics_endyear",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_basics_genres",
+"label": "title_basics_genres",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_basics_isadult",
+"label": "title_basics_isadult",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_basics_originaltitle",
+"label": "title_basics_originaltitle",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_basics_primarytitle",
+"label": "title_basics_primarytitle",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_basics_runtimeminutes",
+"label": "title_basics_runtimeminutes",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_basics_startyear",
+"label": "title_basics_startyear",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_basics_tconst",
+"label": "title_basics_tconst",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_basics_titletype",
+"label": "title_basics_titletype",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_crew_directors",
+"label": "title_crew_directors",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_crew_tconst",
+"label": "title_crew_tconst",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_crew_writers",
+"label": "title_crew_writers",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_episode_episodenumber",
+"label": "title_episode_episodenumber",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_episode_parenttconst",
+"label": "title_episode_parenttconst",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_episode_seasonnumber",
+"label": "title_episode_seasonnumber",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_episode_tconst",
+"label": "title_episode_tconst",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_principals_category",
+"label": "title_principals_category",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_principals_characters",
+"label": "title_principals_characters",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_principals_job",
+"label": "title_principals_job",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_principals_nconst",
+"label": "title_principals_nconst",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_principals_ordering",
+"label": "title_principals_ordering",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_principals_tconst",
+"label": "title_principals_tconst",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_ratings_averagerating",
+"label": "title_ratings_averagerating",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_ratings_numvotes",
+"label": "title_ratings_numvotes",
+"depth": 2,
+"colour": "#ec4899"
+},
+{
+"id": "title_ratings_tconst",
+"label": "title_ratings_tconst",
+"depth": 2,
+"colour": "#ec4899"
+}
+],
+"edges": [
+{
+"source": "Media",
+"target": "Name"
+},
+{
+"source": "Media",
+"target": "TitleAkas"
+},
+{
+"source": "Media",
+"target": "TitleBasics"
+},
+{
+"source": "Media",
+"target": "TitleCrew"
+},
+{
+"source": "Media",
+"target": "TitleEpisode"
+},
+{
+"source": "Media",
+"target": "TitlePrincipals"
+},
+{
+"source": "Media",
+"target": "TitleRatings"
+},
+{
+"source": "Name",
+"target": "name_basics_birthyear"
+},
+{
+"source": "Name",
+"target": "name_basics_deathyear"
+},
+{
+"source": "Name",
+"target": "name_basics_knownfortitles"
+},
+{
+"source": "Name",
+"target": "name_basics_nconst"
+},
+{
+"source": "Name",
+"target": "name_basics_primaryname"
+},
+{
+"source": "Name",
+"target": "name_basics_primaryprofession"
+},
+{
+"source": "TitleAkas",
+"target": "title_akas_attributes"
+},
+{
+"source": "TitleAkas",
+"target": "title_akas_isoriginaltitle"
+},
+{
+"source": "TitleAkas",
+"target": "title_akas_language"
+},
+{
+"source": "TitleAkas",
+"target": "title_akas_ordering"
+},
+{
+"source": "TitleAkas",
+"target": "title_akas_region"
+},
+{
+"source": "TitleAkas",
+"target": "title_akas_title"
+},
+{
+"source": "TitleAkas",
+"target": "title_akas_titleid"
+},
+{
+"source": "TitleAkas",
+"target": "title_akas_types"
+},
+{
+"source": "TitleBasics",
+"target": "title_basics_endyear"
+},
+{
+"source": "TitleBasics",
+"target": "title_basics_genres"
+},
+{
+"source": "TitleBasics",
+"target": "title_basics_isadult"
+},
+{
+"source": "TitleBasics",
+"target": "title_basics_originaltitle"
+},
+{
+"source": "TitleBasics",
+"target": "title_basics_primarytitle"
+},
+{
+"source": "TitleBasics",
+"target": "title_basics_runtimeminutes"
+},
+{
+"source": "TitleBasics",
+"target": "title_basics_startyear"
+},
+{
+"source": "TitleBasics",
+"target": "title_basics_tconst"
+},
+{
+"source": "TitleBasics",
+"target": "title_basics_titletype"
+},
+{
+"source": "TitleCrew",
+"target": "title_crew_directors"
+},
+{
+"source": "TitleCrew",
+"target": "title_crew_tconst"
+},
+{
+"source": "TitleCrew",
+"target": "title_crew_writers"
+},
+{
+"source": "TitleEpisode",
+"target": "title_episode_episodenumber"
+},
+{
+"source": "TitleEpisode",
+"target": "title_episode_parenttconst"
+},
+{
+"source": "TitleEpisode",
+"target": "title_episode_seasonnumber"
+},
+{
+"source": "TitleEpisode",
+"target": "title_episode_tconst"
+},
+{
+"source": "TitlePrincipals",
+"target": "title_principals_category"
+},
+{
+"source": "TitlePrincipals",
+"target": "title_principals_characters"
+},
+{
+"source": "TitlePrincipals",
+"target": "title_principals_job"
+},
+{
+"source": "TitlePrincipals",
+"target": "title_principals_nconst"
+},
+{
+"source": "TitlePrincipals",
+"target": "title_principals_ordering"
+},
+{
+"source": "TitlePrincipals",
+"target": "title_principals_tconst"
+},
+{
+"source": "TitleRatings",
+"target": "title_ratings_averagerating"
+},
+{
+"source": "TitleRatings",
+"target": "title_ratings_numvotes"
+},
+{
+"source": "TitleRatings",
+"target": "title_ratings_tconst"
+}
+]
+}
+}

--- a/src/prompts/structured_output.md
+++ b/src/prompts/structured_output.md
@@ -16,4 +16,5 @@ interface GraphPayload {
 - Children of any node will have `depth: parent[depth] + 1`
   - For example, nodes with `depth: 2` will have a parent of `depth: 1` and children with `depth: 3`
 - Each edge represents a parent-child relationship where `source` is the parent ID and `target` is the child ID. Every non-root node must have exactly one incoming edge from its parent.
+- For all nodes, you **MUST** differentiate between the `id` and `label` where the `id` should be kept the same from the variable name in the codebook, while the label **MUST** be a cleaned version of the `id`, where if it is using `camelCase`, change it to `Camel Case`, or `snake_case` into `Snake Case`. Essentially, remove all underscores and replace with space, capitalize the first letter of every word, and add spaces between words where underscores are not present such as in `camelCase` and `PascalCase`. If any numbers are present within the `id` such as `income_1` and `income_2`, keep the number so it becomes `Income 1` and `Income 2`. Ensure **ALL** variables from the codebook are still present.
 - Do **not** wrap the JSON in markdown fences.

--- a/src/prompts/structured_output.md
+++ b/src/prompts/structured_output.md
@@ -1,0 +1,19 @@
+You must respond with **valid JSON** matching this TypeScript interface:
+
+```ts
+interface GraphPayload {
+  nodes: { id: string; label: string; depth: number }[];
+  edges: { source: string; target: string }[];
+}
+```
+
+**CRITICAL REQUIREMENTS:**
+
+- You **MUST** include both `nodes` and `edges` arrays in your response
+- `edges` array **CANNOT** be empty - you must create edges for the hierarchy
+- The root node has `depth: 0`.
+- Children of the root have `depth: 1`.
+- Children of any node will have `depth: parent[depth] + 1`
+  - For example, nodes with `depth: 2` will have a parent of `depth: 1` and children with `depth: 3`
+- Each edge represents a parent-child relationship where `source` is the parent ID and `target` is the child ID. Every non-root node must have exactly one incoming edge from its parent.
+- Do **not** wrap the JSON in markdown fences.

--- a/src/upload/dto/upload.dto.ts
+++ b/src/upload/dto/upload.dto.ts
@@ -1,0 +1,38 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UploadDto {
+  @ApiPropertyOptional({
+    description: 'Additional context or instructions for the analysis',
+    maxLength: 2000,
+    example: 'Focus on identifying primary categories and their relationships',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2_000)
+  context?: string;
+
+  @ApiProperty({
+    description: 'File type being uploaded (pdf or csv)',
+    enum: ['pdf', 'csv'],
+    example: 'pdf',
+  })
+  @IsString()
+  filetype: string;
+
+  @ApiPropertyOptional({
+    description: 'LLM model ID to use for analysis',
+    example: 'openai:gpt-4',
+  })
+  @IsOptional()
+  @IsString()
+  modelId?: string;
+}
+
+export class UploadResponseDto {
+  @ApiProperty({
+    description: 'Unique job ID for tracking analysis progress',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  jobId: string;
+}

--- a/src/upload/upload.constants.ts
+++ b/src/upload/upload.constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Upload module constants
+ */
+
+export const UPLOAD_MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MiB

--- a/src/upload/upload.controller.ts
+++ b/src/upload/upload.controller.ts
@@ -1,0 +1,126 @@
+import {
+  Controller,
+  Post,
+  UploadedFile,
+  UseInterceptors,
+  Body,
+  BadRequestException,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { diskStorage, FileFilterCallback } from 'multer';
+import { UploadDto, UploadResponseDto } from './dto/upload.dto';
+import { UploadService } from './upload.service';
+import { UPLOAD_MAX_FILE_SIZE } from './upload.constants';
+import { Request } from 'express';
+import { v4 as uuid } from 'uuid';
+import * as path from 'path';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiConsumes,
+  ApiBody,
+  ApiResponse,
+  ApiBadRequestResponse,
+} from '@nestjs/swagger';
+
+@ApiTags('uploads')
+@Controller('uploads')
+export class UploadController {
+  constructor(private readonly uploadSvc: UploadService) {}
+
+  @Post()
+  @ApiOperation({
+    summary: 'Upload and analyze file',
+    description:
+      'Upload a PDF or CSV file for hierarchical structure analysis. Returns a job ID for tracking analysis progress.',
+  })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['file', 'filetype'],
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+          description: 'PDF or CSV file (max 10MB)',
+        },
+        filetype: {
+          type: 'string',
+          enum: ['pdf', 'csv'],
+          description: 'File type being uploaded',
+        },
+        context: {
+          type: 'string',
+          maxLength: 2000,
+          description: 'Optional analysis context',
+        },
+        modelId: {
+          type: 'string',
+          description: 'Optional LLM model ID',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'File uploaded successfully, analysis job created',
+    type: UploadResponseDto,
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid file type, size, or mimetype mismatch',
+  })
+  @UseInterceptors(
+    FileInterceptor('file', {
+      storage: diskStorage({
+        destination: process.env.UPLOAD_TMPDIR || '/tmp/archetype-discovery',
+        filename: (
+          _req: Request,
+          file: Express.Multer.File,
+          cb: (error: Error | null, filename: string) => void,
+        ) => {
+          const sanitizedOriginalName = path
+            .parse(file.originalname)
+            .name.replace(/[^a-zA-Z0-9.-]/g, '_')
+            .substring(0, 100);
+          const extension = path.extname(file.originalname);
+          const safeFilename = `${uuid()}-${sanitizedOriginalName}${extension}`;
+          cb(null, safeFilename);
+        },
+      }),
+      limits: { fileSize: UPLOAD_MAX_FILE_SIZE },
+      fileFilter: (
+        _req: Request,
+        file: Express.Multer.File,
+        cb: FileFilterCallback,
+      ) => {
+        const allowed = ['application/pdf', 'text/csv'];
+        if (allowed.includes(file.mimetype)) {
+          cb(null, true);
+        } else {
+          cb(new Error('Unsupported mimetype: ' + file.mimetype));
+        }
+      },
+    }),
+  )
+  handleUpload(
+    @UploadedFile() file: Express.Multer.File,
+    @Body() dto: UploadDto,
+  ) {
+    const expectedMimetypes: Record<string, string> = {
+      pdf: 'application/pdf',
+      csv: 'text/csv',
+    };
+
+    const actual = file.mimetype;
+    const expected = expectedMimetypes[dto.filetype.toLowerCase()];
+    if (!expected || actual !== expected) {
+      throw new BadRequestException(
+        `Mimetype mismatch: expected ${expected}, got ${actual}`,
+      );
+    }
+
+    const jobId = this.uploadSvc.processFile(file, dto.context, dto.modelId);
+    return { jobId };
+  }
+}

--- a/src/upload/upload.controller.ts
+++ b/src/upload/upload.controller.ts
@@ -21,9 +21,11 @@ import {
   ApiBody,
   ApiResponse,
   ApiBadRequestResponse,
+  ApiBearerAuth,
 } from '@nestjs/swagger';
 
 @ApiTags('uploads')
+@ApiBearerAuth()
 @Controller('uploads')
 export class UploadController {
   constructor(private readonly uploadSvc: UploadService) {}

--- a/src/upload/upload.module.ts
+++ b/src/upload/upload.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { UploadController } from './upload.controller';
+import { UploadService } from './upload.service';
+import { JobsModule } from '../jobs/jobs.module';
+import { GraphModule } from '../graph/graph.module';
+
+@Module({
+  imports: [JobsModule, GraphModule],
+  controllers: [UploadController],
+  providers: [UploadService],
+  exports: [UploadService],
+})
+export class UploadModule {}

--- a/src/upload/upload.service.spec.ts
+++ b/src/upload/upload.service.spec.ts
@@ -1,0 +1,375 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Test, TestingModule } from '@nestjs/testing';
+import { UploadService } from './upload.service';
+import { JobsService } from '../jobs/jobs.service';
+import { GraphService } from '../graph/graph.service';
+import { BadRequestException, Logger } from '@nestjs/common';
+import { writeFile, unlink } from 'node:fs/promises';
+
+jest.mock('node:fs/promises');
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'test-job-id-123'),
+}));
+
+describe('UploadService', () => {
+  let service: UploadService;
+  let jobsService: jest.Mocked<JobsService>;
+  let graphService: jest.Mocked<GraphService>;
+
+  const writeFileMock = writeFile as jest.MockedFunction<typeof writeFile>;
+  const unlinkMock = unlink as jest.MockedFunction<typeof unlink>;
+
+  beforeAll(() => {
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UploadService,
+        {
+          provide: JobsService,
+          useValue: {
+            enqueue: jest.fn(),
+            status: jest.fn(),
+          },
+        },
+        {
+          provide: GraphService,
+          useValue: {
+            generateGraphFromFile: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<UploadService>(UploadService);
+    jobsService = module.get(JobsService);
+    graphService = module.get(GraphService);
+
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('processFile', () => {
+    it('should enqueue job with file path when path is provided', () => {
+      const file = {
+        path: '/uploads/test.pdf',
+        originalname: 'test.pdf',
+        mimetype: 'application/pdf',
+        buffer: Buffer.from(''),
+      } as Express.Multer.File;
+
+      const context = 'Test context';
+      const modelId = 'openai:gpt-4';
+
+      const jobId = service.processFile(file, context, modelId);
+
+      expect(jobId).toBe('test-job-id-123');
+      expect(jobsService.enqueue).toHaveBeenCalledTimes(1);
+      expect(jobsService.enqueue).toHaveBeenCalledWith(
+        'test-job-id-123',
+        expect.any(Function),
+      );
+    });
+
+    it('should enqueue job without context and modelId', () => {
+      const file = {
+        path: '/uploads/test.pdf',
+        originalname: 'test.pdf',
+        mimetype: 'application/pdf',
+        buffer: Buffer.from('test content'),
+      } as Express.Multer.File;
+
+      const jobId = service.processFile(file);
+
+      expect(jobId).toBe('test-job-id-123');
+      expect(jobsService.enqueue).toHaveBeenCalledTimes(1);
+    });
+
+    it('should create temp file from buffer when path is not provided', async () => {
+      const buffer = Buffer.from('test content');
+      const file = {
+        path: undefined,
+        originalname: 'test.pdf',
+        mimetype: 'application/pdf',
+        buffer,
+      } as unknown as Express.Multer.File;
+
+      writeFileMock.mockResolvedValue(undefined);
+      unlinkMock.mockResolvedValue(undefined);
+      graphService.generateGraphFromFile.mockResolvedValue({
+        nodes: [],
+        edges: [],
+      });
+
+      service.processFile(file);
+
+      expect(jobsService.enqueue).toHaveBeenCalledTimes(1);
+
+      const enqueuedFn = jobsService.enqueue.mock.calls[0][1];
+      await enqueuedFn();
+
+      expect(writeFileMock).toHaveBeenCalledWith(
+        '/tmp/test-job-id-123-test.pdf',
+        buffer,
+      );
+      expect(graphService.generateGraphFromFile).toHaveBeenCalledWith(
+        'test.pdf',
+        '/tmp/test-job-id-123-test.pdf',
+        'application/pdf',
+        undefined,
+        undefined,
+      );
+    });
+
+    it('should throw BadRequestException when no path and no buffer', async () => {
+      const file = {
+        path: undefined,
+        originalname: 'test.pdf',
+        mimetype: 'application/pdf',
+        buffer: undefined,
+      } as unknown as Express.Multer.File;
+
+      service.processFile(file);
+
+      const enqueuedFn = jobsService.enqueue.mock.calls[0][1];
+
+      await expect(enqueuedFn()).rejects.toThrow(BadRequestException);
+      await expect(enqueuedFn()).rejects.toThrow(
+        'File content unavailable (no path or buffer)',
+      );
+    });
+
+    it('should call generateGraphFromFile with correct parameters', async () => {
+      const file = {
+        path: '/uploads/document.pdf',
+        originalname: 'document.pdf',
+        mimetype: 'application/pdf',
+        buffer: Buffer.from('content'),
+      } as Express.Multer.File;
+
+      const context = 'Important context';
+      const modelId = 'anthropic:claude-3';
+
+      graphService.generateGraphFromFile.mockResolvedValue({
+        nodes: [{ id: '1', label: 'Node', depth: 0, colour: '#ffffff' }],
+        edges: [],
+      });
+      unlinkMock.mockResolvedValue(undefined);
+
+      service.processFile(file, context, modelId);
+
+      const enqueuedFn = jobsService.enqueue.mock.calls[0][1];
+      const result = await enqueuedFn();
+
+      expect(graphService.generateGraphFromFile).toHaveBeenCalledWith(
+        'document.pdf',
+        '/uploads/document.pdf',
+        'application/pdf',
+        context,
+        modelId,
+      );
+      expect(result).toEqual({
+        nodes: [{ id: '1', label: 'Node', depth: 0, colour: '#ffffff' }],
+        edges: [],
+      });
+    });
+
+    it('should delete file after processing when path exists', async () => {
+      const file = {
+        path: '/uploads/test.pdf',
+        originalname: 'test.pdf',
+        mimetype: 'application/pdf',
+        buffer: Buffer.from(''),
+      } as Express.Multer.File;
+
+      graphService.generateGraphFromFile.mockResolvedValue({
+        nodes: [],
+        edges: [],
+      });
+      unlinkMock.mockResolvedValue(undefined);
+
+      service.processFile(file);
+
+      const enqueuedFn = jobsService.enqueue.mock.calls[0][1];
+      await enqueuedFn();
+
+      expect(unlinkMock).toHaveBeenCalledWith('/uploads/test.pdf');
+    });
+
+    it('should delete temp file after processing when created from buffer', async () => {
+      const file = {
+        path: undefined,
+        originalname: 'test.pdf',
+        mimetype: 'application/pdf',
+        buffer: Buffer.from('content'),
+      } as unknown as Express.Multer.File;
+
+      writeFileMock.mockResolvedValue(undefined);
+      graphService.generateGraphFromFile.mockResolvedValue({
+        nodes: [],
+        edges: [],
+      });
+      unlinkMock.mockResolvedValue(undefined);
+
+      service.processFile(file);
+
+      const enqueuedFn = jobsService.enqueue.mock.calls[0][1];
+      await enqueuedFn();
+
+      expect(unlinkMock).toHaveBeenCalledWith('/tmp/test-job-id-123-test.pdf');
+    });
+
+    it('should handle file deletion errors gracefully', async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      const file = {
+        path: '/uploads/test.pdf',
+        originalname: 'test.pdf',
+        mimetype: 'application/pdf',
+        buffer: Buffer.from(''),
+      } as Express.Multer.File;
+
+      graphService.generateGraphFromFile.mockResolvedValue({
+        nodes: [],
+        edges: [],
+      });
+      unlinkMock.mockRejectedValue(new Error('Permission denied'));
+
+      service.processFile(file);
+
+      const enqueuedFn = jobsService.enqueue.mock.calls[0][1];
+      await enqueuedFn();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '`Failed to delete temporary file ${filePath}:`',
+        expect.any(Error),
+      );
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should delete file even when generateGraphFromFile throws error', async () => {
+      const file = {
+        path: '/uploads/test.pdf',
+        originalname: 'test.pdf',
+        mimetype: 'application/pdf',
+        buffer: Buffer.from(''),
+      } as Express.Multer.File;
+
+      graphService.generateGraphFromFile.mockRejectedValue(
+        new Error('Graph generation failed'),
+      );
+      unlinkMock.mockResolvedValue(undefined);
+
+      service.processFile(file);
+
+      const enqueuedFn = jobsService.enqueue.mock.calls[0][1];
+
+      await expect(enqueuedFn()).rejects.toThrow('Graph generation failed');
+      expect(unlinkMock).toHaveBeenCalledWith('/uploads/test.pdf');
+    });
+
+    it('should handle different mimetypes', async () => {
+      const pdfFile = {
+        path: '/uploads/doc.pdf',
+        originalname: 'doc.pdf',
+        mimetype: 'application/pdf',
+        buffer: Buffer.from(''),
+      } as Express.Multer.File;
+
+      const jsonFile = {
+        path: '/uploads/data.json',
+        originalname: 'data.json',
+        mimetype: 'application/json',
+        buffer: Buffer.from(''),
+      } as Express.Multer.File;
+
+      graphService.generateGraphFromFile.mockResolvedValue({
+        nodes: [],
+        edges: [],
+      });
+      unlinkMock.mockResolvedValue(undefined);
+
+      service.processFile(pdfFile);
+      service.processFile(jsonFile);
+
+      const pdfFn = jobsService.enqueue.mock.calls[0][1];
+      const jsonFn = jobsService.enqueue.mock.calls[1][1];
+
+      await pdfFn();
+      await jsonFn();
+
+      expect(graphService.generateGraphFromFile).toHaveBeenNthCalledWith(
+        1,
+        'doc.pdf',
+        '/uploads/doc.pdf',
+        'application/pdf',
+        undefined,
+        undefined,
+      );
+
+      expect(graphService.generateGraphFromFile).toHaveBeenNthCalledWith(
+        2,
+        'data.json',
+        '/uploads/data.json',
+        'application/json',
+        undefined,
+        undefined,
+      );
+    });
+
+    it('should log file properties', () => {
+      const logSpy = jest.spyOn(Logger.prototype, 'log');
+
+      const file = {
+        path: '/uploads/test.pdf',
+        originalname: 'test.pdf',
+        mimetype: 'application/pdf',
+        buffer: Buffer.from('content'),
+      } as Express.Multer.File;
+
+      service.processFile(file);
+
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('File properties'),
+      );
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('File Path: /uploads/test.pdf'),
+      );
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Buffer: Present'),
+      );
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Name: test.pdf'),
+      );
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Type: application/pdf'),
+      );
+    });
+
+    it('should log when buffer is missing', () => {
+      const logSpy = jest.spyOn(Logger.prototype, 'log');
+
+      const file = {
+        path: '/uploads/test.pdf',
+        originalname: 'test.pdf',
+        mimetype: 'application/pdf',
+        buffer: undefined,
+      } as unknown as Express.Multer.File;
+
+      service.processFile(file);
+
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Buffer: Missing'),
+      );
+    });
+  });
+});

--- a/src/upload/upload.service.ts
+++ b/src/upload/upload.service.ts
@@ -1,0 +1,70 @@
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { unlink, writeFile } from 'node:fs/promises';
+import { v4 as uuid } from 'uuid';
+import { JobsService } from '../jobs/jobs.service';
+import { GraphService } from '../graph/graph.service';
+
+@Injectable()
+export class UploadService {
+  private readonly logger = new Logger('UploadService');
+
+  constructor(
+    private readonly jobs: JobsService,
+    private readonly graphSvc: GraphService,
+  ) {}
+
+  processFile(
+    file: Express.Multer.File,
+    context?: string,
+    modelId?: string,
+  ): string {
+    const jobId = uuid();
+
+    let { path: filePath } = file;
+    const { originalname: filename, mimetype, buffer } = file;
+
+    this.logger.log(
+      `File properties - File Path: ${filePath}, Buffer: ${buffer ? 'Present' : 'Missing'}, Name: ${filename}, Type: ${mimetype}`,
+    );
+
+    this.jobs.enqueue(jobId, async () => {
+      try {
+        if (!filePath) {
+          if (!buffer) {
+            throw new BadRequestException(
+              'File content unavailable (no path or buffer)',
+            );
+          }
+          // Create temp file from buffer
+          // We need a temp path. Using /tmp directly or process.env
+          const tempPath = `/tmp/${jobId}-${filename}`;
+          await writeFile(tempPath, buffer);
+          filePath = tempPath;
+        }
+
+        return await this.graphSvc.generateGraphFromFile(
+          filename,
+          filePath,
+          mimetype,
+          context,
+          modelId,
+        );
+      } finally {
+        // Only delete file if we created it (isTempFile) OR if it was a temp upload that we want to clean up (which is usually the case for upload endpoints)
+        // Assuming we always want to clean up the uploaded file after processing
+        if (filePath) {
+          try {
+            await unlink(filePath);
+          } catch (cleanupError) {
+            console.error(
+              '`Failed to delete temporary file ${filePath}:`',
+              cleanupError,
+            );
+          }
+        }
+      }
+    });
+
+    return jobId;
+  }
+}

--- a/src/upload/upload.service.ts
+++ b/src/upload/upload.service.ts
@@ -50,8 +50,6 @@ export class UploadService {
           modelId,
         );
       } finally {
-        // Only delete file if we created it (isTempFile) OR if it was a temp upload that we want to clean up (which is usually the case for upload endpoints)
-        // Assuming we always want to clean up the uploaded file after processing
         if (filePath) {
           try {
             await unlink(filePath);


### PR DESCRIPTION
- Ported the endpoints from the SWE FYP project
- New modules: `graph`, `llm`, `jobs`, `upload`

Notes:
- Not sure if some of the ported endpoints require `ApiAuthBearer()` 
- Still using an in-memory job queue, will implement using RabbitMQ or redis in another issue
- There are some es-lint errors due to the types from `pdf-parse` not being robust(?) enough, so there are a few lines where es-lint is disabled