### PR TITLE
feat(coordinator): include connectionType and proxyInfo in archetype …

### DIFF
--- a/src/database/database.service.ts
+++ b/src/database/database.service.ts
@@ -343,6 +343,23 @@ export class DatabaseService {
         }
       }
     }
+    // Include project connection type and proxy info
+    const project = await this.prisma.project.findUnique({
+      where: { projectId },
+      include: { proxy: true },
+    });
+    if (project) {
+      result.connectionType = project.connectionType;
+      if (project.connectionType === 'PROXY' && project.proxy) {
+        result.proxyInfo = {
+          proxyId: project.proxy.projectId,
+          proxyToken: project.proxy.proxyToken ?? '',
+          assignedPort: project.proxy.assignedPort ?? 0,
+          status: project.proxy.status,
+        };
+      }
+    }
+
     return result;
   }
 

--- a/src/database/dto/database.dto.ts
+++ b/src/database/dto/database.dto.ts
@@ -314,4 +314,24 @@ export class DatasetDetailsResponseDto {
   @IsOptional()
   @IsObject()
   properties?: Record<string, any>;
+
+  @ApiProperty({
+    description: 'Project connection type',
+    enum: ['CLOUD_CONNECT', 'DIRECT_DB', 'PROXY'],
+    required: false,
+  })
+  @IsOptional()
+  connectionType?: string;
+
+  @ApiProperty({
+    description: 'Proxy connection info (only present for PROXY projects)',
+    required: false,
+  })
+  @IsOptional()
+  proxyInfo?: {
+    proxyId: string;
+    proxyToken: string;
+    assignedPort: number;
+    status: string;
+  };
 }


### PR DESCRIPTION
…response

The getDatasetDetails endpoint now returns the project's connectionType (CLOUD_CONNECT, DIRECT_DB, PROXY) and proxy connection info when applicable. This allows the middleware to auto-detect proxy mode without a separate API call.