### PR TITLE
feat: proxy integration, server-side pagination, and bug fixes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,26 +58,29 @@ model Analysis {
 }
 
 model Project {
-  projectId       String        @id(map: "project_pkey") @default(uuid()) @db.Uuid
-  ownerId         String        @db.Uuid
-  name            String        @db.Text
-  lead            String        @db.Text
-  university      String        @db.Text
-  faculty         String        @db.Text
-  ethicsId        String        @db.Text
-  description     String        @db.Text
-  startDate       DateTime      @db.Date
-  endDate         DateTime      @db.Date
-  lastModified    DateTime      @default(now()) @db.Timestamp(6)
-  participantsNum Int           @db.Integer
-  members         Json?         @db.Json
+  projectId       String         @id(map: "project_pkey") @default(uuid()) @db.Uuid
+  ownerId         String         @db.Uuid
+  name            String         @db.Text
+  lead            String         @db.Text
+  university      String         @db.Text
+  faculty         String         @db.Text
+  ethicsId        String         @db.Text
+  description     String         @db.Text
+  startDate       DateTime       @db.Date
+  endDate         DateTime       @db.Date
+  lastModified    DateTime       @default(now()) @db.Timestamp(6)
+  participantsNum Int            @db.Integer
+  members         Json?          @db.Json
   dbKeywords      String[]
-  createdDate     DateTime      @default(now()) @db.Date
-  visualizations  Json?         @db.Json
-  status          ProjectStatus @default(PENDING)
-  isPublic        Boolean       @default(false)
+  createdDate     DateTime       @default(now()) @db.Date
+  visualizations  Json?          @db.Json
+  status          ProjectStatus  @default(PENDING)
+  isPublic        Boolean        @default(false)
+  connectionType  ConnectionType @default(CLOUD_CONNECT)
   connection      Connection?
   analysis        Analysis[]
+  proxy              Proxy?
+  proxyInstallTokens ProxyInstallToken[]
 
   @@unique([ownerId, projectId])
 }
@@ -131,6 +134,12 @@ enum ProjectStatus {
   MAPPED
 }
 
