### PR TITLE
feat: add proxy module with rathole config management

### DIFF
--- a/prisma/migrations/20260311101320_add_proxy_model/migration.sql
+++ b/prisma/migrations/20260311101320_add_proxy_model/migration.sql
@@ -1,0 +1,42 @@
+-- CreateEnum
+CREATE TYPE "ConnectionType" AS ENUM ('CLOUD_CONNECT', 'DIRECT_DB', 'PROXY');
+
+-- CreateEnum
+CREATE TYPE "ProxyStatus" AS ENUM ('PENDING', 'ONLINE', 'OFFLINE');
+
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN     "connectionType" "ConnectionType" NOT NULL DEFAULT 'CLOUD_CONNECT';
+
+-- CreateTable
+CREATE TABLE "Proxy" (
+    "id" UUID NOT NULL,
+    "projectId" UUID NOT NULL,
+    "installToken" TEXT NOT NULL,
+    "proxyToken" TEXT,
+    "ratholeToken" TEXT,
+    "noisePublicKey" TEXT,
+    "noisePrivateKey" TEXT,
+    "assignedPort" INTEGER,
+    "status" "ProxyStatus" NOT NULL DEFAULT 'PENDING',
+    "version" TEXT,
+    "lastSeenAt" TIMESTAMP(6),
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "proxy_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Proxy_projectId_key" ON "Proxy"("projectId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Proxy_installToken_key" ON "Proxy"("installToken");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Proxy_proxyToken_key" ON "Proxy"("proxyToken");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Proxy_assignedPort_key" ON "Proxy"("assignedPort");
+
+-- AddForeignKey
+ALTER TABLE "Proxy" ADD CONSTRAINT "fk_proxy_project_id" FOREIGN KEY ("projectId") REFERENCES "Project"("projectId") ON DELETE CASCADE ON UPDATE NO ACTION;

--- a/prisma/migrations/20260311102541_proxy_install_tokens/migration.sql
+++ b/prisma/migrations/20260311102541_proxy_install_tokens/migration.sql
@@ -1,0 +1,30 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `installToken` on the `Proxy` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "Proxy_installToken_key";
+
+-- AlterTable
+ALTER TABLE "Proxy" DROP COLUMN "installToken";
+
+-- CreateTable
+CREATE TABLE "ProxyInstallToken" (
+    "id" UUID NOT NULL,
+    "projectId" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "tokenPrefix" VARCHAR(16) NOT NULL,
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsedAt" TIMESTAMP(6),
+
+    CONSTRAINT "proxy_install_token_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProxyInstallToken_tokenHash_key" ON "ProxyInstallToken"("tokenHash");
+
+-- AddForeignKey
+ALTER TABLE "ProxyInstallToken" ADD CONSTRAINT "fk_proxy_install_token_project_id" FOREIGN KEY ("projectId") REFERENCES "Project"("projectId") ON DELETE CASCADE ON UPDATE NO ACTION;

--- a/src/proxy/dto/index.ts
+++ b/src/proxy/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './proxy.dto';

--- a/src/proxy/dto/proxy.dto.ts
+++ b/src/proxy/dto/proxy.dto.ts
@@ -1,0 +1,132 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsDefined,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+
+export class GenerateTokenDto {
+  @ApiProperty({
+    description: 'Human-readable name for this token',
+    example: 'Production server',
+  })
+  @IsDefined()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name: string;
+}
+
+export class GenerateTokenResponseDto {
+  @ApiProperty({ description: 'Token ID (for revocation)' })
+  id: string;
+
+  @ApiProperty({ description: 'Token name' })
+  name: string;
+
+  @ApiProperty({ description: 'Full install token — shown only once' })
+  installToken: string;
+
+  @ApiProperty({ description: 'Token prefix for display (e.g. ept_a1b2c3...)' })
+  tokenPrefix: string;
+
+  @ApiProperty()
+  createdAt: Date;
+}
+
+export class InstallTokenSummaryDto {
+  @ApiProperty() id: string;
+  @ApiProperty() name: string;
+  @ApiProperty({ description: 'First 12 chars of the token' })
+  tokenPrefix: string;
+  @ApiProperty() createdAt: Date;
+  @ApiPropertyOptional() lastUsedAt?: Date;
+}
+
+export class ProxyRegisterDto {
+  @ApiProperty({ description: 'Install token from platform UI' })
+  @IsDefined()
+  @IsString()
+  @IsNotEmpty()
+  installToken: string;
+
+  @ApiPropertyOptional({ description: 'Proxy version' })
+  @IsOptional()
+  @IsString()
+  version?: string;
+
+  @ApiPropertyOptional({ description: 'Database type (e.g. postgres)' })
+  @IsOptional()
+  @IsString()
+  dbType?: string;
+}
+
+export class ProxyRegisterResponseDto {
+  @ApiProperty() proxyId: string;
+  @ApiProperty() proxyToken: string;
+  @ApiProperty() ratholeToken: string;
+  @ApiProperty() noisePublicKey: string;
+  @ApiProperty() serverAddr: string;
+  @ApiProperty() serviceName: string;
+  @ApiProperty() assignedPort: number;
+}
+
+export class ProxyHeartbeatDto {
+  @ApiProperty({ description: 'Proxy token for authentication' })
+  @IsDefined()
+  @IsString()
+  proxyToken: string;
+
+  @ApiPropertyOptional() @IsOptional() @IsString() version?: string;
+  @ApiPropertyOptional() @IsOptional() databaseReachable?: boolean;
+  @ApiPropertyOptional() @IsOptional() tunnelConnected?: boolean;
+  @ApiPropertyOptional() @IsOptional() uptimeSeconds?: number;
+}
+
+export class ProxyStatusResponseDto {
+  @ApiProperty() proxyId: string;
+  @ApiProperty({ enum: ['PENDING', 'ONLINE', 'OFFLINE'] }) status: string;
+  @ApiPropertyOptional() version?: string;
+  @ApiPropertyOptional() lastSeenAt?: Date;
+  @ApiPropertyOptional() assignedPort?: number;
+}
+
+export class ProxyInfoResponseDto {
+  @ApiProperty() proxyId: string;
+  @ApiProperty() proxyToken: string;
+  @ApiProperty() assignedPort: number;
+  @ApiProperty({ enum: ['PENDING', 'ONLINE', 'OFFLINE'] }) status: string;
+}
+
+export class ProxyMetadataDto {
+  @ApiProperty({ description: 'Proxy token for authentication' })
+  @IsDefined()
+  @IsString()
+  proxyToken: string;
+
+  @ApiProperty({ description: 'tbls JSON schema output' })
+  @IsDefined()
+  @IsObject()
+  schema: Record<string, unknown>;
+
+  @ApiProperty({ description: 'Mermaid ERD text' })
+  @IsDefined()
+  @IsString()
+  erd: string;
+
+  @ApiPropertyOptional({ description: 'Database type' })
+  @IsOptional()
+  @IsString()
+  dbType?: string;
+}
+
+export class ProxyHeartbeatResponseDto {
+  @ApiPropertyOptional({
+    description: 'Action for the proxy to take',
+    enum: ['crawl'],
+  })
+  action?: string;
+}

--- a/src/proxy/proxy.controller.ts
+++ b/src/proxy/proxy.controller.ts
@@ -1,0 +1,164 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Delete,
+  Body,
+  Param,
+  ParseUUIDPipe,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { ProxyService } from './proxy.service';
+import {
+  GenerateTokenDto,
+  GenerateTokenResponseDto,
+  InstallTokenSummaryDto,
+  ProxyRegisterDto,
+  ProxyRegisterResponseDto,
+  ProxyHeartbeatDto,
+  ProxyHeartbeatResponseDto,
+  ProxyStatusResponseDto,
+  ProxyInfoResponseDto,
+  ProxyMetadataDto,
+} from './dto';
+import { Resource } from 'src/common/decorators/resource.decorator';
+import { Scopes } from 'src/common/decorators/scopes.decorator';
+import { ResourceGuard } from 'src/common/guards/resource.guard';
+import { Public } from 'src/common/decorators/public.decorator';
+
+@ApiTags('Proxy')
+@Controller('proxy')
+@Resource('project')
+export class ProxyController {
+  constructor(private proxyService: ProxyService) {}
+
+  // --- Authenticated endpoints (data owner via JWT) ---
+
+  @UseGuards(ResourceGuard)
+  @Scopes('view', 'edit')
+  @ApiBearerAuth()
+  @Post(':projectId/token')
+  @ApiOperation({ summary: 'Generate a new install token for epsilon-proxy' })
+  @ApiOkResponse({ type: GenerateTokenResponseDto })
+  async generateToken(
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+    @Body() dto: GenerateTokenDto,
+  ): Promise<GenerateTokenResponseDto> {
+    return this.proxyService.generateInstallToken(projectId, dto.name);
+  }
+
+  @UseGuards(ResourceGuard)
+  @Scopes('view')
+  @ApiBearerAuth()
+  @Get(':projectId/tokens')
+  @ApiOperation({ summary: 'List all install tokens for a project' })
+  @ApiOkResponse({ type: [InstallTokenSummaryDto] })
+  async listTokens(
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+  ): Promise<InstallTokenSummaryDto[]> {
+    return this.proxyService.listInstallTokens(projectId);
+  }
+
+  @UseGuards(ResourceGuard)
+  @Scopes('view', 'edit')
+  @ApiBearerAuth()
+  @Delete(':projectId/tokens/:tokenId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Revoke (delete) an install token' })
+  async revokeToken(
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+    @Param('tokenId', ParseUUIDPipe) tokenId: string,
+  ) {
+    return this.proxyService.revokeInstallToken(projectId, tokenId);
+  }
+
+  @UseGuards(ResourceGuard)
+  @Scopes('view')
+  @ApiBearerAuth()
+  @Get(':projectId/status')
+  @ApiOperation({ summary: 'Get proxy status for a project' })
+  @ApiOkResponse({ type: ProxyStatusResponseDto })
+  async getStatus(
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+  ): Promise<ProxyStatusResponseDto> {
+    return this.proxyService.getStatus(projectId);
+  }
+
+  @UseGuards(ResourceGuard)
+  @Scopes('view')
+  @ApiBearerAuth()
+  @Get(':projectId/info')
+  @ApiOperation({
+    summary: 'Get proxy connection info (for coordinator/middleware)',
+  })
+  @ApiOkResponse({ type: ProxyInfoResponseDto })
+  async getProxyInfo(
+    @Param('projectId', ParseUUIDPipe) projectId: string,
+  ): Promise<ProxyInfoResponseDto> {
+    return this.proxyService.getProxyInfo(projectId);
+  }
+
+  @UseGuards(ResourceGuard)
+  @Scopes('view', 'edit', 'delete')
+  @ApiBearerAuth()
+  @Delete(':projectId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Unregister proxy for a project' })
+  async unregister(@Param('projectId', ParseUUIDPipe) projectId: string) {
+    return this.proxyService.unregister(projectId);
+  }
+
+  // --- Public endpoints (called by epsilon-proxy binary, no JWT) ---
+
+  @Public()
+  @Post('register')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Register epsilon-proxy (called by proxy binary)' })
+  @ApiOkResponse({ type: ProxyRegisterResponseDto })
+  async register(
+    @Body() dto: ProxyRegisterDto,
+  ): Promise<ProxyRegisterResponseDto> {
+    return this.proxyService.register(dto);
+  }
+
+  @Public()
+  @Post('heartbeat')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Proxy heartbeat (called by proxy binary every 30s)',
+  })
+  @ApiOkResponse({ type: ProxyHeartbeatResponseDto })
+  async heartbeat(
+    @Body() dto: ProxyHeartbeatDto,
+  ): Promise<ProxyHeartbeatResponseDto> {
+    return this.proxyService.heartbeat(dto.proxyToken, {
+      version: dto.version,
+      databaseReachable: dto.databaseReachable,
+      tunnelConnected: dto.tunnelConnected,
+    });
+  }
+
+  @Public()
+  @Post('metadata')
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ApiOperation({ summary: 'Upload crawled schema metadata from proxy' })
+  async uploadMetadata(@Body() dto: ProxyMetadataDto) {
+    return this.proxyService.handleMetadataUpload(dto);
+  }
+
+  @Public()
+  @Post('offline')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Proxy going offline (called on SIGTERM)' })
+  async offline(@Body() body: { proxyToken: string }) {
+    return this.proxyService.markOffline(body.proxyToken);
+  }
+}

