### PR TITLE
feat: add pipeline resilience and retry-crawl endpoint

### DIFF
--- a/src/docker/docker.service.ts
+++ b/src/docker/docker.service.ts
@@ -111,6 +111,7 @@ export class DockerService {
         },
       });
       this.logger.error(`Error running container ${instanceName}: `, error);
+      throw error;
     }
   }
 
@@ -143,19 +144,39 @@ export class DockerService {
       },
     });
 
-    // remove container if stopped
     if (existingContainers.length > 0) {
+      const existingContainer = this.docker.getContainer(
+        existingContainers[0].Id,
+      );
+
       if (await this.isContainerRunning(existingContainers[0].Id as string)) {
         this.logger.debug(`Running image ${imageName} exists, monitoring...`);
-        return await this.docker.getContainer(existingContainers[0].Id);
-      } else {
-        const existingContainer = this.docker.getContainer(
-          existingContainers[0].Id,
-        );
-        // should ne stopped, but just in case
-        await existingContainer.stop();
-        await existingContainer.remove();
+        return existingContainer;
       }
+
+      // Container exists but is stopped — check if it already finished successfully
+      const inspect = await existingContainer.inspect();
+      const exitCode = inspect.State?.ExitCode ?? 1;
+      const logs = await this.readAllLogs(existingContainer);
+      const done = /(^|\n)DONE(\r?\n|$)/.test(logs);
+
+      if (done || exitCode === 0) {
+        this.logger.log(
+          `Stopped container ${name} already completed successfully (exit=${exitCode}), reusing it.`,
+        );
+        return existingContainer;
+      }
+
+      // Container failed — clean up and create a fresh one
+      try {
+        await existingContainer.stop();
+      } catch {
+        // container may already be stopped (HTTP 304), ignore
+      }
+      await existingContainer.remove();
+      this.logger.debug(
+        `Removed existing failed container ${name} (exit=${exitCode}), creating fresh one...`,
+      );
     }
     const container = await this.docker.createContainer({
       Image: imageName,

--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -514,6 +514,20 @@ export class ProjectController {
     );
   }
 
+  @UseGuards(ResourceGuard)
+  @Scopes('edit', 'connect')
+  @Post(':projectId/retry-crawl')
+  @ApiOperation({ summary: 'Retry failed crawl for a project' })
+  @ApiOkResponse({ description: 'Crawl retried, returns jobId' })
+  @ApiBadRequestResponse({ type: GenericErrorResponseDto })
+  @ApiNotFoundResponse({ type: GenericErrorResponseDto })
+  async retryCrawl(
+    @CurrentUser() user: CurrentUserInfo,
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+  ) {
+    return await this.projectService.retryCrawl(user, projectId);
+  }
+
   // TODO: need to see if this is needed
   @UseGuards(ResourceGuard)
   @Scopes('view', 'edit')

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -600,6 +600,41 @@ export class ProjectService {
     return;
   }
 
+  async retryCrawl(user: CurrentUserInfo, projectId: string) {
+    const project = await this.prisma.project.findUnique({
+      where: { projectId },
+      select: { status: true },
+    });
+
+    if (!project) throw new NotFoundException('Project not found');
+    if (project.status !== 'ERROR') {
+      throw new BadRequestException(
+        `Cannot retry crawl for project with status ${project.status}`,
+      );
+    }
+
+    // resubmit using existing job data from Redis
+    try {
+      const { jobId } = await this.queue.retryCrawlJob(
+        projectId,
+        user.username,
+      );
+
+      // only set CRAWLING after job is successfully queued
+      await this.prisma.project.update({
+        where: { projectId },
+        data: { status: 'CRAWLING' },
+      });
+
+      this.logger.log(`Retry crawl for project ${projectId}, jobId: ${jobId}`);
+      return { jobId };
+    } catch (error) {
+      throw new BadRequestException(
+        error instanceof Error ? error.message : 'Failed to retry crawl',
+      );
+    }
+  }
+
   async updateCredentials(
     user: CurrentUserInfo,
     projectId: string,

--- a/src/queue/queue.module.ts
+++ b/src/queue/queue.module.ts
@@ -21,8 +21,14 @@ import { KeycloakProcessor } from './keycloak.processor';
       }),
     }),
     BullModule.registerQueue(
-      { name: 'atlas-queue' },
-      { name: 'keycloak-queue' },
+      {
+        name: 'atlas-queue',
+        settings: { maxStalledCount: 5 },
+      },
+      {
+        name: 'keycloak-queue',
+        settings: { maxStalledCount: 5 },
+      },
     ),
     DockerModule,
   ],