+enum ConnectionType {
+  CLOUD_CONNECT
+  DIRECT_DB
+  PROXY
+}
+
 enum RequestStatus {
   PENDING
   REVISION
@@ -153,4 +162,37 @@ model BackgroundJob {
   error        String?   @db.Text
   createdDate  DateTime  @default(now()) @db.Timestamp(6)
   lastModified DateTime  @default(now()) @updatedAt @db.Timestamp(6)
+}
+
+model Proxy {
+  id              String      @id(map: "proxy_pkey") @default(uuid()) @db.Uuid
+  projectId       String      @unique @db.Uuid
+  project         Project     @relation(fields: [projectId], references: [projectId], onDelete: Cascade, onUpdate: NoAction, map: "fk_proxy_project_id")
+  proxyToken      String?     @unique @db.Text
+  ratholeToken    String?     @db.Text
+  noisePublicKey  String?     @db.Text
+  noisePrivateKey String?     @db.Text
+  assignedPort    Int?        @unique @db.Integer
+  status          ProxyStatus @default(PENDING)
+  version         String?     @db.Text
+  lastSeenAt      DateTime?   @db.Timestamp(6)
+  createdAt       DateTime    @default(now()) @db.Timestamp(6)
+  updatedAt       DateTime    @default(now()) @updatedAt @db.Timestamp(6)
+}
+
+model ProxyInstallToken {
+  id          String    @id(map: "proxy_install_token_pkey") @default(uuid()) @db.Uuid
+  projectId   String    @db.Uuid
+  project     Project   @relation(fields: [projectId], references: [projectId], onDelete: Cascade, onUpdate: NoAction, map: "fk_proxy_install_token_project_id")
+  name        String    @db.Text
+  tokenHash   String    @unique @db.Text
+  tokenPrefix String    @db.VarChar(16)
+  createdAt   DateTime  @default(now()) @db.Timestamp(6)
+  lastUsedAt  DateTime? @db.Timestamp(6)
+}
+
+enum ProxyStatus {
+  PENDING
+  ONLINE
+  OFFLINE
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,6 +22,7 @@ import { AuthConfigService } from './config/auth-config.service';
 import { AnalysisModule } from './analysis/analysis.module';
 import { CoordinatorModule } from './coordinator/coordinator.module';
 import { JobModule } from './job/job.module';
+import { ProxyModule } from './proxy/proxy.module';
 
 @Module({
   imports: [
@@ -49,6 +50,7 @@ import { JobModule } from './job/job.module';
     DockerModule,
     CoordinatorModule,
     JobModule,
+    ProxyModule,
   ],
   controllers: [AppController],
   providers: [AdminConfigService, AuthConfigService],

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -37,6 +37,10 @@ export class AuthModule implements NestModule {
       { path: 'health', method: RequestMethod.GET },
       { path: 'analysis/auth', method: RequestMethod.POST }, // analysis sdk auth path
       { path: 'coordinator/auth', method: RequestMethod.POST }, // coordinator client auth path
+      { path: 'proxy/register', method: RequestMethod.POST }, // proxy binary registration
+      { path: 'proxy/heartbeat', method: RequestMethod.POST }, // proxy binary heartbeat
+      { path: 'proxy/metadata', method: RequestMethod.POST }, // proxy binary metadata upload
+      { path: 'proxy/offline', method: RequestMethod.POST }, // proxy binary shutdown
     ];
 
     // only add docs if dev

--- a/src/docker/docker.service.ts
+++ b/src/docker/docker.service.ts
@@ -115,6 +115,82 @@ export class DockerService {
     }
   }
 
+  async runDataBrokerLoadOnly(
+    ownerId: string,
+    projectId: string,
+    metadataPath: string,
+  ) {
+    this.logger.log(
+      `Preparing to run crawler container (LOAD_ONLY) for project ${projectId}...`,
+    );
+    const envArgs = [
+      `ATLAS_URI=${this.isDev ? this.atlasUrl.replace('localhost', 'host.docker.internal') : this.atlasUrl}`,
+      `ATLAS_ADMIN_USER=${this.username}`,
+      `ATLAS_ADMIN_PASSWORD=${this.password}`,
+      `OWNER=${ownerId}`,
+      `PROJECT_ID=${projectId}`,
+      `LOAD_ONLY=true`,
+      `SCHEMA_PATH=/data/schema.json`,
+      `ERD_PATH=/data/erd.txt`,
+      `DB_TYPE=pg`,
+      `DB_HOST=proxy`,
+      `DB_PORT=5432`,
+      `DB_SSLMODE=unknown`,
+    ];
+
+    const instanceName = `data-broker-proxy-${projectId}`;
+    try {
+      this.logger.debug(`Checking for base image ${this.imageName}...`);
+      void this.imageExistsLocally(this.imageName);
+
+      this.logger.debug(`Starting the container ${instanceName}...`);
+
+      const container = await this.createAndStartContainer(
+        this.imageName,
+        envArgs,
+        instanceName,
+        [`${metadataPath}:/data:ro`],
+      );
+
+      try {
+        this.logger.debug(
+          `Waiting for the container ${instanceName} to finish...`,
+        );
+        await this.monitorContainer(container);
+
+        const output = await this.readAllLogs(container);
+        const done = /(^|\n)DONE(\r?\n|$)/.test(output);
+        const inspect = await container.inspect();
+        const exitCode = inspect.State?.ExitCode ?? 1;
+        const success = done || exitCode === 0;
+
+        if (!success) {
+          throw new Error(
+            `Container finished without DONE marker and non-zero exit code with output ${output}`,
+          );
+        }
+        this.logger.log(
+          `Container ${instanceName} run successfully (LOAD_ONLY) for project ${projectId}.`,
+        );
+        await this.prisma.project.update({
+          where: { projectId },
+          data: { status: 'READY' },
+        });
+      } finally {
+        this.logger.debug(`Removing container ${instanceName}...`);
+        await container.remove({ force: true });
+        this.logger.debug(`Container ${instanceName} removed successfully.`);
+      }
+    } catch (error) {
+      await this.prisma.project.update({
+        where: { projectId },
+        data: { status: 'ERROR' },
+      });
+      this.logger.error(`Error running container ${instanceName}: `, error);
+      throw error;
+    }
+  }
+
   private async imageExistsLocally(imageName) {
     try {
       const image = this.docker.getImage(imageName);
@@ -136,6 +212,7 @@ export class DockerService {
     imageName: string,
     envVariables: string[],
     name: string,
+    binds?: string[],
   ): Promise<Container> {
     const existingContainers = await this.docker.listContainers({
       all: true,
@@ -185,6 +262,7 @@ export class DockerService {
       // run runDataBroker function should remove the container
       HostConfig: {
         AutoRemove: false,
+        ...(binds?.length ? { Binds: binds } : {}),
       },
       // only for dev + testing
       NetworkingConfig: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { AppModule } from './app.module';
 import { BadRequestException, ValidationPipe } from '@nestjs/common';
 import { AuthExceptionFilter } from './common/filters/auth-exception.filter';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import * as express from 'express';
 
 import { ConfigService } from '@nestjs/config';
 import { PrismaClientExceptionFilter } from './common/filters/prisma-client-exception.filter';
@@ -13,7 +14,11 @@ import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     logger: ['error', 'warn', 'log', 'debug', 'verbose'],
+    bodyParser: false, // Use custom body parser with increased limit
   });
+  // Increase global body size limit for proxy metadata uploads (schema JSON can be large)
+  app.use(express.json({ limit: '10mb' }));
+  app.use(express.urlencoded({ extended: true }));
   const configService = app.get(ConfigService);
   app.setGlobalPrefix(configService.get<string>('apiBaseUrl')!);
   app.enableCors({

--- a/src/project/dto/project.dto.ts
+++ b/src/project/dto/project.dto.ts
@@ -59,6 +59,37 @@ export class ProjectMember {
   name?: string;
 }
 
+export class PaginationQueryDto {
+  @ApiPropertyOptional({ default: 1, minimum: 1 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 12, minimum: 1, maximum: 100 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @IsOptional()
+  limit?: number = 12;
+
+  @ApiPropertyOptional({
+    description: 'Sort order',
+    enum: ['date-created', 'title', 'last-modified'],
+    default: 'date-created',
+  })
+  @IsIn(['date-created', 'title', 'last-modified'])
+  @IsOptional()
+  sort?: 'date-created' | 'title' | 'last-modified' = 'date-created';
+
+  @ApiPropertyOptional({ description: 'Search by project name' })
+  @IsString()
+  @IsOptional()
+  search?: string;
+}
+
 export class BrowseProjectsQueryDto {
   @ApiPropertyOptional({ default: 1, minimum: 1 })
   @Type(() => Number)
@@ -292,6 +323,15 @@ export class CreateProjectDto {
   @IsDefined()
   @IsString({ each: true })
   dbKeywords!: string[];
+
+  @ApiPropertyOptional({
+    description: 'How the platform accesses this database',
+    enum: ['CLOUD_CONNECT', 'DIRECT_DB', 'PROXY'],
+    default: 'CLOUD_CONNECT',
+  })
+  @IsOptional()
+  @IsIn(['CLOUD_CONNECT', 'DIRECT_DB', 'PROXY'])
+  connectionType?: string;
 
   @ApiProperty({
     description: 'Connection metadata & crawling request info',

--- a/src/project/project.controller.ts
+++ b/src/project/project.controller.ts
@@ -20,6 +20,7 @@ import {
 import { ProjectService } from './project.service';
 import {
   BrowseProjectsQueryDto,
+  PaginationQueryDto,
   ProjectDetailsResponseDto,
   CreateProjectDto,
   ProjectRequestsResponse,
@@ -153,8 +154,11 @@ export class ProjectController {
       },
     },
   })
-  async getUserOwnedProjects(@CurrentUser() user: CurrentUserInfo) {
-    return await this.projectService.getUserOwnedProjects(user.id);
+  async getUserOwnedProjects(
+    @CurrentUser() user: CurrentUserInfo,
+    @Query() query: PaginationQueryDto,
+  ) {
+    return await this.projectService.getUserOwnedProjects(user.id, query);
   }
 
   @Get('shared')
@@ -190,7 +194,10 @@ export class ProjectController {
       },
     },
   })
-  async getUserSharedProjects(@Req() request: Request) {
+  async getUserSharedProjects(
+    @Req() request: Request,
+    @Query() query: PaginationQueryDto,
+  ) {
     // check for user resource permissions against keycloak
     // TODO: perhaps call this once and cache or make it into a helper/decorator
     const authzRequest = {
@@ -200,7 +207,7 @@ export class ProjectController {
       authzRequest,
       request,
     );
-    return await this.projectService.getUserSharedProjects(permissions);
+    return await this.projectService.getUserSharedProjects(permissions, query);
   }
 
   @Get('all')

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -8,10 +8,10 @@ import { PrismaService } from 'src/prisma/prisma.service';
 import {
   BrowseProjectsQueryDto,
   CreateProjectDto,
+  PaginationQueryDto,
   ProjectDetailsResponseDto,
   ProjectRequestsResponse,
   ProjectRequestsResponseDto,
-  ProjectSummaryInfoDto,
   SettingsDto,
   SettingsResponseDto,
   UpdateCredentialsDto,
@@ -39,51 +39,86 @@ export class ProjectService {
     private readonly keycloak: KeycloakAdminService,
   ) {}
 
+  private buildPaginationOrderBy(
+    sort: PaginationQueryDto['sort'],
+  ): Prisma.ProjectOrderByWithRelationInput {
+    return sort === 'title'
+      ? { name: 'asc' }
+      : sort === 'last-modified'
+        ? { lastModified: 'desc' }
+        : { createdDate: 'desc' };
+  }
+
+  private readonly projectSummarySelect = {
+    projectId: true,
+    name: true,
+    lastModified: true,
+    status: true,
+    university: true,
+    lead: true,
+    faculty: true,
+    createdDate: true,
+  } as const;
+
   // Queries
-  async getUserOwnedProjects(userId: string): Promise<ProjectSummaryInfoDto[]> {
-    return await this.prisma.project.findMany({
-      where: {
-        ownerId: userId,
-      },
-      select: {
-        projectId: true,
-        name: true,
-        lastModified: true,
-        status: true,
-        university: true,
-        lead: true,
-        faculty: true,
-        createdDate: true,
-      },
-    });
+  async getUserOwnedProjects(userId: string, query: PaginationQueryDto = {}) {
+    const { page = 1, limit = 12, sort = 'date-created', search } = query;
+
+    const where: Prisma.ProjectWhereInput = {
+      ownerId: userId,
+      ...(search && { name: { contains: search, mode: 'insensitive' } }),
+    };
+
+    const [data, total] = await Promise.all([
+      this.prisma.project.findMany({
+        where,
+        orderBy: this.buildPaginationOrderBy(sort),
+        skip: (page - 1) * limit,
+        take: limit,
+        select: this.projectSummarySelect,
+      }),
+      this.prisma.project.count({ where }),
+    ]);
+
+    return {
+      data,
+      pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+    };
   }
 
   async getUserSharedProjects(
     permissions: KeycloakPermissionDto[],
-  ): Promise<ProjectSummaryInfoDto[]> {
+    query: PaginationQueryDto = {},
+  ) {
+    const { page = 1, limit = 12, sort = 'date-created', search } = query;
+
     const uuids = permissions
       .filter(
         (item) =>
           item.scopes.includes('view') && !item.scopes.includes('delete'),
       )
       .map((item) => item.rsname.split(':').at(1)!);
-    return await this.prisma.project.findMany({
-      where: {
-        projectId: {
-          in: uuids, // find all projects associated
-        },
-      },
-      select: {
-        projectId: true,
-        name: true,
-        lastModified: true,
-        createdDate: true,
-        lead: true,
-        status: true,
-        university: true,
-        faculty: true,
-      },
-    });
+
+    const where: Prisma.ProjectWhereInput = {
+      projectId: { in: uuids },
+      ...(search && { name: { contains: search, mode: 'insensitive' } }),
+    };
+
+    const [data, total] = await Promise.all([
+      this.prisma.project.findMany({
+        where,
+        orderBy: this.buildPaginationOrderBy(sort),
+        skip: (page - 1) * limit,
+        take: limit,
+        select: this.projectSummarySelect,
+      }),
+      this.prisma.project.count({ where }),
+    ]);
+
+    return {
+      data,
+      pagination: { page, limit, total, totalPages: Math.ceil(total / limit) },
+    };
   }
 
   async getAllProjects(query: BrowseProjectsQueryDto = {}) {
@@ -430,6 +465,11 @@ export class ProjectService {
     const members = dto.members
       ? (dto.members as unknown as Prisma.JsonArray)
       : undefined;
+    const connectionType = (dto.connectionType ?? 'CLOUD_CONNECT') as
+      | 'CLOUD_CONNECT'
+      | 'DIRECT_DB'
+      | 'PROXY';
+
     const request = {
       ownerId,
       name: dto.name,
@@ -441,11 +481,13 @@ export class ProjectService {
       startDate: dto.startDate,
       endDate: dto.endDate,
       participantsNum: dto.participantsNum,
+      connectionType,
 
       ...(members && {
         members,
       }),
       dbKeywords: dto.dbKeywords,
+      ...(dto.isPublic !== undefined && { isPublic: dto.isPublic }),
     };
 
     // check if database credential request is needed
@@ -501,6 +543,12 @@ export class ProjectService {
           },
         });
       }
+    } else if (connectionType === 'PROXY') {
+      // Proxy mode: no credentials needed, no crawling
+      // Data owner will install epsilon-proxy and register it later
+      this.logger.log(
+        `Project ${project.projectId} created with PROXY connection type — awaiting proxy registration`,
+      );
     } else {
       // database credentials should exist so run database crawling
       if (dto.connection.dbDetails?.url) {
@@ -603,14 +651,26 @@ export class ProjectService {
   async retryCrawl(user: CurrentUserInfo, projectId: string) {
     const project = await this.prisma.project.findUnique({
       where: { projectId },
-      select: { status: true },
+      select: { status: true, connectionType: true },
     });
 
     if (!project) throw new NotFoundException('Project not found');
-    if (project.status !== 'ERROR') {
+    if (!['ERROR', 'CRAWLING'].includes(project.status)) {
       throw new BadRequestException(
         `Cannot retry crawl for project with status ${project.status}`,
       );
+    }
+
+    // For PROXY projects: reset to PENDING so proxy's heartbeat triggers re-crawl
+    if (project.connectionType === 'PROXY') {
+      await this.prisma.project.update({
+        where: { projectId },
+        data: { status: 'PENDING' },
+      });
+      this.logger.log(
+        `Retry crawl for PROXY project ${projectId}: reset to PENDING`,
+      );
+      return { status: 'pending', message: 'Waiting for proxy to re-crawl' };
     }
 
     // resubmit using existing job data from Redis

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -49,19 +49,35 @@ export class AtlasProcessor {
 
   @Process('process-data-broker')
   async handleDataBrokerJob(job: Job) {
-    const { jobId, owner, projectId, requestId, database } =
-      job.data as DataBrokerJobDataDto;
+    const {
+      jobId,
+      owner,
+      projectId,
+      requestId,
+      database,
+      loadOnly,
+      metadataPath,
+    } = job.data as DataBrokerJobDataDto;
     this.logger.log(
-      `Handling 'process-data-broker' for requestId ${requestId}...`,
+      `Handling 'process-data-broker' ${loadOnly ? '(LOAD_ONLY) ' : ''}for requestId ${requestId}...`,
     );
     await this.jobService.markActive(jobId);
     try {
-      const result = await this.docker.runDataBroker(
-        owner,
-        projectId,
-        requestId,
-        database,
-      );
+      let result: unknown;
+      if (loadOnly && metadataPath) {
+        result = await this.docker.runDataBrokerLoadOnly(
+          owner,
+          projectId,
+          metadataPath,
+        );
+      } else {
+        result = await this.docker.runDataBroker(
+          owner,
+          projectId,
+          requestId,
+          database!,
+        );
+      }
       await this.jobService.markCompleted(jobId, result);
       return result;
     } catch (error) {

--- a/src/queue/dto/queue.dto.ts
+++ b/src/queue/dto/queue.dto.ts
@@ -80,6 +80,14 @@ export class DataBrokerJobDataDto {
   requestId!: string;
 
   @ValidateNested()
+  @IsOptional()
   @Type(() => DatabaseInfoDto)
-  database!: DatabaseInfoDto;
+  database?: DatabaseInfoDto;
+
+  @IsOptional()
+  loadOnly?: boolean;
+
+  @IsString()
+  @IsOptional()
+  metadataPath?: string;
 }

--- a/src/queue/queue.service.ts
+++ b/src/queue/queue.service.ts
@@ -119,6 +119,7 @@ export class QueueService implements OnModuleInit {
   }
 
   private async syncJobState(job: Job, state: 'completed' | 'failed') {
+    if (!job?.data) return;
     const { jobId, projectId } = (job.data as BullJobData) ?? {};
     if (!jobId) return;
 
@@ -237,6 +238,34 @@ export class QueueService implements OnModuleInit {
       },
       {
         jobId: `process-data-broker:${requestId}`,
+        attempts: 5,
+        backoff: 10000,
+      },
+    );
+    return { jobId };
+  }
+
+  async dataBrokerLoadOnlyJob(
+    owner: string,
+    projectId: string,
+    metadataPath: string,
+  ) {
+    this.logger.log(
+      `Submitting 'process-data-broker' (LOAD_ONLY) to queue for projectId ${projectId}`,
+    );
+    const jobId = await this.jobService.createJob('process-data-broker');
+    await this.atlasQueue.add(
+      'process-data-broker',
+      {
+        jobId,
+        owner,
+        projectId,
+        requestId: `proxy-${projectId}`,
+        loadOnly: true,
+        metadataPath,
+      },
+      {
+        jobId: `process-data-broker:proxy:${jobId}`,
         attempts: 5,
         backoff: 10000,
       },


### PR DESCRIPTION
- Add proxy model, registration, heartbeat, and metadata upload endpoints
- Add server-side pagination for owned/shared project endpoints (skip/take/orderBy/search)
- Fix isPublic flag not being saved during project creation
- Fix Bull job deduplication causing silently dropped jobs (use unique jobId)
- Fix queue reconciliation crash on null job data
- Handle PROXY connection type in project creation and retry-crawl
- Extend heartbeat crawl trigger to PENDING, ERROR, and CRAWLING statuses