### PR TITLE
fix(proxy): prevent duplicate crawls while project is CRAWLING

### DIFF
--- a/src/proxy/proxy.service.ts
+++ b/src/proxy/proxy.service.ts
@@ -223,7 +223,7 @@ export class ProxyService {
 
     const needsCrawl =
       proxy.project.connectionType === 'PROXY' &&
-      ['PENDING', 'ERROR', 'CRAWLING'].includes(proxy.project.status) &&
+      ['PENDING', 'ERROR'].includes(proxy.project.status) &&
       Boolean(meta?.databaseReachable);
 
     return needsCrawl ? { action: 'crawl' } : {};


### PR DESCRIPTION
Only trigger crawl action on heartbeat when project status is PENDING or ERROR, not CRAWLING. Prevents overlapping data-broker jobs.