--- a/src/queue/queue.service.ts
+++ b/src/queue/queue.service.ts
@@ -1,18 +1,192 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bull';
-import type { Queue } from 'bull';
+import type { Queue, Job } from 'bull';
 import { ArchetypeDto } from 'src/archetype/dto';
 import { DatabaseInfoDto } from 'src/connection-request/dto';
 import { JobService } from 'src/job/job.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+type BullJobData = {
+  jobId?: string;
+  owner?: string;
+  projectId?: string;
+  requestId?: string;
+  database?: DatabaseInfoDto;
+};
 
 @Injectable()
-export class QueueService {
+export class QueueService implements OnModuleInit {
   private readonly logger = new Logger(QueueService.name);
   constructor(
     @InjectQueue('atlas-queue') private atlasQueue: Queue,
     @InjectQueue('keycloak-queue') private keycloakQueue: Queue,
     private readonly jobService: JobService,
+    private readonly prisma: PrismaService,
   ) {}
+
+  async onModuleInit() {
+    await this.reconcileJobs(this.atlasQueue);
+    await this.retryFailedJobs(this.atlasQueue);
+    await this.retryFailedJobs(this.keycloakQueue);
+  }
+
+  /**
+   * On startup, sync Postgres state (backgroundJob + project.status)
+   * with Bull/Redis which is the source of truth for job execution.
+   */
+  private async reconcileJobs(queue: Queue) {
+    // 1. Completed Bull jobs → ensure backgroundJob=COMPLETED, project=READY
+    const completed = await queue.getCompleted();
+    for (const job of completed) {
+      await this.syncJobState(job, 'completed');
+    }
+
+    // 2. Failed Bull jobs (exhausted attempts) → ensure backgroundJob=FAILED, project=ERROR
+    const failed = await queue.getFailed();
+    const exhaustedJobs = failed.filter(
+      (job) => job.attemptsMade >= (job.opts.attempts ?? 1),
+    );
+    for (const job of exhaustedJobs) {
+      await this.syncJobState(job, 'failed');
+    }
+
+    // 3. Active backgroundJobs with no matching Bull job → mark as FAILED
+    const staleJobs = await this.prisma.backgroundJob.findMany({
+      where: { status: { in: ['PENDING', 'ACTIVE'] } },
+    });
+    for (const bgJob of staleJobs) {
+      // check if there's a matching Bull job still in queue
+      const allJobs = [
+        ...(await queue.getWaiting()),
+        ...(await queue.getActive()),
+        ...(await queue.getDelayed()),
+        ...failed.filter((j) => j.attemptsMade < (j.opts.attempts ?? 1)),
+      ];
+      const hasBullJob = allJobs.some(
+        (j) => (j.data as BullJobData)?.jobId === bgJob.jobId,
+      );
+      if (!hasBullJob) {
+        this.logger.warn(
+          `Stale backgroundJob ${bgJob.jobId} (${bgJob.type}) has no matching Bull job, marking as FAILED`,
+        );
+        await this.jobService.markFailed(
+          bgJob.jobId,
+          'Job lost during API restart',
+        );
+      }
+    }
+
+    // 4. Orphaned CRAWLING projects with no matching Bull job → mark as ERROR
+    const crawlingProjects = await this.prisma.project.findMany({
+      where: { status: 'CRAWLING' },
+      select: { projectId: true },
+    });
+    const activeBullJobs = [
+      ...(await queue.getWaiting()),
+      ...(await queue.getActive()),
+      ...(await queue.getDelayed()),
+      ...failed.filter((j) => j.attemptsMade < (j.opts.attempts ?? 1)),
+    ];
+    const projectIdsWithBullJob = new Set(
+      activeBullJobs
+        .filter((j) => j.name === 'process-data-broker')
+        .map((j) => (j.data as BullJobData)?.projectId),
+    );
+    let orphanedCount = 0;
+    for (const project of crawlingProjects) {
+      if (!projectIdsWithBullJob.has(project.projectId)) {
+        await this.prisma.project.update({
+          where: { projectId: project.projectId },
+          data: { status: 'ERROR' },
+        });
+        orphanedCount++;
+        this.logger.warn(
+          `Orphaned CRAWLING project ${project.projectId} has no matching Bull job, set to ERROR`,
+        );
+      }
+    }
+
+    if (
+      completed.length ||
+      exhaustedJobs.length ||
+      staleJobs.length ||
+      orphanedCount
+    ) {
+      this.logger.log(
+        `Reconciliation done: ${completed.length} completed, ${exhaustedJobs.length} exhausted, ${staleJobs.length} stale backgroundJobs checked, ${orphanedCount} orphaned CRAWLING projects`,
+      );
+    }
+  }
+
+  private async syncJobState(job: Job, state: 'completed' | 'failed') {
+    const { jobId, projectId } = (job.data as BullJobData) ?? {};
+    if (!jobId) return;
+
+    try {
+      const bgJob = await this.prisma.backgroundJob.findUnique({
+        where: { jobId },
+      });
+      if (!bgJob || bgJob.status === 'COMPLETED' || bgJob.status === 'FAILED')
+        return;
+
+      if (state === 'completed') {
+        await this.jobService.markCompleted(jobId);
+        this.logger.log(`Synced backgroundJob ${jobId} → COMPLETED`);
+      } else {
+        await this.jobService.markFailed(
+          jobId,
+          job.failedReason ?? 'Exhausted all retry attempts',
+        );
+        this.logger.log(`Synced backgroundJob ${jobId} → FAILED`);
+      }
+
+      // sync project status for data-broker jobs
+      if (projectId && job.name === 'process-data-broker') {
+        const project = await this.prisma.project.findUnique({
+          where: { projectId },
+        });
+        if (project && project.status === 'CRAWLING') {
+          const newStatus = state === 'completed' ? 'READY' : 'ERROR';
+          await this.prisma.project.update({
+            where: { projectId },
+            data: { status: newStatus },
+          });
+          this.logger.log(`Synced project ${projectId} status → ${newStatus}`);
+        }
+      }
+    } catch (err) {
+      this.logger.warn(`Failed to sync job ${jobId}: ${err}`);
+    }
+  }
+
+  private async retryFailedJobs(queue: Queue) {
+    const failed = await queue.getFailed();
+    if (!failed.length) return;
+
+    // only retry jobs that haven't exhausted all attempts
+    const retryableJobs = failed.filter(
+      (job) => job.attemptsMade < (job.opts.attempts ?? 1),
+    );
+    if (!retryableJobs.length) return;
+
+    this.logger.log(
+      `Retrying ${retryableJobs.length} failed job(s) in '${queue.name}'...`,
+    );
+    for (const job of retryableJobs) {
+      try {
+        // assign a new jobId if missing (old jobs before job tracking)
+        const data = job.data as BullJobData;
+        if (!data.jobId) {
+          data.jobId = await this.jobService.createJob(job.name);
+          await job.update(data);
+        }
+        await job.retry();
+        this.logger.log(`Retried job ${job.id} (${job.name})`);
+      } catch (err) {
+        this.logger.warn(`Could not retry job ${job.id}: ${err}`);
+      }
+    }
+  }
 
   async addResourceJob(
     id: string,
@@ -170,6 +344,66 @@ export class QueueService {
 
     const result: unknown = await job.finished();
     return { jobId, result };
+  }
+
+  async retryCrawlJob(projectId: string, owner: string) {
+    // check for already active job for this project
+    const activeJobs = [
+      ...(await this.atlasQueue.getWaiting()),
+      ...(await this.atlasQueue.getActive()),
+      ...(await this.atlasQueue.getDelayed()),
+    ];
+    const hasActiveJob = activeJobs.some(
+      (j) =>
+        j.name === 'process-data-broker' &&
+        (j.data as BullJobData)?.projectId === projectId,
+    );
+    if (hasActiveJob) {
+      throw new Error(
+        `A data-broker job is already active for project ${projectId}`,
+      );
+    }
+
+    // find the last completed or failed data-broker job for this project
+    const finishedJobs = [
+      ...(await this.atlasQueue.getCompleted()),
+      ...(await this.atlasQueue.getFailed()),
+    ];
+
+    const previousJob = finishedJobs.find(
+      (j) =>
+        j.name === 'process-data-broker' &&
+        (j.data as BullJobData)?.projectId === projectId,
+    );
+
+    if (!previousJob) {
+      throw new Error(
+        `No previous data-broker job found for project ${projectId}`,
+      );
+    }
+
+    const { database, requestId } = previousJob.data as BullJobData;
+    this.logger.log(
+      `Retrying 'process-data-broker' for projectId ${projectId} using existing job data`,
+    );
+
+    const jobId = await this.jobService.createJob('process-data-broker');
+    await this.atlasQueue.add(
+      'process-data-broker',
+      {
+        jobId,
+        owner,
+        projectId,
+        requestId,
+        database,
+      },
+      {
+        jobId: `process-data-broker:retry:${jobId}`,
+        attempts: 5,
+        backoff: 10000,
+      },
+    );
+    return { jobId };
   }
 
   async getJob(jobId: number | string) {


### PR DESCRIPTION
- Add reconciliation on startup to sync Bull/Redis state with Postgres
- Handle orphaned CRAWLING projects and stale backgroundJobs
- Retry failed Bull jobs that have remaining attempts
- Add retry-crawl endpoint that re-queues from existing Bull job data
- Reuse stopped Docker containers that completed successfully
- Add maxStalledCount to queue config for stall recovery