### PR TITLE
fix: onboarding flow bugs and data integrity issues

### DIFF
--- a/src/admin/keycloak/keycloak-admin.service.ts
+++ b/src/admin/keycloak/keycloak-admin.service.ts
@@ -290,7 +290,7 @@ export class KeycloakAdminService implements OnModuleInit {
         { catchNotFound: false },
       );
     } catch (error) {
-      return this.logKeycloakError('checkUser', error);
+      return this.handleKeycloakError('checkUser', error);
     }
   }
 
@@ -481,16 +481,21 @@ export class KeycloakAdminService implements OnModuleInit {
       `Modifying policy ${analysisPolicyPrefix}${projectId}, adding user ${userId}`,
     );
     try {
+      this.logger.debug(
+        `Looking up existing policy: ${analysisPolicyPrefix}${projectId}`,
+      );
       const existingPolicy = await this.kcAdminClient.clients.findPolicyByName({
         id: this.defaultClient.id!,
         realm: this.config.realm,
         name: `${analysisPolicyPrefix}${projectId}`,
       });
+      this.logger.debug(`Existing policy found: ${!!existingPolicy}`);
       let policy: PolicyRepresentation = {
         name: `${analysisPolicyPrefix}${projectId}`,
         decisionStrategy: DecisionStrategy.UNANIMOUS,
         type: 'user',
         logic: Logic.POSITIVE,
+        users: [userId],
       };
       if (existingPolicy) {
         existingPolicy.config ??= {};
@@ -518,11 +523,15 @@ export class KeycloakAdminService implements OnModuleInit {
           users: Array.from(existingUsers),
         };
       }
+      this.logger.debug(
+        `Creating/updating policy with users: ${JSON.stringify(policy.users)}`,
+      );
       await this.kcAdminClient.clients.createOrUpdatePolicy({
         id: this.defaultClient.id!,
         policyName: `${analysisPolicyPrefix}${projectId}`,
         policy: policy,
       });
+      this.logger.debug(`Policy created/updated successfully`);
 
       if (!existingPolicy)
         // create analysis permission as the existing Policy didn't exist

--- a/src/analysis-request/analysis-request.service.ts
+++ b/src/analysis-request/analysis-request.service.ts
@@ -149,6 +149,15 @@ export class AnalysisRequestService {
   }
 
   async createRequest(userId: string, dto: AnalysisDto) {
+    const existing = await this.prisma.analysis.findFirst({
+      where: { projectId: dto.projectId, request: { requestorId: userId } },
+    });
+    if (existing) {
+      throw new BadRequestException(
+        'An access request for this project already exists',
+      );
+    }
+
     const request = {
       requestorName: dto.requestorName,
       requestorEmail: dto.requestorEmail,
@@ -185,14 +194,15 @@ export class AnalysisRequestService {
     });
 
     if (project?.isPublic) {
+      // grant Keycloak permissions first — if this fails, request stays PENDING
+      await this.keycloak.auth();
+      await this.keycloak.addUserToUserPolicy(dto.projectId, userId);
       await this.prisma.request.update({
         where: { requestId: createdRequest.requestId },
         data: {
           status: $Enums.RequestStatus.APPROVED,
         },
       });
-      await this.keycloak.auth();
-      await this.keycloak.addUserToUserPolicy(dto.projectId, userId);
     }
 
     return; // no content return
@@ -204,18 +214,20 @@ export class AnalysisRequestService {
     dto: AnalysisStatusDto,
   ) {
     const { status } = dto;
-    const result = await this.prisma.request.update({
-      where: { requestId: requestId },
-      data: {
-        status,
-      },
-    });
+
     if (status === $Enums.RequestStatus.APPROVED) {
-      // update client auth
+      const request = await this.prisma.request.findUniqueOrThrow({
+        where: { requestId },
+      });
+      // grant Keycloak permissions first — if this fails, DB stays unchanged
       await this.keycloak.auth();
-      // TODO: need proper error handling here from keycloak or go via queue
-      await this.keycloak.addUserToUserPolicy(projectId, result.requestorId);
+      await this.keycloak.addUserToUserPolicy(projectId, request.requestorId);
     }
+
+    await this.prisma.request.update({
+      where: { requestId: requestId },
+      data: { status },
+    });
     return;
   }
 

--- a/src/archetype/archetype.service.spec.ts
+++ b/src/archetype/archetype.service.spec.ts
@@ -572,7 +572,7 @@ describe('ArchetypeService', () => {
   });
 
   describe('getPublishedArchetype', () => {
-    it('builds published template info with nodes, edges, minus columns and permissions', async () => {
+    it('builds published template info with nodes, edges, permissions, minus columns', async () => {
       const projectId = '16297faf-b27d-4227-913b-9ccf4c480211';
       const templateGuid = 'template-guid';
       const archetypeId = '8ryVfIcqIpqN';
@@ -798,8 +798,10 @@ describe('ArchetypeService', () => {
       )!;
       expect(columnEdge).toBeUndefined();
 
-      // Permissions should be undefined
-      expect(result.permissions).toBeUndefined();
+      // Permissions: catNode has DETAILED, root is skipped, propagated is ignored
+      expect(result.permissions).toEqual([
+        { id: catNodeId, permission: 'DETAILED' },
+      ]);
     });
 
     // TODO: this needs to be better tested

--- a/src/archetype/archetype.service.ts
+++ b/src/archetype/archetype.service.ts
@@ -320,6 +320,7 @@ export class ArchetypeService {
       status: entityRes.entity?.attributes?.status as ArchetypeStatus,
       nodes: [],
       edges: [],
+      permissions: [],
       lastModified: new Date(entityRes.entity?.updateTime),
     };
 
@@ -369,6 +370,27 @@ export class ArchetypeService {
             target: nodeId,
           };
           templateInfo.edges!.push(edge);
+        }
+
+        // add permissions (skip root node)
+        if (entity.attributes?.level !== 0) {
+          const analysisPermission = (() => {
+            const permission = entity.classifications?.find(
+              (c) =>
+                c.typeName === 'archetype_node_analysis_permissions' &&
+                c.entityStatus === 'ACTIVE' &&
+                entity.guid === c.entityGuid,
+            );
+            return permission
+              ? {
+                  id: nodeId,
+                  permission: permission?.attributes
+                    ?.access_level as ArchetypePermission,
+                }
+              : null;
+          })();
+          if (analysisPermission)
+            templateInfo.permissions!.push(analysisPermission);
         }
       }
     }

--- a/src/connection-request/connection-request.service.ts
+++ b/src/connection-request/connection-request.service.ts
@@ -108,7 +108,7 @@ export class ConnectionRequestService {
       ? $Enums.RequestStatus.APPROVED
       : $Enums.RequestStatus.REJECTED;
 
-    // database credentials should exist so run database crawling
+    // run vault/connection flow first — if this fails, status stays unchanged
     if (status === $Enums.RequestStatus.APPROVED && dto.dbDetails?.url) {
       await this.vaultService.runConnectionFlow(
         user,
@@ -118,13 +118,13 @@ export class ConnectionRequestService {
         accessToken,
       );
     }
+    // only update status after external operations succeed
     await this.prisma.request.update({
       where: { requestId: requestId },
       data: {
         status,
       },
     });
-    // just return, no content
     return;
   }
 

--- a/src/project/project.service.spec.ts
+++ b/src/project/project.service.spec.ts
@@ -210,6 +210,7 @@ describe('ProjectService', () => {
           status: {
             in: ['MAPPED'],
           },
+          isPublic: true,
         },
         select: {
           projectId: true,
@@ -219,6 +220,7 @@ describe('ProjectService', () => {
           dbKeywords: true,
           university: true,
           faculty: true,
+          isPublic: true,
         },
       });
       expect(result).toEqual(projects);

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -91,6 +91,7 @@ export class ProjectService {
         status: {
           in: ['MAPPED'],
         },
+        isPublic: true,
       },
       select: {
         projectId: true,
@@ -100,6 +101,7 @@ export class ProjectService {
         university: true,
         faculty: true,
         dbKeywords: true,
+        isPublic: true,
       },
     });
   }
@@ -142,6 +144,7 @@ export class ProjectService {
 
     const analyses = await this.prisma.analysis.findMany({
       where: {
+        projectId: projectId,
         project: {
           ownerId: userId,
         },
@@ -415,7 +418,9 @@ export class ProjectService {
       },
     });
 
-    const memberEmails = dto.members.flatMap((m) => (m.email ? [m.email] : []));
+    const memberEmails = [
+      ...new Set(dto.members.flatMap((m) => (m.email ? [m.email] : []))),
+    ].filter((email) => email !== user.email);
 
     // add keycloak resource
     await this.queue.addResourceJob(
@@ -518,6 +523,9 @@ export class ProjectService {
   }
 
   async deleteProject(projectId: string) {
+    // delete keycloak resource first — if this fails, project stays intact
+    await this.keycloak.auth();
+    await this.keycloak.deleteResource(projectId);
     // queue Atlas cleanup (fire-and-forget, retries on its own)
     await this.queue.deleteProjectAtlasJob(projectId);
     // delete project information
@@ -530,9 +538,6 @@ export class ProjectService {
         analysis: true,
       },
     });
-    // delete keycloak resource
-    await this.keycloak.auth();
-    await this.keycloak.deleteResource(projectId);
     return;
   }
 

--- a/src/queue/keycloak.processor.ts
+++ b/src/queue/keycloak.processor.ts
@@ -57,7 +57,9 @@ export class KeycloakProcessor {
         throw new Error(
           `Owner with id ${ownerId} doesn't exists. This should not happen!`,
         );
-      const ownerUsername = owner.username!;
+      if (!owner.username)
+        throw new Error(`Owner ${ownerId} has no username in Keycloak`);
+      const ownerUsername = owner.username;
 
       // get authorisationservice client
       const authClient = this.configService.get<string>('auth.clientId');
@@ -146,9 +148,16 @@ export class KeycloakProcessor {
             });
             return await this.keycloak.setUserActions(user.id);
           } else {
-            return users.map(async (user: UserRepresentation) => {
-              await this.keycloak.addUserToGroup(user.id!, createGroup.id);
-            });
+            await Promise.all(
+              users
+                .filter(
+                  (user): user is UserRepresentation & { id: string } =>
+                    !!user.id,
+                )
+                .map((user) =>
+                  this.keycloak.addUserToGroup(user.id, createGroup.id),
+                ),
+            );
           }
         });
         await Promise.all(collabQueries);
@@ -167,8 +176,10 @@ export class KeycloakProcessor {
           await this.keycloak.setUserActions(user.id);
         } else {
           const user = users[0];
-          custodianUserName = user.username!;
-          await this.keycloak.addUserToGroup(user.id!, createGroup.id);
+          if (!user.id)
+            throw new Error(`Custodian user ${custodian} has no ID`);
+          custodianUserName = user.username ?? custodian;
+          await this.keycloak.addUserToGroup(user.id, createGroup.id);
         }
         // create custodian policy
         await this.keycloak.createPolicy(client, 'user', {


### PR DESCRIPTION
- Fix analysis requests leaking across projects (missing projectId filter)
- Fix nested Promise.all not awaiting in keycloak processor
- Fix Keycloak/DB state mismatch: run external calls before DB updates
- Fix checkUser swallowing errors (use handleKeycloakError)
- Fix duplicate analysis request creation (add existence check)
- Fix project delete order: Keycloak cleanup before DB delete
- Fix non-null assertions with proper null guards
- Deduplicate member emails and exclude owner on project create
- Add isPublic filter and field to getAllProjects (browse hub)
- Add permissions extraction to published archetype
- Add debug logging to addUserToUserPolicy