--- a/src/proxy/proxy.module.ts
+++ b/src/proxy/proxy.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { ProxyController } from './proxy.controller';
+import { ProxyService } from './proxy.service';
+import { RatholeConfigService } from './rathole-config.service';
+import { QueueModule } from 'src/queue/queue.module';
+
+@Module({
+  imports: [QueueModule],
+  controllers: [ProxyController],
+  providers: [ProxyService, RatholeConfigService],
+  exports: [ProxyService],
+})
+export class ProxyModule {}

--- a/src/proxy/proxy.service.ts
+++ b/src/proxy/proxy.service.ts
@@ -1,0 +1,384 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { ConfigService } from '@nestjs/config';
+import { randomBytes, createHash } from 'crypto';
+import { writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import {
+  ProxyRegisterDto,
+  ProxyRegisterResponseDto,
+  ProxyStatusResponseDto,
+  ProxyInfoResponseDto,
+  GenerateTokenResponseDto,
+  InstallTokenSummaryDto,
+  ProxyMetadataDto,
+  ProxyHeartbeatResponseDto,
+} from './dto';
+import { QueueService } from 'src/queue/queue.service';
+import { RatholeConfigService } from './rathole-config.service';
+
+const PROXY_PORT_BASE = 10000;
+const PROXY_PORT_MAX = 10099;
+
+function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+@Injectable()
+export class ProxyService {
+  private readonly logger = new Logger(ProxyService.name);
+
+  constructor(
+    private prisma: PrismaService,
+    private config: ConfigService,
+    private queueService: QueueService,
+    private ratholeConfig: RatholeConfigService,
+  ) {}
+
+  async generateInstallToken(
+    projectId: string,
+    name: string,
+  ): Promise<GenerateTokenResponseDto> {
+    const project = await this.prisma.project.findUnique({
+      where: { projectId },
+      select: { connectionType: true },
+    });
+
+    if (!project) throw new NotFoundException('Project not found');
+    if (project.connectionType !== 'PROXY') {
+      throw new BadRequestException(
+        'Project connection type must be PROXY to generate install token',
+      );
+    }
+
+    // Clean up existing tokens with the same name to prevent duplicates
+    await this.prisma.proxyInstallToken.deleteMany({
+      where: { projectId, name },
+    });
+
+    const plainToken = `ept_${randomBytes(24).toString('hex')}`;
+    const tokenH = hashToken(plainToken);
+    const tokenPrefix = plainToken.substring(0, 12);
+
+    const record = await this.prisma.proxyInstallToken.create({
+      data: {
+        projectId,
+        name,
+        tokenHash: tokenH,
+        tokenPrefix,
+      },
+    });
+
+    return {
+      id: record.id,
+      name: record.name,
+      installToken: plainToken,
+      tokenPrefix,
+      createdAt: record.createdAt,
+    };
+  }
+
+  async listInstallTokens(
+    projectId: string,
+  ): Promise<InstallTokenSummaryDto[]> {
+    const tokens = await this.prisma.proxyInstallToken.findMany({
+      where: { projectId },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return tokens.map((t) => ({
+      id: t.id,
+      name: t.name,
+      tokenPrefix: t.tokenPrefix,
+      createdAt: t.createdAt,
+      lastUsedAt: t.lastUsedAt ?? undefined,
+    }));
+  }
+
+  async revokeInstallToken(projectId: string, tokenId: string): Promise<void> {
+    const token = await this.prisma.proxyInstallToken.findFirst({
+      where: { id: tokenId, projectId },
+    });
+
+    if (!token) throw new NotFoundException('Token not found');
+
+    await this.prisma.proxyInstallToken.delete({
+      where: { id: tokenId },
+    });
+
+    this.logger.log(
+      `Install token ${token.tokenPrefix}... revoked for project ${projectId}`,
+    );
+  }
+
+  async register(dto: ProxyRegisterDto): Promise<ProxyRegisterResponseDto> {
+    const tokenH = hashToken(dto.installToken);
+
+    const installToken = await this.prisma.proxyInstallToken.findUnique({
+      where: { tokenHash: tokenH },
+      include: { project: { select: { projectId: true, name: true } } },
+    });
+
+    if (!installToken) {
+      throw new UnauthorizedException('Invalid install token');
+    }
+
+    const projectId = installToken.projectId;
+
+    // Reuse existing port if proxy was previously registered
+    const existingProxy = await this.prisma.proxy.findUnique({
+      where: { projectId },
+      select: { assignedPort: true },
+    });
+
+    const proxyToken = `pt_${randomBytes(32).toString('hex')}`;
+    const ratholeToken = randomBytes(32).toString('hex');
+    const assignedPort =
+      existingProxy?.assignedPort ?? (await this.allocatePort());
+
+    // Use the rathole server's noise public key (shared across all proxies)
+    const noisePublicKey = this.ratholeConfig.noisePublicKey || '';
+
+    const proxy = await this.prisma.proxy.upsert({
+      where: { projectId },
+      create: {
+        projectId,
+        proxyToken,
+        ratholeToken,
+        noisePublicKey: noisePublicKey || null,
+        assignedPort,
+        status: 'OFFLINE',
+        version: dto.version ?? null,
+      },
+      update: {
+        proxyToken,
+        ratholeToken,
+        noisePublicKey: noisePublicKey || null,
+        assignedPort,
+        status: 'OFFLINE',
+        version: dto.version ?? null,
+      },
+    });
+
+    // Mark the token as used
+    await this.prisma.proxyInstallToken.update({
+      where: { id: installToken.id },
+      data: { lastUsedAt: new Date() },
+    });
+
+    const serviceName = `proxy-${proxy.id}`;
+
+    this.logger.log(
+      `Proxy registered: ${proxy.id} for project ${installToken.project.name} on port ${assignedPort}`,
+    );
+
+    // Update rathole server config so the tunnel accepts this proxy
+    try {
+      await this.ratholeConfig.rebuildConfig();
+    } catch (err) {
+      this.logger.warn(
+        `Failed to update rathole config: ${(err as Error).message}`,
+      );
+    }
+
+    const serverAddr =
+      this.config.get<string>('RATHOLE_SERVER_ADDR') || '127.0.0.1:7100';
+
+    return {
+      proxyId: proxy.id,
+      proxyToken,
+      ratholeToken,
+      noisePublicKey,
+      serverAddr,
+      serviceName,
+      assignedPort,
+    };
+  }
+
+  async heartbeat(
+    proxyToken: string,
+    meta?: Record<string, unknown>,
+  ): Promise<ProxyHeartbeatResponseDto> {
+    const proxy = await this.prisma.proxy.findUnique({
+      where: { proxyToken },
+      include: { project: { select: { status: true, connectionType: true } } },
+    });
+
+    if (!proxy) throw new UnauthorizedException('Invalid proxy token');
+
+    await this.prisma.proxy.update({
+      where: { id: proxy.id },
+      data: {
+        status: 'ONLINE',
+        lastSeenAt: new Date(),
+        ...(typeof meta?.version === 'string' && { version: meta.version }),
+      },
+    });
+
+    const needsCrawl =
+      proxy.project.connectionType === 'PROXY' &&
+      ['PENDING', 'ERROR', 'CRAWLING'].includes(proxy.project.status) &&
+      Boolean(meta?.databaseReachable);
+
+    return needsCrawl ? { action: 'crawl' } : {};
+  }
+
+  async handleMetadataUpload(dto: ProxyMetadataDto) {
+    const proxy = await this.prisma.proxy.findUnique({
+      where: { proxyToken: dto.proxyToken },
+      include: {
+        project: {
+          select: {
+            projectId: true,
+            status: true,
+            connectionType: true,
+            ownerId: true,
+          },
+        },
+      },
+    });
+
+    if (!proxy) throw new UnauthorizedException('Invalid proxy token');
+
+    if (proxy.project.connectionType !== 'PROXY') {
+      throw new BadRequestException('Project is not configured for proxy mode');
+    }
+
+    if (!['PENDING', 'ERROR', 'CRAWLING'].includes(proxy.project.status)) {
+      throw new BadRequestException(
+        `Project status is ${proxy.project.status}, expected PENDING, ERROR or CRAWLING`,
+      );
+    }
+
+    const projectId = proxy.project.projectId;
+    const metadataDir = join('/tmp', 'proxy-metadata', projectId);
+
+    mkdirSync(metadataDir, { recursive: true });
+    writeFileSync(join(metadataDir, 'schema.json'), JSON.stringify(dto.schema));
+    writeFileSync(join(metadataDir, 'erd.txt'), dto.erd);
+
+    await this.prisma.project.update({
+      where: { projectId },
+      data: { status: 'CRAWLING' },
+    });
+
+    const { jobId } = await this.queueService.dataBrokerLoadOnlyJob(
+      proxy.project.ownerId,
+      projectId,
+      metadataDir,
+    );
+
+    this.logger.log(
+      `Metadata received from proxy for project ${projectId}, queued load-only job ${jobId}`,
+    );
+
+    return { status: 'accepted', projectId, jobId };
+  }
+
+  async markOffline(proxyToken: string) {
+    const proxy = await this.prisma.proxy.findUnique({
+      where: { proxyToken },
+    });
+
+    if (!proxy) throw new UnauthorizedException('Invalid proxy token');
+
+    await this.prisma.proxy.update({
+      where: { id: proxy.id },
+      data: { status: 'OFFLINE', lastSeenAt: new Date() },
+    });
+  }
+
+  async getStatus(projectId: string): Promise<ProxyStatusResponseDto> {
+    const proxy = await this.prisma.proxy.findUnique({
+      where: { projectId },
+    });
+
+    if (!proxy) {
+      return {
+        proxyId: '',
+        status: 'PENDING',
+      };
+    }
+
+    // Auto-mark offline if no heartbeat in 90 seconds
+    if (
+      proxy.status === 'ONLINE' &&
+      proxy.lastSeenAt &&
+      Date.now() - proxy.lastSeenAt.getTime() > 90_000
+    ) {
+      await this.prisma.proxy.update({
+        where: { id: proxy.id },
+        data: { status: 'OFFLINE' },
+      });
+      proxy.status = 'OFFLINE';
+    }
+
+    return {
+      proxyId: proxy.id,
+      status: proxy.status,
+      version: proxy.version ?? undefined,
+      lastSeenAt: proxy.lastSeenAt ?? undefined,
+      assignedPort: proxy.assignedPort ?? undefined,
+    };
+  }
+
+  async getProxyInfo(projectId: string): Promise<ProxyInfoResponseDto> {
+    const proxy = await this.prisma.proxy.findUnique({
+      where: { projectId },
+    });
+
+    if (!proxy) throw new NotFoundException('No proxy configured');
+    if (!proxy.proxyToken || !proxy.assignedPort) {
+      throw new BadRequestException('Proxy not fully registered');
+    }
+
+    return {
+      proxyId: proxy.id,
+      proxyToken: proxy.proxyToken,
+      assignedPort: proxy.assignedPort,
+      status: proxy.status,
+    };
+  }
+
+  async unregister(projectId: string) {
+    const proxy = await this.prisma.proxy.findUnique({
+      where: { projectId },
+    });
+
+    if (!proxy) throw new NotFoundException('No proxy configured');
+
+    await this.prisma.proxy.delete({ where: { id: proxy.id } });
+
+    // Remove this proxy's service from the rathole server config
+    try {
+      await this.ratholeConfig.rebuildConfig();
+    } catch (err) {
+      this.logger.warn(
+        `Failed to update rathole config: ${(err as Error).message}`,
+      );
+    }
+
+    this.logger.log(`Proxy unregistered for project ${projectId}`);
+  }
+
+  private async allocatePort(): Promise<number> {
+    const usedPorts = await this.prisma.proxy.findMany({
+      where: { assignedPort: { not: null } },
+      select: { assignedPort: true },
+    });
+
+    const used = new Set(usedPorts.map((p) => p.assignedPort));
+
+    for (let port = PROXY_PORT_BASE; port <= PROXY_PORT_MAX; port++) {
+      if (!used.has(port)) return port;
+    }
+
+    throw new BadRequestException('No available proxy ports (max 100 proxies)');
+  }
+}

--- a/src/proxy/rathole-config.service.ts
+++ b/src/proxy/rathole-config.service.ts
@@ -1,0 +1,128 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+
+// Production: Docker volume at /rathole-config/server.toml
+// Local dev: sibling platform repo at ../platform/dev/rathole-config/server.toml
+const DEV_CONFIG_PATH = resolve(
+  process.cwd(),
+  '..',
+  'platform',
+  'dev',
+  'rathole-config',
+  'server.toml',
+);
+
+// Dev keypair for local testing (production uses env vars)
+const DEV_NOISE_PRIVATE_KEY = 'Y7Rv+VdKogaOCx+ug4ktBwztOJcH7MEbnZ7L2+jqV4Y=';
+const DEV_NOISE_PUBLIC_KEY = 'oKp5T9B2ClJGcjVNtZI415npcTUti+/SaEuiVQWpbkw=';
+
+/**
+ * Manages the rathole server TOML config file.
+ *
+ * On startup, rebuilds the config from all registered proxies in the database.
+ * On register/unregister, rewrites the full config so rathole picks up the change
+ * (rathole watches the file for hot-reload).
+ */
+@Injectable()
+export class RatholeConfigService implements OnModuleInit {
+  private readonly logger = new Logger(RatholeConfigService.name);
+  private readonly configPath: string;
+  private readonly noisePrivateKey: string;
+  private readonly bindPort: string;
+
+  constructor(
+    private prisma: PrismaService,
+    private config: ConfigService,
+  ) {
+    this.configPath =
+      this.config.get<string>('RATHOLE_CONFIG_PATH') || DEV_CONFIG_PATH;
+    this.noisePrivateKey =
+      this.config.get<string>('RATHOLE_NOISE_PRIVATE_KEY') ||
+      DEV_NOISE_PRIVATE_KEY;
+    // Rathole inside Docker always binds on 7000. Docker maps host 7100 → container 7000 for local dev.
+    this.bindPort = this.config.get<string>('RATHOLE_BIND_PORT') || '7000';
+  }
+
+  /** Public key to send to proxy clients so they can verify the server. */
+  get noisePublicKey(): string {
+    return (
+      this.config.get<string>('RATHOLE_NOISE_PUBLIC_KEY') ||
+      DEV_NOISE_PUBLIC_KEY
+    );
+  }
+
+  async onModuleInit() {
+    try {
+      await this.rebuildConfig();
+    } catch (err) {
+      // Non-fatal: rathole config dir may not exist in dev/local environments
+      this.logger.warn(
+        `Could not write rathole config: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  /**
+   * Rebuild the full rathole server config from all registered proxies.
+   */
+  async rebuildConfig(): Promise<void> {
+    const proxies = await this.prisma.proxy.findMany({
+      where: {
+        ratholeToken: { not: null },
+        assignedPort: { not: null },
+      },
+      select: {
+        id: true,
+        ratholeToken: true,
+        assignedPort: true,
+      },
+    });
+
+    const services = proxies.map((p) => {
+      const serviceName = `proxy-${p.id}`;
+      return [
+        `[server.services.${serviceName}]`,
+        `token = "${p.ratholeToken}"`,
+        `bind_addr = "0.0.0.0:${p.assignedPort}"`,
+      ].join('\n');
+    });
+
+    // Rathole requires at least one service — add a placeholder if none exist
+    if (services.length === 0) {
+      services.push(
+        '[server.services.placeholder]\ntoken = "placeholder-token-do-not-use"\nbind_addr = "0.0.0.0:19999"',
+      );
+    }
+
+    const header = ['[server]', `bind_addr = "0.0.0.0:${this.bindPort}"`];
+
+    if (this.noisePrivateKey) {
+      header.push(
+        '',
+        '[server.transport]',
+        'type = "noise"',
+        '',
+        '[server.transport.noise]',
+        `local_private_key = "${this.noisePrivateKey}"`,
+      );
+    }
+
+    const toml = [...header, '', ...services, ''].join('\n');
+
+    this.writeConfig(toml);
+    this.logger.log(
+      `Rathole config written with ${proxies.length} service(s) → ${this.configPath}`,
+    );
+  }
+
+  private writeConfig(content: string): void {
+    const dir = dirname(this.configPath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    writeFileSync(this.configPath, content, { mode: 0o644 });
+  }
+}


### PR DESCRIPTION
Add proxy controller, service, DTOs, rathole config writer, and Prisma migrations for proxy and install token models.