### PR TITLE
feat(api): cleanup Atlas resources on project delete

### DIFF
--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -518,6 +518,8 @@ export class ProjectService {
   }
 
   async deleteProject(projectId: string) {
+    // queue Atlas cleanup (fire-and-forget, retries on its own)
+    await this.queue.deleteProjectAtlasJob(projectId);
     // delete project information
     await this.prisma.project.delete({
       where: {

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -14,10 +14,15 @@ import {
   AtlasExistingNode,
   AtlasPostEntityResponseDto,
   AtlasRelatedEntityRefDto,
+  AtlasSearchBasicResponseDto,
   AtlasSubmitArchetypeEntityDto,
 } from 'src/atlas/dto';
 
-import { ArchetypeJobDataDto, DataBrokerJobDataDto } from './dto';
+import {
+  ArchetypeJobDataDto,
+  DataBrokerJobDataDto,
+  DeleteProjectAtlasJobDataDto,
+} from './dto';
 import { JobService } from 'src/job/job.service';
 import {
   archetypeTemplateToAtlasEntities,
@@ -371,6 +376,78 @@ export class AtlasProcessor {
       return projectId;
     } catch (error) {
       this.logger.error(`Error deleting archetype ${archetypeId}: `, error);
+      await this.jobService.markFailed(jobId, String(error));
+      throw error;
+    }
+  }
+
+  @Process('process-delete-project-atlas')
+  async handleDeleteProjectAtlasJob(job: Job) {
+    const { jobId, projectId } = job.data as DeleteProjectAtlasJobDataDto;
+    this.logger.log(
+      `Handling 'process-delete-project-atlas' for projectId ${projectId}...`,
+    );
+    await this.jobService.markActive(jobId);
+    try {
+      // 1. Delete all archetype_templates for this project
+      const searchRes = await this.atlas.post<AtlasSearchBasicResponseDto>(
+        '/search/basic',
+        {
+          typeName: AtlasArchetypeTypeName.Template,
+          excludeDeletedEntities: true,
+          includeSubTypes: false,
+          entityFilters: {
+            attributeName: 'projectId',
+            operator: 'eq',
+            attributeValue: projectId,
+          },
+          attributes: ['qualifiedName'],
+        },
+      );
+
+      const archetypeEntities = searchRes?.entities ?? [];
+      for (const entity of archetypeEntities) {
+        const qualifiedName = entity.attributes?.qualifiedName as string;
+        if (!qualifiedName) continue;
+        try {
+          await this.atlas.delete(
+            `/entity/uniqueAttribute/type/${AtlasArchetypeTypeName.Template}`,
+            { 'attr:qualifiedName': qualifiedName },
+          );
+        } catch (err: unknown) {
+          const status = (err as { response?: { status?: number } })?.response
+            ?.status;
+          if (status !== 404) throw err;
+          this.logger.warn(
+            `Archetype template ${qualifiedName} already deleted (404), skipping.`,
+          );
+        }
+      }
+
+      // 2. Delete rdbms_instance (Atlas cascades to rdbms_db -> rdbms_table -> rdbms_column)
+      try {
+        await this.atlas.delete('/entity/uniqueAttribute/type/rdbms_instance', {
+          'attr:projectId': projectId,
+        });
+      } catch (err: unknown) {
+        const status = (err as { response?: { status?: number } })?.response
+          ?.status;
+        if (status !== 404) throw err;
+        this.logger.warn(
+          `No rdbms_instance for project ${projectId} (404), skipping.`,
+        );
+      }
+
+      this.logger.log(
+        `Handling 'process-delete-project-atlas' for projectId ${projectId} DONE!`,
+      );
+      await this.jobService.markCompleted(jobId, projectId);
+      return projectId;
+    } catch (error) {
+      this.logger.error(
+        `Error cleaning up Atlas entities for project ${projectId}: `,
+        error,
+      );
       await this.jobService.markFailed(jobId, String(error));
       throw error;
     }

--- a/src/queue/dto/queue.dto.ts
+++ b/src/queue/dto/queue.dto.ts
@@ -50,6 +50,16 @@ export class AddResourceJobDataDto {
   custodian?: string;
 }
 
+export class DeleteProjectAtlasJobDataDto {
+  @IsUUID()
+  @IsDefined()
+  jobId!: string;
+
+  @IsString()
+  @IsDefined()
+  projectId!: string;
+}
+
 export class DataBrokerJobDataDto {
   @IsUUID()
   @IsDefined()

--- a/src/queue/queue.service.ts
+++ b/src/queue/queue.service.ts
@@ -121,6 +121,27 @@ export class QueueService {
     return { jobId };
   }
 
+  async deleteProjectAtlasJob(projectId: string) {
+    this.logger.log(
+      `Submitting 'process-delete-project-atlas' to queue with projectId ${projectId}...`,
+    );
+    const jobId = await this.jobService.createJob(
+      'process-delete-project-atlas',
+    );
+    await this.atlasQueue.add(
+      'process-delete-project-atlas',
+      {
+        jobId,
+        projectId,
+      },
+      {
+        attempts: 5,
+        backoff: 10000,
+      },
+    );
+    return { jobId };
+  }
+
   async deleteArchetypeJob(projectId: string, archetypeId: string) {
     this.logger.log(
       `Submitting 'process-delete-archetype' to queue with archetypeId ${archetypeId}...`,


### PR DESCRIPTION
Queue a background job to delete all archetype_templates and the rdbms_instance (cascading to databases, tables, columns) when a project is deleted.