### PR TITLE
feat: add DB-backed background job status tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 dist
 node_modules
 
+# Claude
+.claude/
+
 # Logs
 logs
 *.log

--- a/prisma/migrations/20260226164138_add_background_job/migration.sql
+++ b/prisma/migrations/20260226164138_add_background_job/migration.sql
@@ -1,0 +1,15 @@
+-- CreateEnum
+CREATE TYPE "JobStatus" AS ENUM ('PENDING', 'ACTIVE', 'COMPLETED', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "BackgroundJob" (
+    "jobId" UUID NOT NULL,
+    "type" TEXT NOT NULL,
+    "status" "JobStatus" NOT NULL DEFAULT 'PENDING',
+    "result" JSON,
+    "error" TEXT,
+    "createdDate" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastModified" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "background_job_pkey" PRIMARY KEY ("jobId")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -137,3 +137,20 @@ enum RequestStatus {
   REJECTED
   APPROVED
 }
+
+enum JobStatus {
+  PENDING
+  ACTIVE
+  COMPLETED
+  FAILED
+}
+
+model BackgroundJob {
+  jobId        String    @id(map: "background_job_pkey") @default(uuid()) @db.Uuid
+  type         String    @db.Text
+  status       JobStatus @default(PENDING)
+  result       Json?     @db.Json
+  error        String?   @db.Text
+  createdDate  DateTime  @default(now()) @db.Timestamp(6)
+  lastModified DateTime  @default(now()) @updatedAt @db.Timestamp(6)
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -21,6 +21,7 @@ import { AdminConfigService } from './config/admin-config.service';
 import { AuthConfigService } from './config/auth-config.service';
 import { AnalysisModule } from './analysis/analysis.module';
 import { CoordinatorModule } from './coordinator/coordinator.module';
+import { JobModule } from './job/job.module';
 
 @Module({
   imports: [
@@ -47,6 +48,7 @@ import { CoordinatorModule } from './coordinator/coordinator.module';
     AtlasModule,
     DockerModule,
     CoordinatorModule,
+    JobModule,
   ],
   controllers: [AppController],
   providers: [AdminConfigService, AuthConfigService],

--- a/src/job/dto/index.ts
+++ b/src/job/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './job-status-response.dto';

--- a/src/job/dto/job-status-response.dto.ts
+++ b/src/job/dto/job-status-response.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class JobStatusResponseDto {
+  @ApiProperty({ description: 'Job UUID' })
+  jobId!: string;
+
+  @ApiProperty({
+    description: 'Job status',
+    enum: ['pending', 'completed', 'error'],
+  })
+  status!: 'pending' | 'completed' | 'error';
+
+  @ApiPropertyOptional({ description: 'Job result payload' })
+  result?: unknown;
+
+  @ApiPropertyOptional({ description: 'Error message if job failed' })
+  error?: string;
+}

--- a/src/job/job.controller.ts
+++ b/src/job/job.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Get, Param, ParseUUIDPipe } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { JobService } from './job.service';
+import { JobStatusResponseDto } from './dto';
+import { $Enums } from 'src/generated/prisma/client';
+
+@ApiTags('Jobs')
+@Controller('jobs')
+export class JobController {
+  constructor(private readonly jobService: JobService) {}
+
+  @ApiOperation({ summary: 'Get background job status' })
+  @ApiOkResponse({ type: JobStatusResponseDto })
+  @Get(':jobId/status')
+  async getJobStatus(
+    @Param('jobId', ParseUUIDPipe) jobId: string,
+  ): Promise<JobStatusResponseDto> {
+    const job = await this.jobService.getJobStatus(jobId);
+
+    const statusMap: Record<$Enums.JobStatus, JobStatusResponseDto['status']> =
+      {
+        PENDING: 'pending',
+        ACTIVE: 'pending',
+        COMPLETED: 'completed',
+        FAILED: 'error',
+      };
+
+    return {
+      jobId: job.jobId,
+      status: statusMap[job.status],
+      ...(job.result != null && { result: job.result }),
+      ...(job.error != null && { error: job.error }),
+    };
+  }
+}

--- a/src/job/job.module.ts
+++ b/src/job/job.module.ts
@@ -1,0 +1,11 @@
+import { Global, Module } from '@nestjs/common';
+import { JobService } from './job.service';
+import { JobController } from './job.controller';
+
+@Global()
+@Module({
+  controllers: [JobController],
+  providers: [JobService],
+  exports: [JobService],
+})
+export class JobModule {}

--- a/src/job/job.service.ts
+++ b/src/job/job.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class JobService {
+  private readonly logger = new Logger(JobService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createJob(type: string): Promise<string> {
+    const job = await this.prisma.backgroundJob.create({
+      data: { type },
+    });
+    this.logger.log(`Created background job ${job.jobId} (type=${type})`);
+    return job.jobId;
+  }
+
+  async markActive(jobId: string) {
+    await this.prisma.backgroundJob.update({
+      where: { jobId },
+      data: { status: 'ACTIVE' },
+    });
+  }
+
+  async markCompleted(jobId: string, result?: unknown) {
+    await this.prisma.backgroundJob.update({
+      where: { jobId },
+      data: {
+        status: 'COMPLETED',
+        result: result != null ? (result as object) : undefined,
+      },
+    });
+  }
+
+  async markFailed(jobId: string, error: string) {
+    await this.prisma.backgroundJob.update({
+      where: { jobId },
+      data: { status: 'FAILED', error },
+    });
+  }
+
+  async getJobStatus(jobId: string) {
+    const job = await this.prisma.backgroundJob.findUnique({
+      where: { jobId },
+    });
+    if (!job) {
+      throw new NotFoundException(`Job ${jobId} not found`);
+    }
+    return job;
+  }
+}

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -18,6 +18,7 @@ import {
 } from 'src/atlas/dto';
 
 import { ArchetypeJobDataDto, DataBrokerJobDataDto } from './dto';
+import { JobService } from 'src/job/job.service';
 import {
   archetypeTemplateToAtlasEntities,
   getDesiredChildNodeIdsForSource,
@@ -38,26 +39,36 @@ export class AtlasProcessor {
     private readonly docker: DockerService,
     private readonly atlas: AtlasService,
     private prisma: PrismaService,
+    private readonly jobService: JobService,
   ) {}
 
   @Process('process-data-broker')
   async handleDataBrokerJob(job: Job) {
-    const { owner, projectId, requestId, database } =
+    const { jobId, owner, projectId, requestId, database } =
       job.data as DataBrokerJobDataDto;
     this.logger.log(
       `Handling 'process-data-broker' for requestId ${requestId}...`,
     );
-    return await this.docker.runDataBroker(
-      owner,
-      projectId,
-      requestId,
-      database,
-    );
+    await this.jobService.markActive(jobId);
+    try {
+      const result = await this.docker.runDataBroker(
+        owner,
+        projectId,
+        requestId,
+        database,
+      );
+      await this.jobService.markCompleted(jobId, result);
+      return result;
+    } catch (error) {
+      await this.jobService.markFailed(jobId, String(error));
+      throw error;
+    }
   }
 
   @Process('process-add-archetype')
   async handleAddArchetypeJob(job: Job) {
-    const { owner, projectId, archetype } = job.data as ArchetypeJobDataDto;
+    const { jobId, owner, projectId, archetype } =
+      job.data as ArchetypeJobDataDto;
     this.logger.log(
       `Handling 'process-add-archetype' for projectId ${projectId}...`,
     );
@@ -68,6 +79,7 @@ export class AtlasProcessor {
       );
       return await this.handleUpdateArchetypeJob(job);
     }
+    await this.jobService.markActive(jobId);
     try {
       //  1. create archetype_template entity
       // generate new unique archetypeId (nanoid)
@@ -125,21 +137,26 @@ export class AtlasProcessor {
         `Handling 'process-add-archetype' for projectId ${projectId} DONE!`,
         `Created archetype ${archetype.archetypeId} with status ${archetype.status}`,
       );
+      await this.jobService.markCompleted(jobId, archetype.archetypeId);
       return archetype.archetypeId;
     } catch (error) {
       this.logger.error(
         `Error creating archetype for project ${archetype.projectId}: `,
         error,
       );
+      await this.jobService.markFailed(jobId, String(error));
+      throw error;
     }
   }
 
   @Process('process-update-archetype')
   async handleUpdateArchetypeJob(job: Job) {
-    const { owner, projectId, archetype } = job.data as ArchetypeJobDataDto;
+    const { jobId, owner, projectId, archetype } =
+      job.data as ArchetypeJobDataDto;
     this.logger.log(
       `Handling 'process-update-archetype' for archetype ${archetype.archetypeId}...`,
     );
+    await this.jobService.markActive(jobId);
     try {
       const updateEntities: AtlasSubmitArchetypeEntityDto[] = [];
       // separate columns from archetype_nodes
@@ -315,24 +332,29 @@ export class AtlasProcessor {
         `Updated archetype ${archetype.archetypeId} with status ${archetype.status}`,
       );
 
+      await this.jobService.markCompleted(jobId, archetype.archetypeId);
       return archetype.archetypeId;
     } catch (error) {
       this.logger.error(
         `Error updating archetype ${archetype.archetypeId}: `,
         error,
       );
+      await this.jobService.markFailed(jobId, String(error));
+      throw error;
     }
   }
 
   @Process('process-delete-archetype')
   async handleDeleteArchetypeJob(job: Job) {
-    const { archetypeId, projectId } = job.data as {
+    const { jobId, archetypeId, projectId } = job.data as {
+      jobId: string;
       archetypeId: string;
       projectId: string;
     };
     this.logger.log(
       `Handling 'process-delete-archetype' for archetype ${archetypeId}...`,
     );
+    await this.jobService.markActive(jobId);
     try {
       await this.atlas.delete(
         `/entity/uniqueAttribute/type/${AtlasArchetypeTypeName.Template}`,
@@ -345,9 +367,12 @@ export class AtlasProcessor {
       this.logger.log(
         `Handling 'process-delete-archetype' for archetype ${archetypeId} DONE!`,
       );
+      await this.jobService.markCompleted(jobId, projectId);
       return projectId;
     } catch (error) {
       this.logger.error(`Error deleting archetype ${archetypeId}: `, error);
+      await this.jobService.markFailed(jobId, String(error));
+      throw error;
     }
   }
 

--- a/src/queue/dto/queue.dto.ts
+++ b/src/queue/dto/queue.dto.ts
@@ -11,6 +11,10 @@ import { ArchetypeDto } from 'src/archetype/dto';
 import { DatabaseInfoDto } from 'src/connection-request/dto';
 
 export class ArchetypeJobDataDto {
+  @IsUUID()
+  @IsDefined()
+  jobId!: string;
+
   @IsString()
   @IsDefined()
   owner!: string;
@@ -25,6 +29,10 @@ export class ArchetypeJobDataDto {
 }
 
 export class AddResourceJobDataDto {
+  @IsUUID()
+  @IsDefined()
+  jobId!: string;
+
   @IsUUID()
   @IsDefined()
   id!: string;
@@ -43,6 +51,10 @@ export class AddResourceJobDataDto {
 }
 
 export class DataBrokerJobDataDto {
+  @IsUUID()
+  @IsDefined()
+  jobId!: string;
+
   @IsString()
   @IsDefined()
   owner!: string;

--- a/src/queue/keycloak.processor.ts
+++ b/src/queue/keycloak.processor.ts
@@ -26,6 +26,7 @@ import {
 } from '@epsilon-data/keycloak-admin-client';
 import { AddResourceJobDataDto } from './dto';
 import { ConfigService } from '@nestjs/config';
+import { JobService } from 'src/job/job.service';
 
 // TODO: we need properly handle failed request for all these processors
 @Injectable()
@@ -36,13 +37,15 @@ export class KeycloakProcessor {
   constructor(
     private readonly keycloak: KeycloakAdminService,
     private readonly configService: ConfigService,
+    private readonly jobService: JobService,
   ) {}
 
   @Process('process-add-resource')
   async handleAddResource(job: Job) {
-    const { id, ownerId, collaborators, custodian } =
+    const { jobId, id, ownerId, collaborators, custodian } =
       job.data as AddResourceJobDataDto;
     this.logger.log(`Handling 'process-add-resource' for resource id ${id}...`);
+    await this.jobService.markActive(jobId);
     try {
       // TODO: better error handling
       // reauth with keycloak client
@@ -185,8 +188,11 @@ export class KeycloakProcessor {
           policies: [`${custodianPolicyPrefix}${id}`],
         });
       }
+      await this.jobService.markCompleted(jobId);
     } catch (error) {
       this.logger.error(`Error creating resource`, error);
+      await this.jobService.markFailed(jobId, String(error));
+      throw error;
     }
   }
 }

--- a/src/queue/queue.service.ts
+++ b/src/queue/queue.service.ts
@@ -3,6 +3,7 @@ import { InjectQueue } from '@nestjs/bull';
 import type { Queue } from 'bull';
 import { ArchetypeDto } from 'src/archetype/dto';
 import { DatabaseInfoDto } from 'src/connection-request/dto';
+import { JobService } from 'src/job/job.service';
 
 @Injectable()
 export class QueueService {
@@ -10,6 +11,7 @@ export class QueueService {
   constructor(
     @InjectQueue('atlas-queue') private atlasQueue: Queue,
     @InjectQueue('keycloak-queue') private keycloakQueue: Queue,
+    private readonly jobService: JobService,
   ) {}
 
   async addResourceJob(
@@ -22,9 +24,11 @@ export class QueueService {
       `Submitting 'process-add-resource' to queue with resource id ${id}`,
     );
 
-    return await this.keycloakQueue.add(
+    const jobId = await this.jobService.createJob('process-add-resource');
+    await this.keycloakQueue.add(
       'process-add-resource',
       {
+        jobId,
         id,
         ownerId,
         collaborators,
@@ -35,6 +39,7 @@ export class QueueService {
         backoff: 10000,
       },
     );
+    return { jobId };
   }
 
   async dataBrokerJob(
@@ -46,9 +51,11 @@ export class QueueService {
     this.logger.log(
       `Submitting 'process-data-broker' to queue with requestId ${requestId}`,
     );
-    return await this.atlasQueue.add(
+    const jobId = await this.jobService.createJob('process-data-broker');
+    await this.atlasQueue.add(
       'process-data-broker',
       {
+        jobId,
         owner,
         projectId,
         requestId,
@@ -60,6 +67,7 @@ export class QueueService {
         backoff: 10000,
       },
     );
+    return { jobId };
   }
 
   async addArchetypeJob(
@@ -70,9 +78,11 @@ export class QueueService {
     this.logger.log(
       `Submitting 'process-add-archetype' to queue for projectId ${archetype.projectId}`,
     );
-    return await this.atlasQueue.add(
+    const jobId = await this.jobService.createJob('process-add-archetype');
+    await this.atlasQueue.add(
       'process-add-archetype',
       {
+        jobId,
         owner,
         projectId: projectId,
         archetype,
@@ -82,6 +92,7 @@ export class QueueService {
         backoff: 10000,
       },
     );
+    return { jobId };
   }
 
   async updateArchetypeJob(
@@ -93,28 +104,32 @@ export class QueueService {
     this.logger.log(
       `Submitting 'process-update-archetype' to queue for archetypeId ${archetypeId}`,
     );
-    return await this.atlasQueue.add(
+    const jobId = await this.jobService.createJob('process-update-archetype');
+    await this.atlasQueue.add(
       'process-update-archetype',
       {
+        jobId,
         owner,
         projectId,
         archetype,
       },
       {
-        // NOTE: add jobid?
         attempts: 5,
         backoff: 10000,
       },
     );
+    return { jobId };
   }
 
   async deleteArchetypeJob(projectId: string, archetypeId: string) {
     this.logger.log(
       `Submitting 'process-delete-archetype' to queue with archetypeId ${archetypeId}...`,
     );
-    return await this.atlasQueue.add(
+    const jobId = await this.jobService.createJob('process-delete-archetype');
+    await this.atlasQueue.add(
       'process-delete-archetype',
       {
+        jobId,
         projectId,
         archetypeId,
       },
@@ -123,6 +138,7 @@ export class QueueService {
         backoff: 10000,
       },
     );
+    return { jobId };
   }
 
   async getJobResult(jobId: number | string) {


### PR DESCRIPTION
Add BackgroundJob table and JobModule to track Bull queue job lifecycle (PENDING → ACTIVE → COMPLETED/FAILED) in PostgreSQL. QueueService now creates a DB record before queuing and passes jobId to processors. Frontend can poll GET /jobs/:jobId/status for progress visibility.