### PR TITLE
fix(proxy): use named volume for load-only data-broker metadata

### DIFF
--- a/src/docker/docker.service.ts
+++ b/src/docker/docker.service.ts
@@ -115,11 +115,7 @@ export class DockerService {
     }
   }
 
-  async runDataBrokerLoadOnly(
-    ownerId: string,
-    projectId: string,
-    metadataPath: string,
-  ) {
+  async runDataBrokerLoadOnly(ownerId: string, projectId: string) {
     this.logger.log(
       `Preparing to run crawler container (LOAD_ONLY) for project ${projectId}...`,
     );
@@ -130,8 +126,8 @@ export class DockerService {
       `OWNER=${ownerId}`,
       `PROJECT_ID=${projectId}`,
       `LOAD_ONLY=true`,
-      `SCHEMA_PATH=/data/schema.json`,
-      `ERD_PATH=/data/erd.txt`,
+      `SCHEMA_PATH=/proxy-metadata/${projectId}/schema.json`,
+      `ERD_PATH=/proxy-metadata/${projectId}/erd.txt`,
       `DB_TYPE=pg`,
       `DB_HOST=proxy`,
       `DB_PORT=5432`,
@@ -149,7 +145,7 @@ export class DockerService {
         this.imageName,
         envArgs,
         instanceName,
-        [`${metadataPath}:/data:ro`],
+        ['epsilon_proxy_metadata:/proxy-metadata:ro'],
       );
 
       try {

--- a/src/queue/atlas.processor.ts
+++ b/src/queue/atlas.processor.ts
@@ -49,27 +49,16 @@ export class AtlasProcessor {
 
   @Process('process-data-broker')
   async handleDataBrokerJob(job: Job) {
-    const {
-      jobId,
-      owner,
-      projectId,
-      requestId,
-      database,
-      loadOnly,
-      metadataPath,
-    } = job.data as DataBrokerJobDataDto;
+    const { jobId, owner, projectId, requestId, database, loadOnly } =
+      job.data as DataBrokerJobDataDto;
     this.logger.log(
       `Handling 'process-data-broker' ${loadOnly ? '(LOAD_ONLY) ' : ''}for requestId ${requestId}...`,
     );
     await this.jobService.markActive(jobId);
     try {
       let result: unknown;
-      if (loadOnly && metadataPath) {
-        result = await this.docker.runDataBrokerLoadOnly(
-          owner,
-          projectId,
-          metadataPath,
-        );
+      if (loadOnly) {
+        result = await this.docker.runDataBrokerLoadOnly(owner, projectId);
       } else {
         result = await this.docker.runDataBroker(
           owner,


### PR DESCRIPTION
Switch from host bind mount to named Docker volume so data-broker can read metadata written by api-hub inside its container.